### PR TITLE
Add support for multiple sectors per cluster in GhostFAT

### DIFF
--- a/src/uf2.h
+++ b/src/uf2.h
@@ -42,8 +42,12 @@ SOFTWARE.
 // Version is passed by makefile
 // #define UF2_VERSION         "0.0.0"
 
-#define CFG_UF2_FLASH_SIZE  (4*1024*1024)   // TODO absolute max flash size
-#define CFG_UF2_NUM_BLOCKS  0x10109         // just under 32MB
+#define CFG_UF2_FLASH_SIZE          (4*1024*1024)    // TODO absolute max flash size
+#define CFG_UF2_NUM_BLOCKS          (0x10109)        // just under 32MB
+#define CFG_UF2_SECTORS_PER_CLUSTER (1)
+// #define CFG_UF2_FLASH_SIZE          (256*1024*1024)  // TODO absolute max flash size
+// #define CFG_UF2_NUM_BLOCKS          (0x300000)       // 1.5 GB
+// #define CFG_UF2_SECTORS_PER_CLUSTER (64)
 
 //--------------------------------------------------------------------+
 //


### PR DESCRIPTION
Add support for multiple sectors per cluster in GhostFAT to enable larger flash sizes.