### PR TITLE
update funhouse to match revB

### DIFF
--- a/ports/esp32s2/boards/adafruit_funhouse_esp32s2/board.h
+++ b/ports/esp32s2/boards/adafruit_funhouse_esp32s2/board.h
@@ -93,7 +93,7 @@
 //--------------------------------------------------------------------+
 
 #define USB_VID           0x239A
-#define USB_PID           0x00E5 // TODO need PID for its own
+#define USB_PID           0x00F9
 #define USB_MANUFACTURER  "Adafruit"
 #define USB_PRODUCT       "FunHouse"
 

--- a/ports/esp32s2/boards/adafruit_funhouse_esp32s2/board.h
+++ b/ports/esp32s2/boards/adafruit_funhouse_esp32s2/board.h
@@ -36,7 +36,7 @@
 
 // GPIO that implement 1-bit memory with RC components which hold the
 // pin value long enough for double reset detection.
-#define PIN_DOUBLE_RESET_RC   42
+#define PIN_DOUBLE_RESET_RC   38
 
 //--------------------------------------------------------------------+
 // LED
@@ -48,8 +48,8 @@
 // GPIO connected to Dotstar
 #define DOTSTAR_PIN_DATA      14
 #define DOTSTAR_PIN_SCK       15
-#define DOTSTAR_PIN_PWR       41
-#define DOTSTAR_POWER_STATE   0
+//#define DOTSTAR_PIN_PWR       41
+//#define DOTSTAR_POWER_STATE   0
 
 // Brightness percentage from 1 to 255
 #define DOTSTAR_BRIGHTNESS    0x08
@@ -69,9 +69,9 @@
 #define DISPLAY_PIN_MOSI      35
 #define DISPLAY_PIN_SCK       36
 
-#define DISPLAY_PIN_CS        39
-#define DISPLAY_PIN_DC        38
-#define DISPLAY_PIN_RST       40
+#define DISPLAY_PIN_CS        40
+#define DISPLAY_PIN_DC        39
+#define DISPLAY_PIN_RST       41
 
 #define DISPLAY_PIN_BL        21
 #define DISPLAY_BL_ON         1  // GPIO state to enable back light
@@ -79,8 +79,8 @@
 #define DISPLAY_WIDTH         240
 #define DISPLAY_HEIGHT        240
 
-#define DISPLAY_COL_OFFSET    0 // 53
-#define DISPLAY_ROW_OFFSET    0 // 40
+#define DISPLAY_COL_OFFSET    0
+#define DISPLAY_ROW_OFFSET    0
 
 // Memory Data Access Control & // Vertical Scroll Start Address
 #define DISPLAY_MADCTL        (TFT_MADCTL_MX | TFT_MADCTL_MY | TFT_MADCTL_MV)
@@ -88,18 +88,17 @@
 
 #define DISPLAY_TITLE         "Fun House"
 
-
 //--------------------------------------------------------------------+
 // USB UF2
 //--------------------------------------------------------------------+
 
 #define USB_VID           0x239A
-#define USB_PID           0x00E5
+#define USB_PID           0x00E5 // TODO need PID for its own
 #define USB_MANUFACTURER  "Adafruit"
-#define USB_PRODUCT       "Metro FunHouse"
+#define USB_PRODUCT       "FunHouse"
 
 #define UF2_PRODUCT_NAME  USB_MANUFACTURER " " USB_PRODUCT
-#define UF2_BOARD_ID      "MagTag-FunHouse-revA"
+#define UF2_BOARD_ID      "ESP32S2-FunHouse-revB"
 #define UF2_VOLUME_LABEL  "HOUSEBOOT"
 #define UF2_INDEX_URL     "https://www.adafruit.com/"
 

--- a/ports/esp32s2/boards/adafruit_magtag_29gray/board.h
+++ b/ports/esp32s2/boards/adafruit_magtag_29gray/board.h
@@ -67,10 +67,10 @@
 #define USB_VID           0x239A
 #define USB_PID           0x00E5
 #define USB_MANUFACTURER  "Adafruit"
-#define USB_PRODUCT       "Metro MagTag 2.9 Grayscale"
+#define USB_PRODUCT       "MagTag 2.9 Grayscale"
 
 #define UF2_PRODUCT_NAME  USB_MANUFACTURER " " USB_PRODUCT
-#define UF2_BOARD_ID      "MagTag-29gray-revC"
+#define UF2_BOARD_ID      "ESP32S2-MagTag_29gray-revC"
 #define UF2_VOLUME_LABEL  "MAGTAGBOOT"
 #define UF2_INDEX_URL     "https://www.adafruit.com/product/4800"
 

--- a/ports/esp32s2/boards/boards.c
+++ b/ports/esp32s2/boards/boards.c
@@ -321,7 +321,6 @@ void dotstar_init(void)
   gpio_set_level(DOTSTAR_PIN_PWR, DOTSTAR_POWER_STATE);
   #endif
 
-
   spi_bus_config_t bus_cfg =
   {
     .miso_io_num     = -1,

--- a/ports/esp32s2/components/bootloader/subproject/main/bootloader_start.c
+++ b/ports/esp32s2/components/bootloader/subproject/main/bootloader_start.c
@@ -377,10 +377,12 @@ static void board_led_on(void)
   gpio_ll_output_enable(&GPIO, DOTSTAR_PIN_SCK);
   gpio_ll_set_level(&GPIO, DOTSTAR_PIN_SCK, 0);
 
+  #ifdef DOTSTAR_PIN_PWR
   gpio_pad_select_gpio(DOTSTAR_PIN_PWR);
   gpio_ll_input_disable(&GPIO, DOTSTAR_PIN_PWR);
   gpio_ll_output_enable(&GPIO, DOTSTAR_PIN_PWR);
   gpio_ll_set_level(&GPIO, DOTSTAR_PIN_PWR, DOTSTAR_POWER_STATE);
+  #endif
 #endif
 
 #ifdef LED_PIN
@@ -428,8 +430,11 @@ static void board_led_off(void)
 
   gpio_ll_output_disable(&GPIO, DOTSTAR_PIN_DATA);
   gpio_ll_output_disable(&GPIO, DOTSTAR_PIN_SCK);
+
+  #ifdef DOTSTAR_PIN_PWR
   gpio_ll_set_level(&GPIO, DOTSTAR_PIN_PWR, 1-DOTSTAR_POWER_STATE);
   gpio_ll_output_disable(&GPIO, DOTSTAR_PIN_PWR);
+  #endif
 #endif
 
 #ifdef LED_PIN


### PR DESCRIPTION
notice some changes in revB schematics and update board file accordingly
1. Pin double reset RC change from 42 to 38
2. There is no `DOTSTAR_PIN_PWR`
3. Dispaly CS, DC, RST is all +1
4. TODO need new PID for funhouse