### PR TITLE
Initialize UART fully for logging.

### DIFF
--- a/ports/stm32f4/boards.c
+++ b/ports/stm32f4/boards.c
@@ -84,6 +84,15 @@ void board_init(void)
   GPIO_InitStruct.Speed     = GPIO_SPEED_FREQ_HIGH;
   GPIO_InitStruct.Alternate = UART_GPIO_AF;
   HAL_GPIO_Init(UART_GPIO_PORT, &GPIO_InitStruct);
+
+  UartHandle.Instance        = UART_DEV;
+  UartHandle.Init.BaudRate   = 115200;
+  UartHandle.Init.WordLength = UART_WORDLENGTH_8B;
+  UartHandle.Init.StopBits   = UART_STOPBITS_1;
+  UartHandle.Init.Parity     = UART_PARITY_NONE;
+  UartHandle.Init.HwFlowCtl  = UART_HWCONTROL_NONE;
+  UartHandle.Init.Mode       = UART_MODE_TX_RX;
+  HAL_UART_Init(&UartHandle);
 #endif
 }
 


### PR DESCRIPTION
Will trying to port this to some f401 boards I have, I was having a hard time getting logging working. I finally tracked this down to the UART not being fully initialized on startup. This seemed to do it.

Still tracking down the remaining issues, but at least have logs now!