### PR TITLE
Enhance Magtag indicator

### DIFF
--- a/ports/esp32s2/Makefile
+++ b/ports/esp32s2/Makefile
@@ -22,6 +22,9 @@ flash:
 bootloader-flash:
 	idf.py -B$(BUILD) -DBOARD=$(BOARD) bootloader-flash
 
+app-flash:
+	idf.py -B$(BUILD) -DBOARD=$(BOARD) app-flash
+
 erase:
 	idf.py -B$(BUILD) -DBOARD=$(BOARD) erase_flash
 

--- a/ports/esp32s2/Makefile
+++ b/ports/esp32s2/Makefile
@@ -19,6 +19,9 @@ clean:
 flash:
 	idf.py -B$(BUILD) -DBOARD=$(BOARD) flash
 
+bootloader-flash:
+	idf.py -B$(BUILD) -DBOARD=$(BOARD) bootloader-flash
+
 erase:
 	idf.py -B$(BUILD) -DBOARD=$(BOARD) erase_flash
 

--- a/ports/esp32s2/boards/adafruit_magtag_29gray/board.h
+++ b/ports/esp32s2/boards/adafruit_magtag_29gray/board.h
@@ -43,7 +43,10 @@
 //--------------------------------------------------------------------+
 
 // GPIO connected to Neopixel data
-#define PIN_NEOPIXEL          1
+#define PIN_NEOPIXEL                1
+
+#define NEOPIXEL_PIN_ENABLE         21
+#define NEOPIXEL_PIN_ENABLE_STATE   0
 
 // Brightness percentage from 1 to 255
 #define NEOPIXEL_BRIGHTNESS   0x10

--- a/ports/esp32s2/boards/adafruit_magtag_29gray/board.h
+++ b/ports/esp32s2/boards/adafruit_magtag_29gray/board.h
@@ -45,8 +45,8 @@
 // GPIO connected to Neopixel data
 #define NEOPIXEL_PIN                1
 
-#define NEOPIXEL_PIN_ENABLE         21
-#define NEOPIXEL_PIN_ENABLE_STATE   0
+#define NEOPIXEL_ENABLE_PIN         21
+#define NEOPIXEL_ENABLE_STATE   0
 
 // Brightness percentage from 1 to 255
 #define NEOPIXEL_BRIGHTNESS   0x10

--- a/ports/esp32s2/boards/adafruit_magtag_29gray/board.h
+++ b/ports/esp32s2/boards/adafruit_magtag_29gray/board.h
@@ -55,9 +55,10 @@
 #define NEOPIXEL_NUMBER       4
 
 
-// LED for indicator and writing flash
+// LED for indicator
 // If not defined neopixel will be use for flash writing instead
-#define PIN_LED               13
+#define LED_PIN               13
+#define LED_STATE_ON          1
 
 //--------------------------------------------------------------------+
 // USB UF2

--- a/ports/esp32s2/boards/adafruit_magtag_29gray/board.h
+++ b/ports/esp32s2/boards/adafruit_magtag_29gray/board.h
@@ -43,7 +43,7 @@
 //--------------------------------------------------------------------+
 
 // GPIO connected to Neopixel data
-#define PIN_NEOPIXEL                1
+#define NEOPIXEL_PIN                1
 
 #define NEOPIXEL_PIN_ENABLE         21
 #define NEOPIXEL_PIN_ENABLE_STATE   0

--- a/ports/esp32s2/boards/adafruit_magtag_29gray/board.h
+++ b/ports/esp32s2/boards/adafruit_magtag_29gray/board.h
@@ -32,7 +32,7 @@
 // Enter UF2 mode if GPIO is pressed while 2nd stage bootloader indicator
 // is on e.g RGB = Purple. If it is GPIO0, user should not hold this while
 // reset since that will instead run the 1st stage ROM bootloader
-#define PIN_BUTTON_UF2       0
+#define PIN_BUTTON_UF2        0
 
 // GPIO that implement 1-bit memory with RC components which hold the
 // pin value long enough for double reset detection.
@@ -43,10 +43,10 @@
 //--------------------------------------------------------------------+
 
 // GPIO connected to Neopixel data
-#define NEOPIXEL_PIN                1
+#define NEOPIXEL_PIN          1
 
-#define NEOPIXEL_ENABLE_PIN         21
-#define NEOPIXEL_ENABLE_STATE   0
+#define NEOPIXEL_ENABLE_PIN   21
+#define NEOPIXEL_ENABLE_STATE 0
 
 // Brightness percentage from 1 to 255
 #define NEOPIXEL_BRIGHTNESS   0x10

--- a/ports/esp32s2/boards/adafruit_metro_esp32s2/board.h
+++ b/ports/esp32s2/boards/adafruit_metro_esp32s2/board.h
@@ -43,7 +43,7 @@
 //--------------------------------------------------------------------+
 
 // GPIO connected to Neopixel data
-#define PIN_NEOPIXEL          45
+#define NEOPIXEL_PIN          45
 
 // Brightness percentage from 1 to 255
 #define NEOPIXEL_BRIGHTNESS   0x10

--- a/ports/esp32s2/boards/adafruit_metro_esp32s2/board.h
+++ b/ports/esp32s2/boards/adafruit_metro_esp32s2/board.h
@@ -54,7 +54,8 @@
 
 // LED for indicator and writing flash
 // If not defined neopixel will be use for flash writing instead
-#define PIN_LED               42
+#define LED_PIN               42
+#define LED_STATE_ON          1
 
 //--------------------------------------------------------------------+
 // USB UF2

