### PR TITLE
Speedup esp32 flash

### DIFF
--- a/ports/esp32s2/Makefile
+++ b/ports/esp32s2/Makefile
@@ -43,6 +43,12 @@ erase:
 monitor:
 	idf.py -B$(BUILD) -DBOARD=$(BOARD) monitor
 
+size-components:
+	idf.py -B$(BUILD) -DBOARD=$(BOARD) size-components
+
+size-files:
+	idf.py -B$(BUILD) -DBOARD=$(BOARD) size-files
+
 #-------------- Self Update --------------
 $(SELF_BUILD)/update-tinyuf2.bin: app
 	$(PYTHON3) $(TOP)/lib/uf2/utils/uf2conv.py --carray $(BUILD)/tinyuf2.bin -o $(TOP)/self_update/bootloader_bin.c

--- a/src/board_api.h
+++ b/src/board_api.h
@@ -61,6 +61,7 @@
 // Baudrate for UART if used
 #define BOARD_UART_BAUDRATE   115200
 
+// Init basic peripherals such as clock, led indicator control (gpio, pwm etc ..)
 void board_init(void);
 
 // Write PWM duty value to LED
@@ -105,11 +106,11 @@ void     board_flash_write(uint32_t addr, void const *data, uint32_t len);
 void     board_flash_flush(void);
 
 #if TINYUF2_DISPLAY
-  void board_display_init(void);
-  void board_display_draw_line(int y, uint16_t* pixel_color, uint32_t pixel_num);
+void board_display_init(void);
+void board_display_draw_line(int y, uint16_t* pixel_color, uint32_t pixel_num);
 
-  void screen_draw_drag(void);
-  void screen_draw_hf2(void);
+void screen_draw_drag(void);
+void screen_draw_hf2(void);
 #endif
 
 // perform self-update on bootloader

--- a/src/board_api.h
+++ b/src/board_api.h
@@ -91,7 +91,7 @@ void board_app_jump(void);
 // Init DFU process
 void board_dfu_init(void);
 
-// DFU is complete, should reset or jump to application mode
+// DFU is complete, should reset or jump to application mode and not return
 void board_dfu_complete(void);
 
 // Fill Serial Number and return its length (limit to 16 bytes)

--- a/src/board_api.h
+++ b/src/board_api.h
@@ -110,7 +110,6 @@ void board_display_init(void);
 void board_display_draw_line(int y, uint16_t* pixel_color, uint32_t pixel_num);
 
 void screen_draw_drag(void);
-void screen_draw_hf2(void);
 #endif
 
 // perform self-update on bootloader


### PR DESCRIPTION
- Esp32s2 increase flash cache from 4K to 64KB. This allow esp to use block erase instead of sector erase and gain 2x
speed flashing
- Also skip erase & write if contents already matches.

```
Before PR

written 1249536 bytes in 19.38 seconds.
Speed : 64.48 KB/s

After PR

written 1249536 bytes in 9.69 seconds.
Speed : 128.95 KB/s
```
