### PR TITLE
add date to INFO_UF2.TXT

### DIFF
--- a/src/ghostfat.c
+++ b/src/ghostfat.c
@@ -117,10 +117,11 @@ STATIC_ASSERT(FAT_ENTRIES_PER_SECTOR                       ==       256); // FAT
 
 #define UF2_ARRAY_SIZE(_arr)    ( sizeof(_arr) / sizeof(_arr[0]) )
 
-char infoUf2File[128*3] =
+char infoUf2File[] =
     "TinyUF2 Bootloader " UF2_VERSION "\r\n"
     "Model: " UF2_PRODUCT_NAME "\r\n"
-    "Board-ID: " UF2_BOARD_ID "\r\n";
+    "Board-ID: " UF2_BOARD_ID "\r\n"
+    "Date: " __DATE__ "\r\n";
 
 const char indexFile[] =
     "<!doctype html>\n"


### PR DESCRIPTION
Added date of compiled to INFO_UF2.TXT
```
TinyUF2 Bootloader 0.2.1-20-g3811298-dirty - esp-idf (v4.3-dev-1197-g8bc19ba89) tinyusb (0.7.0-45-g4a2baf40)
Model: Espressif Saola 1R WROVER
Board-ID: ESP32S2-Saola1R-v1.2
Date: Feb 17 2021
```