--- a/ports/esp32s2/boards/adafruit_metro_esp32s2/board.h
+++ b/ports/esp32s2/boards/adafruit_metro_esp32s2/board.h
@@ -32,7 +32,7 @@
 // Enter UF2 mode if GPIO is pressed while 2nd stage bootloader indicator
 // is on e.g RGB = Purple. If it is GPIO0, user should not hold this while
 // reset since that will instead run the 1st stage ROM bootloader
-#define PIN_BUTTON_UF2       0
+#define PIN_BUTTON_UF2        0
 
 // GPIO that implement 1-bit memory with RC components which hold the
 // pin value long enough for double reset detection.

--- a/ports/esp32s2/boards/boards.c
+++ b/ports/esp32s2/boards/boards.c
@@ -97,7 +97,7 @@ void app_main(void)
 void board_init(void)
 {
 
-#ifdef PIN_LED
+#ifdef LED_PIN
 //#define BLINK_GPIO 26
 //  gpio_pad_select_gpio(BLINK_GPIO);
 //  gpio_set_direction(BLINK_GPIO, GPIO_MODE_OUTPUT);

--- a/ports/esp32s2/boards/boards.c
+++ b/ports/esp32s2/boards/boards.c
@@ -193,7 +193,10 @@ void board_led_write(uint32_t state)
 void board_rgb_write(uint8_t const rgb[])
 {
 #ifdef NEOPIXEL_PIN
-  strip->set_pixel(strip, 0, rgb[0], rgb[1], rgb[2]);
+  for(uint32_t i=0; i<NEOPIXEL_NUMBER; i++)
+  {
+    strip->set_pixel(strip, i, rgb[0], rgb[1], rgb[2]);
+  }
   strip->refresh(strip, 100);
 #endif
 

--- a/ports/esp32s2/boards/boards.c
+++ b/ports/esp32s2/boards/boards.c
@@ -50,7 +50,7 @@ static TimerHandle_t timer_hdl = NULL;
 static led_strip_t *strip;
 #endif
 
-#ifdef PIN_APA102_SCK
+#ifdef DOTSTAR_PIN_SCK
 #include "led_strip_spi_apa102.h"
 #endif
 
@@ -126,20 +126,20 @@ void board_init(void)
   strip->set_brightness(strip, NEOPIXEL_BRIGHTNESS);
 #endif
 
-#ifdef PIN_APA102_SCK
+#ifdef DOTSTAR_PIN_SCK
   // Setup the IO for the APA DATA and CLK
-  gpio_pad_select_gpio(PIN_APA102_DATA);
-  gpio_pad_select_gpio(PIN_APA102_SCK);
-  gpio_ll_input_disable(&GPIO, PIN_APA102_DATA);
-  gpio_ll_input_disable(&GPIO, PIN_APA102_SCK);
-  gpio_ll_output_enable(&GPIO, PIN_APA102_DATA);
-  gpio_ll_output_enable(&GPIO, PIN_APA102_SCK);
+  gpio_pad_select_gpio(DOTSTAR_PIN_DATA);
+  gpio_pad_select_gpio(DOTSTAR_PIN_SCK);
+  gpio_ll_input_disable(&GPIO, DOTSTAR_PIN_DATA);
+  gpio_ll_input_disable(&GPIO, DOTSTAR_PIN_SCK);
+  gpio_ll_output_enable(&GPIO, DOTSTAR_PIN_DATA);
+  gpio_ll_output_enable(&GPIO, DOTSTAR_PIN_SCK);
 
   // Initialise SPI
-  setupSPI(PIN_APA102_DATA, PIN_APA102_SCK);
+  setupSPI(DOTSTAR_PIN_DATA, DOTSTAR_PIN_SCK);
 
   // Initialise the APA
-  initAPA(APA102_BRIGHTNESS);
+  initAPA(DOTSTAR_BRIGHTNESS);
 #endif
 
   timer_hdl = xTimerCreate(NULL, pdMS_TO_TICKS(1000), true, NULL, _board_timer_cb);
@@ -200,7 +200,7 @@ void board_rgb_write(uint8_t const rgb[])
   strip->refresh(strip, 100);
 #endif
 
-#ifdef PIN_APA102_SCK
+#ifdef DOTSTAR_PIN_SCK
     setAPA(rgb[0], rgb[1], rgb[2]);
 #endif
 }

--- a/ports/esp32s2/boards/boards.c
+++ b/ports/esp32s2/boards/boards.c
@@ -45,7 +45,7 @@
 
 static TimerHandle_t timer_hdl = NULL;
 
-#ifdef PIN_NEOPIXEL
+#ifdef NEOPIXEL_PIN
 #include "led_strip.h"
 static led_strip_t *strip;
 #endif
@@ -105,7 +105,7 @@ void board_init(void)
 //  gpio_set_level(BLINK_GPIO, 1);
 #endif
 
-#ifdef PIN_NEOPIXEL
+#ifdef NEOPIXEL_PIN
 
 #ifdef NEOPIXEL_PIN_ENABLE
   gpio_reset_pin(NEOPIXEL_PIN_ENABLE);
@@ -114,7 +114,7 @@ void board_init(void)
 #endif
 
   // WS2812 Neopixel driver with RMT peripheral
-  rmt_config_t config = RMT_DEFAULT_CONFIG_TX(PIN_NEOPIXEL, RMT_CHANNEL_0);
+  rmt_config_t config = RMT_DEFAULT_CONFIG_TX(NEOPIXEL_PIN, RMT_CHANNEL_0);
   config.clk_div = 2; // set counter clock to 40MHz
 
   rmt_config(&config);
@@ -192,7 +192,7 @@ void board_led_write(uint32_t state)
 
 void board_rgb_write(uint8_t const rgb[])
 {
-#ifdef PIN_NEOPIXEL
+#ifdef NEOPIXEL_PIN
   strip->set_pixel(strip, 0, rgb[0], rgb[1], rgb[2]);
   strip->refresh(strip, 100);
 #endif

--- a/ports/esp32s2/boards/boards.c
+++ b/ports/esp32s2/boards/boards.c
@@ -106,6 +106,13 @@ void board_init(void)
 #endif
 
 #ifdef PIN_NEOPIXEL
+
+#ifdef NEOPIXEL_PIN_ENABLE
+  gpio_reset_pin(NEOPIXEL_PIN_ENABLE);
+  gpio_set_direction(NEOPIXEL_PIN_ENABLE, GPIO_MODE_OUTPUT);
+  gpio_set_level(NEOPIXEL_PIN_ENABLE, NEOPIXEL_PIN_ENABLE_STATE);
+#endif
+
   // WS2812 Neopixel driver with RMT peripheral
   rmt_config_t config = RMT_DEFAULT_CONFIG_TX(PIN_NEOPIXEL, RMT_CHANNEL_0);
   config.clk_div = 2; // set counter clock to 40MHz
@@ -120,19 +127,19 @@ void board_init(void)
 #endif
 
 #ifdef PIN_APA102_SCK
-    // Setup the IO for the APA DATA and CLK
-    gpio_pad_select_gpio(PIN_APA102_DATA);
-    gpio_pad_select_gpio(PIN_APA102_SCK);
-    gpio_ll_input_disable(&GPIO, PIN_APA102_DATA);
-    gpio_ll_input_disable(&GPIO, PIN_APA102_SCK);
-    gpio_ll_output_enable(&GPIO, PIN_APA102_DATA);
-    gpio_ll_output_enable(&GPIO, PIN_APA102_SCK);
+  // Setup the IO for the APA DATA and CLK
+  gpio_pad_select_gpio(PIN_APA102_DATA);
+  gpio_pad_select_gpio(PIN_APA102_SCK);
+  gpio_ll_input_disable(&GPIO, PIN_APA102_DATA);
+  gpio_ll_input_disable(&GPIO, PIN_APA102_SCK);
+  gpio_ll_output_enable(&GPIO, PIN_APA102_DATA);
+  gpio_ll_output_enable(&GPIO, PIN_APA102_SCK);
 
-    // Initialise SPI
-    setupSPI(PIN_APA102_DATA, PIN_APA102_SCK);
+  // Initialise SPI
+  setupSPI(PIN_APA102_DATA, PIN_APA102_SCK);
 
-    // Initialise the APA
-    initAPA(APA102_BRIGHTNESS);
+  // Initialise the APA
+  initAPA(APA102_BRIGHTNESS);
 #endif
 
   timer_hdl = xTimerCreate(NULL, pdMS_TO_TICKS(1000), true, NULL, _board_timer_cb);

--- a/ports/esp32s2/boards/boards.c
+++ b/ports/esp32s2/boards/boards.c
@@ -107,10 +107,10 @@ void board_init(void)
 
 #ifdef NEOPIXEL_PIN
 
-#ifdef NEOPIXEL_PIN_ENABLE
-  gpio_reset_pin(NEOPIXEL_PIN_ENABLE);
-  gpio_set_direction(NEOPIXEL_PIN_ENABLE, GPIO_MODE_OUTPUT);
-  gpio_set_level(NEOPIXEL_PIN_ENABLE, NEOPIXEL_PIN_ENABLE_STATE);
+#ifdef NEOPIXEL_ENABLE_PIN
+  gpio_reset_pin(NEOPIXEL_ENABLE_PIN);
+  gpio_set_direction(NEOPIXEL_ENABLE_PIN, GPIO_MODE_OUTPUT);
+  gpio_set_level(NEOPIXEL_ENABLE_PIN, NEOPIXEL_ENABLE_STATE);
 #endif
 
   // WS2812 Neopixel driver with RMT peripheral

--- a/ports/esp32s2/boards/boards.h
+++ b/ports/esp32s2/boards/boards.h
@@ -40,7 +40,7 @@
 // Double Reset tap to enter DFU
 #define USE_DFU_DOUBLE_TAP      0
 
-#if defined(NEOPIXEL_PIN) || defined(PIN_APA102_SCK)
+#if defined(NEOPIXEL_PIN) || defined(DOTSTAR_PIN_SCK)
 #define USE_RGB   1
 #endif
 

--- a/ports/esp32s2/boards/boards.h
+++ b/ports/esp32s2/boards/boards.h
@@ -40,7 +40,7 @@
 // Double Reset tap to enter DFU
 #define USE_DFU_DOUBLE_TAP      0
 
-#if defined(PIN_NEOPIXEL) || defined(PIN_APA102_SCK)
+#if defined(NEOPIXEL_PIN) || defined(PIN_APA102_SCK)
 #define USE_RGB   1
 #endif
 

--- a/ports/esp32s2/boards/espressif_kaluga_1/board.h
+++ b/ports/esp32s2/boards/espressif_kaluga_1/board.h
@@ -45,7 +45,7 @@
 // GPIO connected to Neopixel data
 // Note: Need to insert Jumper (default is Off) to control neopixel
 // On Kaluga this pin is also connected to Camera D3
-#define PIN_NEOPIXEL          45
+#define NEOPIXEL_PIN          45
 
 // Brightness percentage from 1 to 255
 #define NEOPIXEL_BRIGHTNESS   0x10

--- a/ports/esp32s2/boards/espressif_kaluga_1/board.h
+++ b/ports/esp32s2/boards/espressif_kaluga_1/board.h
@@ -57,18 +57,18 @@
 // TFT Display
 //--------------------------------------------------------------------+
 
-#define PIN_DISPLAY_MISO       8
-#define PIN_DISPLAY_MOSI       9
-#define PIN_DISPLAY_SCK        15
-#define PIN_DISPLAY_CS         11
-#define PIN_DISPLAY_DC         13
-#define PIN_DISPLAY_RST        16
-#define PIN_DISPLAY_BL         6
+#define PIN_DISPLAY_MISO      8
+#define PIN_DISPLAY_MOSI      9
+#define PIN_DISPLAY_SCK       15
+#define PIN_DISPLAY_CS        11
+#define PIN_DISPLAY_DC        13
+#define PIN_DISPLAY_RST       16
+#define PIN_DISPLAY_BL        6
 
-#define DISPLAY_BL_STATE       0  // GPIO state to enable back light
-#define DISPLAY_WIDTH          320
-#define DISPLAY_HEIGHT         240
-#define DISPLAY_MADCTL         0x08
+#define DISPLAY_BL_STATE      0  // GPIO state to enable back light
+#define DISPLAY_WIDTH         320
+#define DISPLAY_HEIGHT        240
+#define DISPLAY_MADCTL        0x08
 
 //--------------------------------------------------------------------+
 // USB UF2

--- a/ports/esp32s2/boards/espressif_saola_1_wroom/board.h
+++ b/ports/esp32s2/boards/espressif_saola_1_wroom/board.h
@@ -53,6 +53,11 @@
 // Number of neopixels
 #define NEOPIXEL_NUMBER       1
 
+// LED for indicator
+// If not defined neopixel will be use for flash writing instead
+// #define LED_PIN               33
+// #define LED_STATE_ON          0
+
 //--------------------------------------------------------------------+
 // USB UF2
 //--------------------------------------------------------------------+

--- a/ports/esp32s2/boards/espressif_saola_1_wroom/board.h
+++ b/ports/esp32s2/boards/espressif_saola_1_wroom/board.h
@@ -32,7 +32,7 @@
 // Enter UF2 mode if GPIO is pressed while 2nd stage bootloader indicator
 // is on e.g RGB = Purple. If it is GPIO0, user should not hold this while
 // reset since that will instead run the 1st stage ROM bootloader
-#define PIN_BUTTON_UF2       0
+#define PIN_BUTTON_UF2        0
 
 // GPIO that implement 1-bit memory with RC components which hold the
 // pin value long enough for double reset detection.

--- a/ports/esp32s2/boards/espressif_saola_1_wroom/board.h
+++ b/ports/esp32s2/boards/espressif_saola_1_wroom/board.h
@@ -45,7 +45,7 @@
 // GPIO connected to Neopixel data
 // Note: On the production version Saola (v1.2) it is GPIO 18,
 // however on earlier revision v1.1 it is GPIO 17
-#define PIN_NEOPIXEL          18
+#define NEOPIXEL_PIN          18
 
 // Brightness percentage from 1 to 255
 #define NEOPIXEL_BRIGHTNESS   0x10

--- a/ports/esp32s2/boards/espressif_saola_1_wrover/board.h
+++ b/ports/esp32s2/boards/espressif_saola_1_wrover/board.h
@@ -54,9 +54,10 @@
 #define NEOPIXEL_NUMBER       1
 
 
-// LED for indicator and writing flash
+// LED for indicator
 // If not defined neopixel will be use for flash writing instead
-#define PIN_LED               33
+// #define LED_PIN               33
+// #define LED_STATE_ON          0
 
 //--------------------------------------------------------------------+
 // USB UF2

--- a/ports/esp32s2/boards/espressif_saola_1_wrover/board.h
+++ b/ports/esp32s2/boards/espressif_saola_1_wrover/board.h
@@ -32,7 +32,7 @@
 // Enter UF2 mode if GPIO is pressed while 2nd stage bootloader indicator
 // is on e.g RGB = Purple. If it is GPIO0, user should not hold this while
 // reset since that will instead run the 1st stage ROM bootloader
-#define PIN_BUTTON_UF2       0
+#define PIN_BUTTON_UF2        0
 
 // GPIO that implement 1-bit memory with RC components which hold the
 // pin value long enough for double reset detection.

--- a/ports/esp32s2/boards/espressif_saola_1_wrover/board.h
+++ b/ports/esp32s2/boards/espressif_saola_1_wrover/board.h
@@ -45,7 +45,7 @@
 // GPIO connected to Neopixel data
 // Note: On the production version Saola (v1.2) it is GPIO 18,
 // however on earlier revision v1.1 it is GPIO 17
-#define PIN_NEOPIXEL          18
+#define NEOPIXEL_PIN          18
 
 // Brightness percentage from 1 to 255
 #define NEOPIXEL_BRIGHTNESS   0x10

--- a/ports/esp32s2/boards/microdev_micro_s2/board.h
+++ b/ports/esp32s2/boards/microdev_micro_s2/board.h
@@ -32,7 +32,7 @@
 // Enter UF2 mode if GPIO is pressed while 2nd stage bootloader indicator
 // is on e.g RGB = Purple. If it is GPIO0, user should not hold this while
 // reset since that will instead run the 1st stage ROM bootloader
-#define PIN_BUTTON_UF2       0
+#define PIN_BUTTON_UF2        0
 
 //--------------------------------------------------------------------+
 // LED

--- a/ports/esp32s2/boards/microdev_micro_s2/board.h
+++ b/ports/esp32s2/boards/microdev_micro_s2/board.h
@@ -49,7 +49,8 @@
 
 // LED for indicator and writing flash
 // If not defined neopixel will be use for flash writing instead
-#define PIN_LED               21
+#define LED_PIN               21
+#define LED_STATE_ON          1
 
 //--------------------------------------------------------------------+
 // USB UF2

--- a/ports/esp32s2/boards/microdev_micro_s2/board.h
+++ b/ports/esp32s2/boards/microdev_micro_s2/board.h
@@ -39,7 +39,7 @@
 //--------------------------------------------------------------------+
 
 // GPIO connected to Neopixel data
-#define PIN_NEOPIXEL          33
+#define NEOPIXEL_PIN          33
 
 // Brightness percentage from 1 to 255
 #define NEOPIXEL_BRIGHTNESS   0x10

--- a/ports/esp32s2/boards/unexpectedmaker_feathers2/board.h
+++ b/ports/esp32s2/boards/unexpectedmaker_feathers2/board.h
@@ -47,7 +47,8 @@
 
 // LED for indicator and writing flash
 // If not defined neopixel will be use for flash writing instead
-#define PIN_LED               13
+#define LED_PIN               13
+#define LED_STATE_ON          1
 
 //--------------------------------------------------------------------+
 // USB UF2

--- a/ports/esp32s2/boards/unexpectedmaker_feathers2/board.h
+++ b/ports/esp32s2/boards/unexpectedmaker_feathers2/board.h
@@ -32,7 +32,7 @@
 // Enter UF2 mode if GPIO is pressed while 2nd stage bootloader indicator
 // is on e.g RGB = Purple. If it is GPIO0, user should not hold this while
 // reset since that will instead run the 1st stage ROM bootloader
-#define PIN_BUTTON_UF2       0
+#define PIN_BUTTON_UF2        0
 
 //--------------------------------------------------------------------+
 // LED

--- a/ports/esp32s2/boards/unexpectedmaker_feathers2/board.h
+++ b/ports/esp32s2/boards/unexpectedmaker_feathers2/board.h
@@ -38,12 +38,12 @@
 // LED
 //--------------------------------------------------------------------+
 
-#define PIN_APA102_DATA       40
-#define PIN_APA102_SCK        45
-#define PIN_APA102_PWR        21
+#define DOTSTAR_PIN_DATA       40
+#define DOTSTAR_PIN_SCK        45
+#define DOTSTAR_PIN_PWR        21
 
 // Brightness percentage from 1 to 255
-#define APA102_BRIGHTNESS     175
+#define DOTSTAR_BRIGHTNESS     175
 
 // LED for indicator and writing flash
 // If not defined neopixel will be use for flash writing instead

--- a/ports/esp32s2/components/bootloader/subproject/main/bootloader_start.c
+++ b/ports/esp32s2/components/bootloader/subproject/main/bootloader_start.c
@@ -328,11 +328,11 @@ static void board_led_on(void)
 {
   #ifdef NEOPIXEL_PIN
 
-  #ifdef NEOPIXEL_PIN_ENABLE
-  gpio_pad_select_gpio(NEOPIXEL_PIN_ENABLE);
-  gpio_ll_input_disable(&GPIO, NEOPIXEL_PIN_ENABLE);
-  gpio_ll_output_enable(&GPIO, NEOPIXEL_PIN_ENABLE);
-  gpio_ll_set_level(&GPIO, NEOPIXEL_PIN_ENABLE, NEOPIXEL_PIN_ENABLE_STATE);
+  #ifdef NEOPIXEL_ENABLE_PIN
+  gpio_pad_select_gpio(NEOPIXEL_ENABLE_PIN);
+  gpio_ll_input_disable(&GPIO, NEOPIXEL_ENABLE_PIN);
+  gpio_ll_output_enable(&GPIO, NEOPIXEL_ENABLE_PIN);
+  gpio_ll_set_level(&GPIO, NEOPIXEL_ENABLE_PIN, NEOPIXEL_ENABLE_STATE);
   #endif
 
   gpio_pad_select_gpio(NEOPIXEL_PIN);
@@ -399,9 +399,9 @@ static void board_led_off(void)
   // TODO how to de-select GPIO pad to set it back to default state !?
   gpio_ll_output_disable(&GPIO, NEOPIXEL_PIN);
 
-  #ifdef NEOPIXEL_PIN_ENABLE
-  gpio_ll_set_level(&GPIO, NEOPIXEL_PIN_ENABLE, 1-NEOPIXEL_PIN_ENABLE_STATE);
-  gpio_ll_output_disable(&GPIO, NEOPIXEL_PIN_ENABLE);
+  #ifdef NEOPIXEL_ENABLE_PIN
+  gpio_ll_set_level(&GPIO, NEOPIXEL_ENABLE_PIN, 1-NEOPIXEL_ENABLE_STATE);
+  gpio_ll_output_disable(&GPIO, NEOPIXEL_ENABLE_PIN);
   #endif
   #endif
 

--- a/ports/esp32s2/components/bootloader/subproject/main/bootloader_start.c
+++ b/ports/esp32s2/components/bootloader/subproject/main/bootloader_start.c
@@ -327,6 +327,14 @@ static void board_apa102_set(uint32_t num_pin_data,uint32_t num_pin_sck, uint8_t
 static void board_led_on(void)
 {
   #ifdef PIN_NEOPIXEL
+
+  #ifdef NEOPIXEL_PIN_ENABLE
+  gpio_pad_select_gpio(NEOPIXEL_PIN_ENABLE);
+  gpio_ll_input_disable(&GPIO, NEOPIXEL_PIN_ENABLE);
+  gpio_ll_output_enable(&GPIO, NEOPIXEL_PIN_ENABLE);
+  gpio_ll_set_level(&GPIO, NEOPIXEL_PIN_ENABLE, NEOPIXEL_PIN_ENABLE_STATE);
+  #endif
+
   gpio_pad_select_gpio(PIN_NEOPIXEL);
   gpio_ll_input_disable(&GPIO, PIN_NEOPIXEL);
   gpio_ll_output_enable(&GPIO, PIN_NEOPIXEL);
@@ -377,7 +385,6 @@ static void board_led_on(void)
   board_apa102_set(PIN_APA102_DATA,PIN_APA102_SCK, pixels, sizeof(pixels));
   #endif
 
-
 }
 
 static void board_led_off(void)
@@ -391,6 +398,11 @@ static void board_led_off(void)
 
   // TODO how to de-select GPIO pad to set it back to default state !?
   gpio_ll_output_disable(&GPIO, PIN_NEOPIXEL);
+
+  #ifdef NEOPIXEL_PIN_ENABLE
+  gpio_ll_set_level(&GPIO, NEOPIXEL_PIN_ENABLE, 1-NEOPIXEL_PIN_ENABLE_STATE);
+  gpio_ll_output_disable(&GPIO, NEOPIXEL_PIN_ENABLE);
+  #endif
   #endif
 
   #ifdef PIN_APA102_DATA
@@ -405,7 +417,7 @@ static void board_led_off(void)
 
 
   #ifdef PIN_LED
-  gpio_ll_set_level(&GPIO, PIN_LED, 0);
+  gpio_ll_set_level(&GPIO, PIN_LED, 1);
   gpio_ll_output_disable(&GPIO, PIN_LED);
   #endif
 

--- a/ports/esp32s2/components/bootloader/subproject/main/bootloader_start.c
+++ b/ports/esp32s2/components/bootloader/subproject/main/bootloader_start.c
@@ -358,11 +358,11 @@ static void board_led_on(void)
   gpio_ll_set_level(&GPIO, PIN_APA102_PWR, 0);
   #endif
 
-  #ifdef PIN_LED
-  gpio_pad_select_gpio(PIN_LED);
-  gpio_ll_input_disable(&GPIO, PIN_LED);
-  gpio_ll_output_enable(&GPIO, PIN_LED);
-  gpio_ll_set_level(&GPIO, PIN_LED, 0);
+  #ifdef LED_PIN
+  gpio_pad_select_gpio(LED_PIN);
+  gpio_ll_input_disable(&GPIO, LED_PIN);
+  gpio_ll_output_enable(&GPIO, LED_PIN);
+  gpio_ll_set_level(&GPIO, LED_PIN, LED_STATE_ON);
   #endif
 
   // Need at least 200 us for initial delay although Neopixel reset time is only 50 us
@@ -374,8 +374,8 @@ static void board_led_on(void)
   board_neopixel_set(NEOPIXEL_PIN, pixels, sizeof(pixels));
   #endif
 
-  #ifdef PIN_LED
-  gpio_ll_set_level(&GPIO, PIN_LED, 1);
+  #ifdef LED_PIN
+  gpio_ll_set_level(&GPIO, LED_PIN, 1);
   #endif
 
   // APA102 colour order is BGR
@@ -415,10 +415,9 @@ static void board_led_off(void)
   gpio_ll_output_disable(&GPIO, PIN_APA102_PWR);
   #endif
 
-
-  #ifdef PIN_LED
-  gpio_ll_set_level(&GPIO, PIN_LED, 1);
-  gpio_ll_output_disable(&GPIO, PIN_LED);
+  #ifdef LED_PIN
+  gpio_ll_set_level(&GPIO, LED_PIN, 1-LED_STATE_ON);
+  gpio_ll_output_disable(&GPIO, LED_PIN);
   #endif
 
 }

--- a/ports/esp32s2/components/bootloader/subproject/main/bootloader_start.c
+++ b/ports/esp32s2/components/bootloader/subproject/main/bootloader_start.c
@@ -266,7 +266,7 @@ static void board_neopixel_set(uint32_t num_pin, uint8_t rgb[])
   uint32_t const time1  = ns2cycle(800);
   uint32_t const period = ns2cycle(1250);
 
-  uint8_t const pixels[3*NEOPIXEL_NUMBER];
+  uint8_t pixels[3*NEOPIXEL_NUMBER];
   for(uint32_t i=0; i<NEOPIXEL_NUMBER; i++)
   {
     // Note: WS2812 color order is GRB

--- a/ports/esp32s2/components/bootloader/subproject/main/bootloader_start.c
+++ b/ports/esp32s2/components/bootloader/subproject/main/bootloader_start.c
@@ -298,7 +298,7 @@ static void board_neopixel_set(uint32_t num_pin, uint8_t rgb[])
 }
 #endif
 
-#ifdef PIN_APA102_DATA
+#ifdef DOTSTAR_PIN_DATA
 //Bit bang out 8 bits
 static void SPI_write(int32_t num_pin_data,uint32_t num_pin_sck,uint8_t c) {
 
@@ -327,7 +327,7 @@ static void board_apa102_set(uint32_t num_pin_data,uint32_t num_pin_sck, uint8_t
   SPI_write(num_pin_data,num_pin_sck,0x00);
   SPI_write(num_pin_data,num_pin_sck,0x00);
 
-  SPI_write(num_pin_data,num_pin_sck,0xe0 | APA102_BRIGHTNESS);
+  SPI_write(num_pin_data,num_pin_sck,0xe0 | DOTSTAR_BRIGHTNESS);
 
   // DotStar APA102 color order is BGR
   uint8_t const pixels[3] = { rgb[2], rgb[1], rgb[0] };
@@ -355,21 +355,21 @@ static void board_led_on(void)
   gpio_ll_set_level(&GPIO, NEOPIXEL_PIN, 0);
 #endif
 
-#ifdef PIN_APA102_DATA
-  gpio_pad_select_gpio(PIN_APA102_DATA);
-  gpio_ll_input_disable(&GPIO, PIN_APA102_DATA);
-  gpio_ll_output_enable(&GPIO, PIN_APA102_DATA);
-  gpio_ll_set_level(&GPIO, PIN_APA102_DATA, 0);
+#ifdef DOTSTAR_PIN_DATA
+  gpio_pad_select_gpio(DOTSTAR_PIN_DATA);
+  gpio_ll_input_disable(&GPIO, DOTSTAR_PIN_DATA);
+  gpio_ll_output_enable(&GPIO, DOTSTAR_PIN_DATA);
+  gpio_ll_set_level(&GPIO, DOTSTAR_PIN_DATA, 0);
 
-  gpio_pad_select_gpio(PIN_APA102_SCK);
-  gpio_ll_input_disable(&GPIO, PIN_APA102_SCK);
-  gpio_ll_output_enable(&GPIO, PIN_APA102_SCK);
-  gpio_ll_set_level(&GPIO, PIN_APA102_SCK, 0);
+  gpio_pad_select_gpio(DOTSTAR_PIN_SCK);
+  gpio_ll_input_disable(&GPIO, DOTSTAR_PIN_SCK);
+  gpio_ll_output_enable(&GPIO, DOTSTAR_PIN_SCK);
+  gpio_ll_set_level(&GPIO, DOTSTAR_PIN_SCK, 0);
 
-  gpio_pad_select_gpio(PIN_APA102_PWR);
-  gpio_ll_input_disable(&GPIO, PIN_APA102_PWR);
-  gpio_ll_output_enable(&GPIO, PIN_APA102_PWR);
-  gpio_ll_set_level(&GPIO, PIN_APA102_PWR, 0);
+  gpio_pad_select_gpio(DOTSTAR_PIN_PWR);
+  gpio_ll_input_disable(&GPIO, DOTSTAR_PIN_PWR);
+  gpio_ll_output_enable(&GPIO, DOTSTAR_PIN_PWR);
+  gpio_ll_set_level(&GPIO, DOTSTAR_PIN_PWR, 0);
 #endif
 
 #ifdef LED_PIN
@@ -391,10 +391,10 @@ static void board_led_on(void)
 #endif
 
   // APA102 colour order is BGR
-#ifdef PIN_APA102_DATA
+#ifdef DOTSTAR_PIN_DATA
   uint8_t pixels[3] = { 0xb3, 0x00, 0x86 };
-  gpio_ll_set_level(&GPIO, PIN_APA102_PWR, 1);
-  board_apa102_set(PIN_APA102_DATA, PIN_APA102_SCK, RGB_DOUBLE_TAP);
+  gpio_ll_set_level(&GPIO, DOTSTAR_PIN_PWR, 1);
+  board_apa102_set(DOTSTAR_PIN_DATA, DOTSTAR_PIN_SCK, RGB_DOUBLE_TAP);
 #endif
 }
 
@@ -415,13 +415,13 @@ static void board_led_off(void)
   #endif
 #endif
 
-#ifdef PIN_APA102_DATA
-  board_apa102_set(PIN_APA102_DATA, PIN_APA102_SCK, RGB_OFF);
+#ifdef DOTSTAR_PIN_DATA
+  board_apa102_set(DOTSTAR_PIN_DATA, DOTSTAR_PIN_SCK, RGB_OFF);
 
-  gpio_ll_output_disable(&GPIO, PIN_APA102_DATA);
-  gpio_ll_output_disable(&GPIO, PIN_APA102_SCK);
-  gpio_ll_set_level(&GPIO, PIN_APA102_PWR, 0);
-  gpio_ll_output_disable(&GPIO, PIN_APA102_PWR);
+  gpio_ll_output_disable(&GPIO, DOTSTAR_PIN_DATA);
+  gpio_ll_output_disable(&GPIO, DOTSTAR_PIN_SCK);
+  gpio_ll_set_level(&GPIO, DOTSTAR_PIN_PWR, 0);
+  gpio_ll_output_disable(&GPIO, DOTSTAR_PIN_PWR);
 #endif
 
 #ifdef LED_PIN

--- a/ports/esp32s2/components/bootloader/subproject/main/bootloader_start.c
+++ b/ports/esp32s2/components/bootloader/subproject/main/bootloader_start.c
@@ -249,7 +249,7 @@ static inline uint32_t delay_cycle(uint32_t cycle)
   return ccount;
 }
 
-#ifdef PIN_NEOPIXEL
+#ifdef NEOPIXEL_PIN
 static void board_neopixel_set(uint32_t num_pin, uint8_t pixels[], uint32_t numBytes)
 {
   // WS2812B should be
@@ -326,7 +326,7 @@ static void board_apa102_set(uint32_t num_pin_data,uint32_t num_pin_sck, uint8_t
 
 static void board_led_on(void)
 {
-  #ifdef PIN_NEOPIXEL
+  #ifdef NEOPIXEL_PIN
 
   #ifdef NEOPIXEL_PIN_ENABLE
   gpio_pad_select_gpio(NEOPIXEL_PIN_ENABLE);
@@ -335,10 +335,10 @@ static void board_led_on(void)
   gpio_ll_set_level(&GPIO, NEOPIXEL_PIN_ENABLE, NEOPIXEL_PIN_ENABLE_STATE);
   #endif
 
-  gpio_pad_select_gpio(PIN_NEOPIXEL);
-  gpio_ll_input_disable(&GPIO, PIN_NEOPIXEL);
-  gpio_ll_output_enable(&GPIO, PIN_NEOPIXEL);
-  gpio_ll_set_level(&GPIO, PIN_NEOPIXEL, 0);
+  gpio_pad_select_gpio(NEOPIXEL_PIN);
+  gpio_ll_input_disable(&GPIO, NEOPIXEL_PIN);
+  gpio_ll_output_enable(&GPIO, NEOPIXEL_PIN);
+  gpio_ll_set_level(&GPIO, NEOPIXEL_PIN, 0);
   #endif
 
   #ifdef PIN_APA102_DATA
@@ -369,9 +369,9 @@ static void board_led_on(void)
   delay_cycle( ns2cycle(200000) ) ;
 
   // Note: WS2812 color order is GRB
-  #ifdef PIN_NEOPIXEL
+  #ifdef NEOPIXEL_PIN
   uint8_t pixels[3] = { 0x00, 0x86, 0xb3 };
-  board_neopixel_set(PIN_NEOPIXEL, pixels, sizeof(pixels));
+  board_neopixel_set(NEOPIXEL_PIN, pixels, sizeof(pixels));
   #endif
 
   #ifdef PIN_LED
@@ -389,15 +389,15 @@ static void board_led_on(void)
 
 static void board_led_off(void)
 {
-  #ifdef PIN_NEOPIXEL
+  #ifdef NEOPIXEL_PIN
   uint8_t pixels[3] = { 0x00, 0x00, 0x00 };
-  board_neopixel_set(PIN_NEOPIXEL, pixels, sizeof(pixels));
+  board_neopixel_set(NEOPIXEL_PIN, pixels, sizeof(pixels));
 
   // Neopixel reset time
   delay_cycle( ns2cycle(200000) ) ;
 
   // TODO how to de-select GPIO pad to set it back to default state !?
-  gpio_ll_output_disable(&GPIO, PIN_NEOPIXEL);
+  gpio_ll_output_disable(&GPIO, NEOPIXEL_PIN);
 
   #ifdef NEOPIXEL_PIN_ENABLE
   gpio_ll_set_level(&GPIO, NEOPIXEL_PIN_ENABLE, 1-NEOPIXEL_PIN_ENABLE_STATE);

--- a/ports/esp32s2/components/bootloader/subproject/main/bootloader_start.c
+++ b/ports/esp32s2/components/bootloader/subproject/main/bootloader_start.c
@@ -266,7 +266,7 @@ static void board_neopixel_set(uint32_t num_pin, uint8_t rgb[])
   uint32_t const time1  = ns2cycle(800);
   uint32_t const period = ns2cycle(1250);
 
-  uint8_t pixels[3*NEOPIXEL_NUMBER];
+  uint8_t const pixels[3*NEOPIXEL_NUMBER];
   for(uint32_t i=0; i<NEOPIXEL_NUMBER; i++)
   {
     // Note: WS2812 color order is GRB
@@ -320,7 +320,7 @@ static void SPI_write(int32_t num_pin_data,uint32_t num_pin_sck,uint8_t c) {
   }
 
  }
-static void board_apa102_set(uint32_t num_pin_data,uint32_t num_pin_sck, uint8_t pixels[], uint32_t numBytes)
+static void board_apa102_set(uint32_t num_pin_data,uint32_t num_pin_sck, uint8_t rgb[])
 {
   SPI_write(num_pin_data,num_pin_sck,0x00);
   SPI_write(num_pin_data,num_pin_sck,0x00);
@@ -329,8 +329,11 @@ static void board_apa102_set(uint32_t num_pin_data,uint32_t num_pin_sck, uint8_t
 
   SPI_write(num_pin_data,num_pin_sck,0xe0 | APA102_BRIGHTNESS);
 
-  for(uint16_t n=0; n<numBytes; n++) {
-    SPI_write(num_pin_data,num_pin_sck,pixels[n]);
+  // DotStar APA102 color order is BGR
+  uint8_t const pixels[3] = { rgb[2], rgb[1], rgb[0] };
+
+  for(uint16_t n=0; n<sizeof(pixels); n++) {
+    SPI_write(num_pin_data, num_pin_sck, pixels[n]);
   }
 }
 #endif
@@ -391,7 +394,7 @@ static void board_led_on(void)
 #ifdef PIN_APA102_DATA
   uint8_t pixels[3] = { 0xb3, 0x00, 0x86 };
   gpio_ll_set_level(&GPIO, PIN_APA102_PWR, 1);
-  board_apa102_set(PIN_APA102_DATA,PIN_APA102_SCK, pixels, sizeof(pixels));
+  board_apa102_set(PIN_APA102_DATA, PIN_APA102_SCK, RGB_DOUBLE_TAP);
 #endif
 }
 
@@ -413,7 +416,7 @@ static void board_led_off(void)
 #endif
 
 #ifdef PIN_APA102_DATA
-  board_apa102_set(PIN_APA102_DATA,PIN_APA102_SCK, RGB_OFF, 3);
+  board_apa102_set(PIN_APA102_DATA, PIN_APA102_SCK, RGB_OFF);
 
   gpio_ll_output_disable(&GPIO, PIN_APA102_DATA);
   gpio_ll_output_disable(&GPIO, PIN_APA102_SCK);


### PR DESCRIPTION
- add NEOPIXEL_ENABLE_PIN for magtag
- Use all 4 neopixels on magtag for indicator in both tinyuf2 and 2nd stage bootloader
- add LED_STATE_ON macro
- rename bunch of macros
- refactor and clean up code.