### PR TITLE
Various stm32f4 improvements, add stm32f401 blackpill board

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,6 +114,7 @@ jobs:
         # stm32f4
         - 'feather_stm32f405_express'
         - 'stm32f411ve_discovery'
+        - 'stm32f401_blackpill'
 
     steps:
     - name: Setup Python

--- a/ports/stm32f4/boards/feather_stm32f405_express/board.h
+++ b/ports/stm32f4/boards/feather_stm32f405_express/board.h
@@ -74,6 +74,7 @@
 
 #define UART_DEV              USART3
 #define UART_CLOCK_ENABLE     __HAL_RCC_USART3_CLK_ENABLE
+#define UART_CLOCK_DISABLE    __HAL_RCC_USART3_CLK_DISABLE
 #define UART_GPIO_PORT        GPIOB
 #define UART_GPIO_AF          GPIO_AF7_USART3
 #define UART_TX_PIN           GPIO_PIN_10

--- a/ports/stm32f4/boards/stm32f401_blackpill/board.h
+++ b/ports/stm32f4/boards/stm32f401_blackpill/board.h
@@ -1,0 +1,123 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Ha Thach for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef BOARD_H_
+#define BOARD_H_
+
+//--------------------------------------------------------------------+
+// LED
+//--------------------------------------------------------------------+
+
+#define LED_PORT              GPIOC
+#define LED_PIN               GPIO_PIN_13
+#define LED_STATE_ON          1
+
+//--------------------------------------------------------------------+
+// Neopixel
+//--------------------------------------------------------------------+
+
+//// Number of neopixels
+#define NEOPIXEL_NUMBER       0
+
+//#define NEOPIXEL_PORT         GPIOC
+//#define NEOPIXEL_PIN          GPIO_PIN_0
+//
+//// Brightness percentage from 1 to 255
+//#define NEOPIXEL_BRIGHTNESS   0x10
+
+
+//--------------------------------------------------------------------+
+// Flash
+//--------------------------------------------------------------------+
+
+// Flash size of the board
+#define BOARD_FLASH_SIZE  (256 * 1024)
+#define BOARD_FLASH_SECTORS 6
+
+//--------------------------------------------------------------------+
+// USB UF2
+//--------------------------------------------------------------------+
+
+#define USB_VID           0x239A
+#define USB_PID           0x005D
+#define USB_MANUFACTURER  "STM32"
+#define USB_PRODUCT       "STM32F401CxUx"
+
+#define UF2_PRODUCT_NAME  USB_MANUFACTURER " " USB_PRODUCT
+#define UF2_BOARD_ID      "BlackPill"
+#define UF2_VOLUME_LABEL  "BlackPill"
+#define UF2_INDEX_URL     "https://stm32-base.org/boards/STM32F411CEU6-WeAct-Black-Pill-V2.0.html"
+
+#define USB_NO_VBUS_PIN   1
+
+//--------------------------------------------------------------------+
+// UART
+//--------------------------------------------------------------------+
+
+#define UART_DEV              USART2
+#define UART_CLOCK_ENABLE     __HAL_RCC_USART2_CLK_ENABLE
+#define UART_CLOCK_DISABLE    __HAL_RCC_USART2_CLK_DISABLE
+#define UART_GPIO_PORT        GPIOA
+#define UART_GPIO_AF          GPIO_AF7_USART2
+#define UART_TX_PIN           GPIO_PIN_2
+#define UART_RX_PIN           GPIO_PIN_3
+
+//--------------------------------------------------------------------+
+// RCC Clock
+//--------------------------------------------------------------------+
+static inline void clock_init(void)
+{
+  RCC_ClkInitTypeDef RCC_ClkInitStruct;
+  RCC_OscInitTypeDef RCC_OscInitStruct;
+
+  /* Enable Power Control clock */
+  __HAL_RCC_PWR_CLK_ENABLE();
+
+  /* The voltage scaling allows optimizing the power consumption when the device is
+     clocked below the maximum system frequency, to update the voltage scaling value
+     regarding system frequency refer to product datasheet.  */
+  __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE2);
+
+  /* Enable HSE Oscillator and activate PLL with HSE as source */
+  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE;
+  RCC_OscInitStruct.HSEState = RCC_HSE_ON;
+  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
+  RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;
+  RCC_OscInitStruct.PLL.PLLM = HSE_VALUE/1000000;
+  RCC_OscInitStruct.PLL.PLLN = 336;
+  RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV4;
+  RCC_OscInitStruct.PLL.PLLQ = 7;
+  HAL_RCC_OscConfig(&RCC_OscInitStruct);
+
+  /* Select PLL as system clock source and configure the HCLK, PCLK1 and PCLK2
+     clocks dividers */
+  RCC_ClkInitStruct.ClockType = (RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2);
+  RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
+  RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
+  RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV2;
+  RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
+  HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_2);
+}
+
+#endif

