### PR TITLE
Rt1010 sdphost always write to flash

### DIFF
--- a/ports/mimxrt10xx/README.md
+++ b/ports/mimxrt10xx/README.md
@@ -18,17 +18,16 @@ make BOARD=metro_m7_1011 flash-jlink-bin
 
 iMXRT has built-in BootROM that implements the Serial Download Protocol (SDP), which can be used to load & execute TinyUF2 to SRAM with `spdhost` tool via USB. You need to
 
-1. Power up your board with the Boot Mode switch set to `BOOT_MODE[1:0]=01` to enter Serial Download mode. Note Serial Download mode also automatically run with blank flash, therefore you don't have to manual change it in your production run.
-2. Run `flash-sdp` make target which in turn uses the `sdphost` with correct address and arguments to load TinyUF2 
+1. Power up your board with the Boot Mode switch set to `BOOT_MODE[1:0]=01` to enter Serial Download mode. Note: Serial Download mode also automatically run with blank flash, therefore you don't have to manual change it in your production run.
+2. Run `flash-sdp` make target which in turn uses the `sdphost` with correct address and arguments to load and execute TinyUF2. While running, TinyUF2 will program the external flash with its SRAM's image.
 
   ```
   make BOARD=imxrt1010_evk flash-sdp
   ```
-3. (Optional) Drag and drop `update-tinyuf2_BOARD.uf2` to program the external flash. This step is optional for blank chip since TinyUF2 will automatically check the external flash to see if it has a valid Flash Configure Block (FCFB), if not TinyUF2 will program the external flash with its SRAM's image.
 
-Note: `sdphost` executable binaries for common platforms (windows/mac/linux) are included in sdphost folder. If you have issue with executable permission, just manually give it permission to run. The source code for sdphost tool is also included just in case binaries for your host platform is not included (e.g ARM, RISC-V etc ...)
+Note1: `sdphost` executable binaries for common platforms (windows/mac/linux) are included in sdphost folder. If you have issue with executable permission, just manually give it permission to run. The source code for sdphost tool is also included just in case binaries for your host platform is not included (e.g ARM, RISC-V etc ...)
 
-Note2: Since SDP with BootROM doesn't requires external debugger and always exists regardless of the external flash, this method can also be used to de-brick your board should it needs. 
+Note2: Since SDP with BootROM doesn't requires external debugger and always exists regardless of the external flash, this method can also be used to de-brick your board should it needs.
 
 ## Update to newer version
 

--- a/ports/mimxrt10xx/board_flash.c
+++ b/ports/mimxrt10xx/board_flash.c
@@ -55,13 +55,15 @@ void board_flash_init(void)
 {
   flexspi_nor_flash_init(FLEXSPI_INSTANCE, (flexspi_nor_config_t*) &qspiflash_config);
 
-  // Check for FCFB and copy bootloader to flash if not present
-  if ( *(uint32_t*) FCFB_START_ADDRESS != FLEXSPI_CFG_BLK_TAG )
+  // TinyUF2 will copy its image to flash if  Boot Mode is '01' i.e Serial Download Mode (BootRom)
+  // Normally it is done once by SDPHost or used to recover an corrupted boards
+  uint32_t const boot_mode = (SRC->SBMR2 & SRC_SBMR2_BMOD_MASK) >> SRC_SBMR2_BMOD_SHIFT;
+  if (boot_mode == 1)
   {
     uint8_t const* image_data = (uint8_t const *) &qspiflash_config;
     uint32_t flash_addr = FCFB_START_ADDRESS;
 
-    TU_LOG1("FCFB not present.  Copying image to flash.\r\n");
+    TU_LOG1("BootMode = 01: copying TinyUF2 image to flash.\r\n");
     while ( flash_addr < (FlexSPI_AMBA_BASE + BOARD_BOOT_LENGTH) )
     {
       board_flash_write(flash_addr, image_data, FLASH_PAGE_SIZE);

--- a/src/board_api.h
+++ b/src/board_api.h
@@ -55,7 +55,7 @@
 #endif
 
 //--------------------------------------------------------------------+
-// Platform Dependent API
+// Basic API
 //--------------------------------------------------------------------+
 
 // Baudrate for UART if used
@@ -88,7 +88,7 @@ bool board_app_valid(void);
 // Jump to Application
 void board_app_jump(void);
 
-// Init DFU process
+// Init DFU process, mostly for starting USB
 void board_dfu_init(void);
 
 // DFU is complete, should reset or jump to application mode and not return
@@ -97,13 +97,28 @@ void board_dfu_complete(void);
 // Fill Serial Number and return its length (limit to 16 bytes)
 uint8_t board_usb_get_serial(uint8_t serial_id[16]);
 
-//------------- Flash -------------//
+//--------------------------------------------------------------------+
+// Flash API
+//--------------------------------------------------------------------+
+
+// Initialize flash for DFU
 void     board_flash_init(void);
+
+// Get size of flash
 uint32_t board_flash_size(void);
 
+// Read from flash
 void     board_flash_read (uint32_t addr, void* buffer, uint32_t len);
+
+// Write to flash
 void     board_flash_write(uint32_t addr, void const *data, uint32_t len);
+
+// Flush/Sync flash contents
 void     board_flash_flush(void);
+
+//--------------------------------------------------------------------+
+// Dispaly API
+//--------------------------------------------------------------------+
 
 #if TINYUF2_DISPLAY
 void board_display_init(void);


### PR DESCRIPTION
Use bootmode from SRC->SBMR2 to determine whether we are in Serial Download mode. If so write the tinyuf2 image to flash. So basically everytime SDPHost is uesd, it will write contents to flash. This works better as 
- recovery method or when reworking components swapping mcu and/or flash chip. 
- prototyping/simulate other boards e.g using evk board without actually drag & drop uf2 once loaded via SDP
- At worse, user load SDP with the same image on flash, the write caching will compare with existing contents and won't perform any erase/write op.

@nxf58843 @gsteiert would you mind reviewing the PR, also please accept the contributor invitation, it make requesting you as reviewer much easier in the future