### PR TITLE
Fix write error on board reset

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -64,6 +64,8 @@ extern uint32_t _board_dfu_dbl_tap[];
 #endif
 static volatile uint32_t _timer_count = 0;
 
+bool _dfu_complete = false;
+
 // return true if start DFU mode, else App mode
 static bool check_dfu_mode(void)
 {
@@ -142,6 +144,15 @@ int main(void)
   while(1)
   {
     tud_task();
+    if (_dfu_complete)
+    {
+      board_dfu_complete();
+	  
+      // _dfu_complete = false;
+      // board_dfu_complete() should not return
+      // getting here is an indicator of error
+      while(1) {}
+    }
   }
 #endif
 }

--- a/src/msc.c
+++ b/src/msc.c
@@ -41,6 +41,8 @@ static WriteState _wr_state = { 0 };
 // tinyusb callbacks
 //--------------------------------------------------------------------+
 
+extern bool _dfu_complete;
+
 // Invoked when received SCSI_CMD_INQUIRY
 // Application fill vendor id, product id and revision with string up to 8, 16, 4 characters respectively
 void tud_msc_inquiry_cb(uint8_t lun, uint8_t vendor_id[8], uint8_t product_id[16], uint8_t product_rev[4])
@@ -190,11 +192,7 @@ void tud_msc_write10_complete_cb(uint8_t lun)
       #endif
 
       indicator_set(STATE_WRITING_FINISHED);
-      board_dfu_complete();
-
-      // board_dfu_complete() should not return
-      // getting here is an indicator of error
-      while(1) {}
+      _dfu_complete = true;
     }
   }
 }


### PR DESCRIPTION
Currently (at least, for me) the reset of the board is always causing Windows to report a write error (which is not very user friendly) when the file is finished uploading.

Deferring the reset, until after `tud_task` has completed, appears to solve this.

(It does *not* fix the write error case when multiple firmware families are concatenated in a single file, though. Is there any mechanism to request a safe eject from the OS?)