--- a/ports/stm32f4/boards/stm32f401_blackpill/board.mk
+++ b/ports/stm32f4/boards/stm32f401_blackpill/board.mk
@@ -1,0 +1,15 @@
+CFLAGS += \
+  -DSTM32F401xC \
+  -DHSE_VALUE=25000000U
+
+SRC_S += \
+	$(ST_CMSIS)/Source/Templates/gcc/startup_stm32f401xc.s
+
+# For flash-jlink target
+JLINK_DEVICE = stm32f401cc
+
+flash: flash-jlink
+erase: erase-jlink
+
+#flash: flash-stlink
+#erase: erase-stlink

--- a/ports/stm32f4/boards/stm32f411ve_discovery/board.h
+++ b/ports/stm32f4/boards/stm32f411ve_discovery/board.h
@@ -74,6 +74,7 @@
 
 #define UART_DEV              USART2
 #define UART_CLOCK_ENABLE     __HAL_RCC_USART2_CLK_ENABLE
+#define UART_CLOCK_DISABLE    __HAL_RCC_USART2_CLK_DISABLE
 #define UART_GPIO_PORT        GPIOA
 #define UART_GPIO_AF          GPIO_AF7_USART2
 #define UART_TX_PIN           GPIO_PIN_2

--- a/ports/stm32f4/linker/stm32f4.ld
+++ b/ports/stm32f4/linker/stm32f4.ld
@@ -43,7 +43,7 @@ _Min_Stack_Size = 0x400; /* required amount of stack */
 /* Specify the memory areas */
 MEMORY
 {
-  RAM (xrw)     : ORIGIN = 0x20000000, LENGTH = 128K - 4 /* reserve 4 bytes for double tap */ 
+  RAM (xrw)     : ORIGIN = 0x20000000, LENGTH = 64K - 4 /* reserve 4 bytes for double tap */
   FLASH (rx)    : ORIGIN = 0x8000000, LENGTH = 31K
   CONFIG (rx)   : ORIGIN = 0x8008000 - 1024, LENGTH = 1024
 }


### PR DESCRIPTION
Got this working on some cheap stm32f401 boards I found on amazon: https://www.amazon.com/SongHe-STM32F401-Development-STM32F401CCU6-Learning/dp/B07XBWGF9M

Doing so required some tweaks:

* Drop RAM listed in the linker script, to account for 64KB SRAM in stm32f401xB/xC. This *should* still work on boards w/ more SRAM, but I don't have one on which to test.
* The VBUS sense pin isn't wired on these, so adding the ability to add a define to have the firmware skip that setup, and properly setup the USB to not do VBUS sensing.
* To fully run my application, (Zephyr based) I added code to de-init the peripherals and timers to the app jump code.
* Only define the `BOARD_FLASH_SECTORS` with a default value of `8` if one isn't set by the board. This let me set this to the proper value of `6` for stm32f401.

With those in place, the board definition itself was pretty simple.

I've made each of these changes fairly atomic commits in this branch, if you'd rather then as separate PRs, let me know.

Thanks!