### PR TITLE
metro m7: Switch bootloader to 4MB flash part

### DIFF
--- a/ports/mimxrt10xx/boards/metro_m7_1011/board.h
+++ b/ports/mimxrt10xx/boards/metro_m7_1011/board.h
@@ -29,7 +29,7 @@
 #define BOARD_H_
 
 // Size of on-board external flash
-#define BOARD_FLASH_SIZE     (2*1024*1024)
+#define BOARD_FLASH_SIZE     (4*1024*1024)
 
 //--------------------------------------------------------------------+
 // LED
@@ -72,7 +72,7 @@
 #define USB_VID           0x239A
 #define USB_PID           0x00E1
 #define USB_MANUFACTURER  "Adafruit"
-#define USB_PRODUCT       "Metro M7 1011"
+#define USB_PRODUCT       "Metro M7 iMX RT1011"
 
 #define UF2_PRODUCT_NAME  USB_MANUFACTURER " " USB_PRODUCT
 #define UF2_BOARD_ID      "MIMXRT1011-Metro-revA"

--- a/ports/mimxrt10xx/boards/metro_m7_1011/flash_config.c
+++ b/ports/mimxrt10xx/boards/metro_m7_1011/flash_config.c
@@ -36,7 +36,7 @@ const BOOT_DATA_T boot_data = {
   0xFFFFFFFF                  /* empty - extra data word */
 };
 
-// Config for W25Q16JV with QSPI routed.
+// Config for W25Q32JV with QSPI routed.
 __attribute__((section(".boot_hdr.conf")))
 const flexspi_nor_config_t qspiflash_config = {
     .pageSize           = 256u,


### PR DESCRIPTION
& change product to match CircuitPython.  @ladyada I'm not sure whether it's this or a change in CircuitPython that is needed to fix copying CIRCUITPY content more than 1MB..