### PR TITLE
Add Imxrt erase firmware

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,7 +161,9 @@ jobs:
         echo ENV_PORT=$ENV_PORT >> $GITHUB_ENV
 
     - name: Build
-      run: make -C $ENV_PORT BOARD=${{ matrix.board }} all copy-artifact
+      run: |
+        make -C $ENV_PORT BOARD=${{ matrix.board }} all copy-artifact
+        make -C $ENV_PORT/erase_firmware BOARD=${{ matrix.board }} all
 
     - uses: actions/upload-artifact@v2
       with:

--- a/erase_firmware/erase_firmware.c
+++ b/erase_firmware/erase_firmware.c
@@ -1,0 +1,90 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include "board_api.h"
+
+/* This is an application that erases whole application firmware by
+ * writing the erase magic and reset to let bootloader do its work
+ */
+
+#ifndef DBL_TAP_REG
+// defined by linker script
+extern uint32_t _board_dfu_dbl_tap[];
+#define DBL_TAP_REG   _board_dfu_dbl_tap[0]
+#endif
+
+//--------------------------------------------------------------------+
+// MACRO TYPEDEF CONSTANT ENUM DECLARATION
+//--------------------------------------------------------------------+
+
+int main(void)
+{
+  board_init();
+  printf("TinyUF2: Erase Application Firmware\r\n");
+
+  // set magic then reset
+  DBL_TAP_REG = DBL_TAP_MAGIC_ERASE_APP;
+
+  board_reset();
+
+  while(1)
+  {
+
+  }
+}
+
+void board_timer_handler(void)
+{
+
+}
+
+//--------------------------------------------------------------------+
+// Logger newlib retarget
+//--------------------------------------------------------------------+
+
+// Enable only with LOG is enabled (Note: ESP32-S2 has built-in support already)
+#if TUF2_LOG // && (CFG_TUSB_MCU != OPT_MCU_ESP32S2)
+
+#if defined(LOGGER_RTT)
+#include "SEGGER_RTT.h"
+#endif
+
+__attribute__ ((used)) int _write (int fhdl, const void *buf, size_t count)
+{
+  (void) fhdl;
+
+#if defined(LOGGER_RTT)
+  SEGGER_RTT_Write(0, (char*) buf, (int) count);
+  return count;
+#else
+  return board_uart_write(buf, count);
+#endif
+}
+
+#endif

--- a/ports/esp32s2/boards/boards.c
+++ b/ports/esp32s2/boards/boards.c
@@ -185,6 +185,11 @@ void board_dfu_init(void)
   configure_pins(&hal);
 }
 
+void board_reset(void)
+{
+  esp_restart();
+}
+
 void board_dfu_complete(void)
 {
   // Set partition OTA0 as bootable and reset

--- a/ports/lpc55/boards.c
+++ b/ports/lpc55/boards.c
@@ -93,6 +93,7 @@ static uint8_t  _flash_cache[FLASH_PAGE_SIZE] __attribute__((aligned(4)));
 //--------------------------------------------------------------------+
 //
 //--------------------------------------------------------------------+
+
 void board_flash_init(void)
 {
 }
@@ -139,6 +140,11 @@ void board_flash_write (uint32_t addr, void const *data, uint32_t len)
     }
   }
   memcpy(_flash_cache + (addr & (FLASH_PAGE_SIZE - 1)), data, len);
+}
+
+void board_flash_erase_app(void)
+{
+  // TODO implement later
 }
 
 uint8_t board_usb_get_serial(uint8_t serial_id[16])
@@ -279,6 +285,11 @@ void board_dfu_init(void)
 #endif
 
   TU_LOG2("FRO192M_CTRL:  0x%08lX\r\n", ANACTRL->FRO192M_CTRL);
+}
+
+void board_reset(void)
+{
+  NVIC_SystemReset();
 }
 
 void board_dfu_complete(void)

--- a/ports/lpc55/erase_firmware/Makefile
+++ b/ports/lpc55/erase_firmware/Makefile
@@ -1,0 +1,2 @@
+all:
+	@echo "not implemented yet"

--- a/ports/make.mk
+++ b/ports/make.mk
@@ -25,7 +25,7 @@ check_defined = \
     $(call __check_defined,$1,$(strip $(value 2)))))
 __check_defined = \
     $(if $(value $1),, \
-    $(error Undefined make flag: $1$(if $2, ($2))))
+    $(error Undefined: $1$(if $2, ($2))))
 
 #-------------- Select the board to build for. ------------
 

--- a/ports/make.mk
+++ b/ports/make.mk
@@ -42,7 +42,7 @@ endif
 
 # Build directory
 BUILD = _build/$(BOARD)
-BIN = _bin/$(BOARD)
+BIN = $(TOP)/$(PORT_DIR)/_bin/$(BOARD)
 
 # can be set manually by custome build such as flash_nuke
 OUTNAME ?= tinyuf2-$(BOARD)

--- a/ports/mimxrt10xx/Makefile
+++ b/ports/mimxrt10xx/Makefile
@@ -9,6 +9,8 @@ FLASH_BIN_ADDR = $(UF2_$(MCU)_WRITE_ADDR)
 
 include ../make.mk
 
+# TODO include port.mk
+
 MCU_DIR = lib/nxp/sdk/devices/$(MCU)
 LD_FILES ?= $(PORT_DIR)/linker/$(MCU)_ram.ld $(PORT_DIR)/linker/memory.ld $(PORT_DIR)/linker/common.ld
 

--- a/ports/mimxrt10xx/Makefile
+++ b/ports/mimxrt10xx/Makefile
@@ -66,6 +66,7 @@ SDP_MIMXRT1011_WRITE_ADDR = 0x20206400
 SDP_MIMXRT1011_JUMP_ADDR  = 0x20207000
 UF2_MIMXRT1011_WRITE_ADDR = 0x60000400
 
+# RT1015, 1050 pid is also 0x0130
 SDP_MIMXRT1021_PID = 0x0130
 SDP_MIMXRT1021_WRITE_ADDR = 0x0400
 SDP_MIMXRT1021_JUMP_ADDR  = 0x1000
@@ -75,6 +76,9 @@ SDP_MIMXRT1062_PID = 0x0135
 SDP_MIMXRT1062_WRITE_ADDR = 0x20208000
 SDP_MIMXRT1062_JUMP_ADDR  = 0x20209000
 UF2_MIMXRT1062_WRITE_ADDR = 0x60000000
+
+DBL_TAP_MAGIC_ERASE_APP = 0xf5e80ab4
+DBL_TAP_REG_ADDR = 0x400D410C
 
 ifeq ($(OS),Windows_NT)
 	SDPHOST = sdphost/win/sdphost.exe
@@ -97,7 +101,14 @@ else
 endif
 
 flash-sdp: $(BUILD)/$(OUTNAME).bin
-	@if [ -z "$(SDPHOST)" ]; then echo SDPHOST is not found for this machine; exit 1; fi
+	@:$(call check_defined, SDPHOST, not found for this machine)
+	$(SDPHOST) -u 0x1fc9,$(SDP_$(MCU)_PID) -- write-file $(SDP_$(MCU)_WRITE_ADDR) $<
+	$(SDPHOST) -u 0x1fc9,$(SDP_$(MCU)_PID) -- jump-address $(SDP_$(MCU)_JUMP_ADDR)
+
+# TODO write-register doesn't work
+erase-app: $(BUILD)/$(OUTNAME).bin
+	@:$(call check_defined, SDPHOST, not found for this machine)
+	$(SDPHOST) -u 0x1fc9,$(SDP_$(MCU)_PID) -- write-register $(DBL_TAP_REG_ADDR) 32 $(DBL_TAP_MAGIC_ERASE_APP)
 	$(SDPHOST) -u 0x1fc9,$(SDP_$(MCU)_PID) -- write-file $(SDP_$(MCU)_WRITE_ADDR) $<
 	$(SDPHOST) -u 0x1fc9,$(SDP_$(MCU)_PID) -- jump-address $(SDP_$(MCU)_JUMP_ADDR)
 

--- a/ports/mimxrt10xx/boards.c
+++ b/ports/mimxrt10xx/boards.c
@@ -190,6 +190,11 @@ uint8_t board_usb_get_serial(uint8_t serial_id[16])
   return 16;
 }
 
+void board_reset(void)
+{
+  NVIC_SystemReset();
+}
+
 void board_dfu_complete(void)
 {
   NVIC_SystemReset();

--- a/ports/mimxrt10xx/boards/imxrt1010_evk/board.h
+++ b/ports/mimxrt10xx/boards/imxrt1010_evk/board.h
@@ -29,7 +29,7 @@
 #define BOARD_H_
 
 // Size of on-board external flash
-#define BOARD_FLASH_SIZE     (0x1000000U)
+#define BOARD_FLASH_SIZE     (16*1024*1024)
 
 //--------------------------------------------------------------------+
 // LED

--- a/ports/mimxrt10xx/boards/imxrt1020_evk/bl_api.c
+++ b/ports/mimxrt10xx/boards/imxrt1020_evk/bl_api.c
@@ -41,6 +41,12 @@ status_t flexspi_nor_flash_page_program(uint32_t instance,
     return g_bootloaderTree->flexSpiNorDriver->program(instance, config, dstAddr, src);
 }
 
+status_t flexspi_nor_flash_erase_all(uint32_t instance, flexspi_nor_config_t *config)
+{
+    // return g_bootloaderTree->flexSpiNorDriver->erase_all(instance, config);
+    return kStatus_Fail; // TODO implement erase all later
+}
+
 status_t flexspi_nor_flash_erase(uint32_t instance, flexspi_nor_config_t *config, uint32_t start, uint32_t length)
 {
     return g_bootloaderTree->flexSpiNorDriver->erase(instance, config, start, length);

--- a/ports/mimxrt10xx/boards/imxrt1020_evk/board.h
+++ b/ports/mimxrt10xx/boards/imxrt1020_evk/board.h
@@ -29,7 +29,7 @@
 #define BOARD_H_
 
 // Size of on-board external flash
-#define BOARD_FLASH_SIZE  (0x800000U)
+#define BOARD_FLASH_SIZE      (8*1024*1024)
 
 //--------------------------------------------------------------------+
 // LED

--- a/ports/mimxrt10xx/boards/imxrt1060_evk/bl_api.h
+++ b/ports/mimxrt10xx/boards/imxrt1060_evk/bl_api.h
@@ -26,8 +26,7 @@ typedef struct
     status_t (*program)(uint32_t instance, flexspi_nor_config_t *config, uint32_t dst_addr, const uint32_t *src);
     status_t (*erase_all)(uint32_t instance, flexspi_nor_config_t *config);
     status_t (*erase)(uint32_t instance, flexspi_nor_config_t *config, uint32_t start, uint32_t lengthInBytes);
-    status_t (*read)(
-        uint32_t instance, flexspi_nor_config_t *config, uint32_t *dst, uint32_t addr, uint32_t lengthInBytes);
+    status_t (*read)(uint32_t instance, flexspi_nor_config_t *config, uint32_t *dst, uint32_t addr, uint32_t lengthInBytes);
     void (*clear_cache)(uint32_t instance);
     status_t (*xfer)(uint32_t instance, flexspi_xfer_t *xfer);
     status_t (*update_lut)(uint32_t instance, uint32_t seqIndex, const uint32_t *lutBase, uint32_t seqNumber);

--- a/ports/mimxrt10xx/boards/imxrt1060_evk/board.h
+++ b/ports/mimxrt10xx/boards/imxrt1060_evk/board.h
@@ -29,7 +29,7 @@
 #define BOARD_H_
 
 // Size of on-board external flash
-#define BOARD_FLASH_SIZE  (0x800000U)
+#define BOARD_FLASH_SIZE      (8*1024*1024)
 
 //--------------------------------------------------------------------+
 // LED

--- a/ports/mimxrt10xx/erase_firmware/Makefile
+++ b/ports/mimxrt10xx/erase_firmware/Makefile
@@ -1,0 +1,72 @@
+UF2_FAMILY_ID = 0x4fb2d5bd
+CROSS_COMPILE = arm-none-eabi-
+PORT = mimxrt10xx
+OUTNAME = erase_firmware-$(BOARD)
+
+# skip src and tinyusb files
+NO_TINYUF2_BUILD = 1
+
+include ../../make.mk
+
+MCU_DIR = lib/nxp/sdk/devices/$(MCU)
+LD_FILES ?= $(PORT_DIR)/linker/$(MCU)_ram.ld $(PORT_DIR)/erase_firmware/memory.ld $(PORT_DIR)/linker/common.ld
+
+# Port Compiler Flags
+CFLAGS += \
+  -mthumb \
+  -mabi=aapcs \
+  -mcpu=cortex-m7 \
+  -mfloat-abi=hard \
+  -mfpu=fpv5-d16 \
+  -D__ARMVFP__=0 -D__ARMFPV5__=0 \
+  -DXIP_EXTERNAL_FLASH=1 \
+  -DXIP_BOOT_HEADER_ENABLE=1 \
+  -DCFG_TUSB_MCU=OPT_MCU_MIMXRT10XX \
+  -DNO_TINYUF2_BUILD
+
+# mcu driver cause following warnings
+CFLAGS += -Wno-error=unused-parameter
+
+# Port source
+SRC_C += \
+	erase_firmware/erase_firmware.c \
+	$(PORT_DIR)/boards.c \
+	$(subst $(TOP)/,,$(wildcard $(TOP)/$(BOARD_DIR)/*.c)) \
+	$(MCU_DIR)/system_$(MCU).c \
+	$(MCU_DIR)/project_template/clock_config.c \
+	$(MCU_DIR)/drivers/fsl_clock.c \
+	$(MCU_DIR)/drivers/fsl_gpio.c \
+	$(MCU_DIR)/drivers/fsl_common.c \
+	$(MCU_DIR)/drivers/fsl_ocotp.c \
+	$(MCU_DIR)/drivers/fsl_cache.c \
+	$(MCU_DIR)/drivers/fsl_pwm.c \
+	$(MCU_DIR)/drivers/fsl_xbara.c \
+	$(MCU_DIR)/drivers/fsl_lpuart.c
+
+SRC_S += $(MCU_DIR)/gcc/startup_$(MCU).S
+
+# Port include
+INC += \
+  $(TOP)/src \
+  $(TOP)/$(PORT_DIR) \
+  $(TOP)/$(BOARD_DIR) \
+	$(TOP)/$(MCU_DIR)/../../CMSIS/Include \
+	$(TOP)/$(MCU_DIR) \
+	$(TOP)/$(MCU_DIR)/drivers \
+	$(TOP)/$(MCU_DIR)/xip \
+	$(TOP)/$(MCU_DIR)/project_template
+
+include ../../rules.mk
+
+APPLICATION_ADDR = 0x6000C000
+
+# self-update uf2 file
+uf2: $(BUILD)/$(OUTNAME).uf2
+
+$(BUILD)/$(OUTNAME).uf2: $(BUILD)/$(OUTNAME)-textonly.bin
+	@echo CREATE $@
+	$(PYTHON3) $(TOP)/lib/uf2/utils/uf2conv.py -f $(UF2_FAMILY_ID) -b $(APPLICATION_ADDR) -c -o $@ $<
+
+$(BUILD)/$(OUTNAME)-textonly.bin: $(BUILD)/$(OUTNAME).elf
+	@echo CREATE $@
+	@$(OBJCOPY) -O binary -R .flash_config -R .ivt $^ $@

--- a/ports/mimxrt10xx/erase_firmware/Makefile
+++ b/ports/mimxrt10xx/erase_firmware/Makefile
@@ -1,4 +1,3 @@
-UF2_FAMILY_ID = 0x4fb2d5bd
 CROSS_COMPILE = arm-none-eabi-
 PORT = mimxrt10xx
 OUTNAME = erase_firmware-$(BOARD)
@@ -8,53 +7,21 @@ NO_TINYUF2_BUILD = 1
 
 include ../../make.mk
 
-MCU_DIR = lib/nxp/sdk/devices/$(MCU)
+include ../port.mk
+
 LD_FILES ?= $(PORT_DIR)/linker/$(MCU)_ram.ld $(PORT_DIR)/erase_firmware/memory.ld $(PORT_DIR)/linker/common.ld
 
 # Port Compiler Flags
-CFLAGS += \
-  -mthumb \
-  -mabi=aapcs \
-  -mcpu=cortex-m7 \
-  -mfloat-abi=hard \
-  -mfpu=fpv5-d16 \
-  -D__ARMVFP__=0 -D__ARMFPV5__=0 \
-  -DXIP_EXTERNAL_FLASH=1 \
-  -DXIP_BOOT_HEADER_ENABLE=1 \
-  -DCFG_TUSB_MCU=OPT_MCU_MIMXRT10XX \
-  -DNO_TINYUF2_BUILD
+CFLAGS += -DNO_TINYUF2_BUILD
 
 # mcu driver cause following warnings
 CFLAGS += -Wno-error=unused-parameter
 
 # Port source
-SRC_C += \
-	erase_firmware/erase_firmware.c \
-	$(PORT_DIR)/boards.c \
-	$(subst $(TOP)/,,$(wildcard $(TOP)/$(BOARD_DIR)/*.c)) \
-	$(MCU_DIR)/system_$(MCU).c \
-	$(MCU_DIR)/project_template/clock_config.c \
-	$(MCU_DIR)/drivers/fsl_clock.c \
-	$(MCU_DIR)/drivers/fsl_gpio.c \
-	$(MCU_DIR)/drivers/fsl_common.c \
-	$(MCU_DIR)/drivers/fsl_ocotp.c \
-	$(MCU_DIR)/drivers/fsl_cache.c \
-	$(MCU_DIR)/drivers/fsl_pwm.c \
-	$(MCU_DIR)/drivers/fsl_xbara.c \
-	$(MCU_DIR)/drivers/fsl_lpuart.c
-
-SRC_S += $(MCU_DIR)/gcc/startup_$(MCU).S
+SRC_C += erase_firmware/erase_firmware.c
 
 # Port include
-INC += \
-  $(TOP)/src \
-  $(TOP)/$(PORT_DIR) \
-  $(TOP)/$(BOARD_DIR) \
-	$(TOP)/$(MCU_DIR)/../../CMSIS/Include \
-	$(TOP)/$(MCU_DIR) \
-	$(TOP)/$(MCU_DIR)/drivers \
-	$(TOP)/$(MCU_DIR)/xip \
-	$(TOP)/$(MCU_DIR)/project_template
+INC += $(TOP)/src
 
 include ../../rules.mk
 
@@ -70,3 +37,13 @@ $(BUILD)/$(OUTNAME).uf2: $(BUILD)/$(OUTNAME)-textonly.bin
 $(BUILD)/$(OUTNAME)-textonly.bin: $(BUILD)/$(OUTNAME).elf
 	@echo CREATE $@
 	@$(OBJCOPY) -O binary -R .flash_config -R .ivt $^ $@
+
+#-------------- Artifacts --------------
+ARTIFACT_DIR =
+
+$(ARTIFACT_DIR):
+	@$(MKDIR) -p $@
+
+copy-artifact: $(ARTIFACT_DIR)
+copy-artifact: $(BUILD)/$(OUTNAME).uf2
+	@$(CP) $(BUILD)/$(OUTNAME).uf2 $(ARTIFACT_DIR)

--- a/ports/mimxrt10xx/erase_firmware/Makefile
+++ b/ports/mimxrt10xx/erase_firmware/Makefile
@@ -39,11 +39,10 @@ $(BUILD)/$(OUTNAME)-textonly.bin: $(BUILD)/$(OUTNAME).elf
 	@$(OBJCOPY) -O binary -R .flash_config -R .ivt $^ $@
 
 #-------------- Artifacts --------------
-ARTIFACT_DIR =
-
-$(ARTIFACT_DIR):
+# TODO refactor/remove later
+$(BIN):
 	@$(MKDIR) -p $@
 
-copy-artifact: $(ARTIFACT_DIR)
-copy-artifact: $(BUILD)/$(OUTNAME).uf2
-	@$(CP) $(BUILD)/$(OUTNAME).uf2 $(ARTIFACT_DIR)
+all: $(BIN)
+all: $(BUILD)/$(OUTNAME).uf2
+	$(CP) $< $(BIN)

--- a/ports/mimxrt10xx/erase_firmware/memory.ld
+++ b/ports/mimxrt10xx/erase_firmware/memory.ld
@@ -1,0 +1,21 @@
+/* offset 0x1000 */
+_ivt_origin = _fcfb_origin + _fcfb_length;
+_ivt_length = 0x0400;
+
+_interrupts_origin = 0x6000C000;
+_interrupts_length = 0x0400;
+
+_text_origin = _interrupts_origin + _interrupts_length;
+_text_length =  0x8800;
+
+/* Specify the memory areas */
+MEMORY
+{
+  /* flash config and ivt are not used, leave here for compile only */
+  m_flash_config        (RX)  : ORIGIN = _fcfb_origin       , LENGTH = _fcfb_length
+  m_ivt                 (RX)  : ORIGIN = _ivt_origin        , LENGTH = _ivt_length
+  
+  m_interrupts          (RX)  : ORIGIN = _interrupts_origin , LENGTH = _interrupts_length
+  m_text                (RX)  : ORIGIN = _text_origin       , LENGTH = _text_length
+  m_data                (RW)  : ORIGIN = 0x20000000         , LENGTH = 32K 
+}

--- a/ports/mimxrt10xx/port.mk
+++ b/ports/mimxrt10xx/port.mk
@@ -1,0 +1,44 @@
+UF2_FAMILY_ID = 0x4fb2d5bd
+
+MCU_DIR = lib/nxp/sdk/devices/$(MCU)
+
+# Port Compiler Flags
+CFLAGS += \
+  -mthumb \
+  -mabi=aapcs \
+  -mcpu=cortex-m7 \
+  -mfloat-abi=hard \
+  -mfpu=fpv5-d16 \
+  -D__ARMVFP__=0 -D__ARMFPV5__=0 \
+  -DXIP_EXTERNAL_FLASH=1 \
+  -DXIP_BOOT_HEADER_ENABLE=1 \
+  -DCFG_TUSB_MCU=OPT_MCU_MIMXRT10XX
+  
+# mcu driver cause following warnings
+CFLAGS += -Wno-error=unused-parameter
+
+# Port source
+SRC_C += \
+	$(PORT_DIR)/boards.c \
+	$(MCU_DIR)/system_$(MCU).c \
+	$(MCU_DIR)/project_template/clock_config.c \
+	$(MCU_DIR)/drivers/fsl_clock.c \
+	$(MCU_DIR)/drivers/fsl_gpio.c \
+	$(MCU_DIR)/drivers/fsl_common.c \
+	$(MCU_DIR)/drivers/fsl_ocotp.c \
+	$(MCU_DIR)/drivers/fsl_cache.c \
+	$(MCU_DIR)/drivers/fsl_pwm.c \
+	$(MCU_DIR)/drivers/fsl_xbara.c \
+	$(MCU_DIR)/drivers/fsl_lpuart.c
+
+SRC_S += $(MCU_DIR)/gcc/startup_$(MCU).S
+
+# Port include
+INC += \
+  $(TOP)/$(PORT_DIR) \
+  $(TOP)/$(BOARD_DIR) \
+	$(TOP)/$(MCU_DIR)/../../CMSIS/Include \
+	$(TOP)/$(MCU_DIR) \
+	$(TOP)/$(MCU_DIR)/drivers \
+	$(TOP)/$(MCU_DIR)/xip \
+	$(TOP)/$(MCU_DIR)/project_template

--- a/ports/stm32f3/board_flash.c
+++ b/ports/stm32f3/board_flash.c
@@ -150,6 +150,10 @@ void board_flash_write (uint32_t addr, void const *data, uint32_t len)
   flash_write(addr, data, len);
 }
 
+void board_flash_erase_app(void)
+{
+  // TODO implement later
+}
 
 #ifdef TINYUF2_SELF_UPDATE
 void board_self_update(const uint8_t * bootloader_bin, uint32_t bootloader_len)

--- a/ports/stm32f3/boards.c
+++ b/ports/stm32f3/boards.c
@@ -114,6 +114,11 @@ void board_dfu_init(void)
   __HAL_RCC_USB_CLK_ENABLE();
 }
 
+void board_reset(void)
+{
+  NVIC_SystemReset();
+}
+
 void board_dfu_complete(void)
 {
   NVIC_SystemReset();

--- a/ports/stm32f3/erase_firmware/Makefile
+++ b/ports/stm32f3/erase_firmware/Makefile
@@ -1,0 +1,2 @@
+all:
+	@echo "not implemented yet"

--- a/ports/stm32f4/board_flash.c
+++ b/ports/stm32f4/board_flash.c
@@ -200,6 +200,10 @@ void board_flash_write (uint32_t addr, void const *data, uint32_t len)
   flash_write(addr, data, len);
 }
 
+void board_flash_erase_app(void)
+{
+  // TODO implement later
+}
 
 #ifdef TINYUF2_SELF_UPDATE
 void board_self_update(const uint8_t * bootloader_bin, uint32_t bootloader_len)

--- a/ports/stm32f4/boards.c
+++ b/ports/stm32f4/boards.c
@@ -140,6 +140,11 @@ void board_dfu_init(void)
 #endif
 }
 
+void board_reset(void)
+{
+  NVIC_SystemReset();
+}
+
 void board_dfu_complete(void)
 {
   NVIC_SystemReset();

--- a/ports/stm32f4/erase_firmware/Makefile
+++ b/ports/stm32f4/erase_firmware/Makefile
@@ -1,0 +1,2 @@
+all:
+	@echo "not implemented yet"

--- a/ports/template_port/board_flash.c
+++ b/ports/template_port/board_flash.c
@@ -52,6 +52,10 @@ void board_flash_write (uint32_t addr, void const *data, uint32_t len)
   (void) addr; (void) data; (void) len;
 }
 
+void board_flash_erase_app(void)
+{
+  // TODO implement later
+}
 
 #ifdef TINYUF2_SELF_UPDATE
 void board_self_update(const uint8_t * bootloader_bin, uint32_t bootloader_len)

--- a/ports/template_port/boards.c
+++ b/ports/template_port/boards.c
@@ -37,6 +37,11 @@ void board_dfu_init(void)
   // Init USB for DFU
 }
 
+void board_reset(void)
+{
+  // NVIC_SystemReset();
+}
+
 void board_dfu_complete(void)
 {
   // Mostly reset

--- a/src/board_api.h
+++ b/src/board_api.h
@@ -54,6 +54,10 @@
 #define TINYUF2_DISPLAY 0
 #endif
 
+#define DBL_TAP_MAGIC            0xf01669ef // Enter DFU magic
+#define DBL_TAP_MAGIC_QUICK_BOOT 0xf02669ef // Skip double tap delay detection
+#define DBL_TAP_MAGIC_ERASE_APP  0xf5e80ab4 // Erase entire application !!
+
 //--------------------------------------------------------------------+
 // Basic API
 //--------------------------------------------------------------------+
@@ -63,6 +67,9 @@
 
 // Init basic peripherals such as clock, led indicator control (gpio, pwm etc ..)
 void board_init(void);
+
+// Reset board, not return
+void board_reset(void);
 
 // Write PWM duty value to LED
 void board_led_write(uint32_t value);
@@ -102,19 +109,22 @@ uint8_t board_usb_get_serial(uint8_t serial_id[16]);
 //--------------------------------------------------------------------+
 
 // Initialize flash for DFU
-void     board_flash_init(void);
+void board_flash_init(void);
 
 // Get size of flash
 uint32_t board_flash_size(void);
 
 // Read from flash
-void     board_flash_read (uint32_t addr, void* buffer, uint32_t len);
+void board_flash_read (uint32_t addr, void* buffer, uint32_t len);
 
 // Write to flash
-void     board_flash_write(uint32_t addr, void const *data, uint32_t len);
+void board_flash_write(uint32_t addr, void const *data, uint32_t len);
 
 // Flush/Sync flash contents
-void     board_flash_flush(void);
+void board_flash_flush(void);
+
+// Erase application
+void board_flash_erase_app(void);
 
 //--------------------------------------------------------------------+
 // Dispaly API

--- a/src/ghostfat.c
+++ b/src/ghostfat.c
@@ -226,6 +226,7 @@ static inline bool is_uf2_block (UF2_Block const *bl)
 
 void uf2_init(void)
 {
+  // TODO maybe limit to application size only if possible board_flash_app_size()
   _flash_size = board_flash_size();
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -37,11 +37,10 @@
 //--------------------------------------------------------------------+
 //#define USE_DFU_BUTTON    1
 
-// Enter DFU magic
-#define DBL_TAP_MAGIC             0xf01669ef
 
-// Skip double tap delay detction
-#define DBL_TAP_MAGIC_QUICK_BOOT  0xf02669ef
+#define DBL_TAP_MAGIC            0xf01669ef // Enter DFU magic
+#define DBL_TAP_MAGIC_QUICK_BOOT 0xf02669ef // Skip double tap delay detection
+#define DBL_TAP_MAGIC_ERASE_APP  0xf5e80ab4 // Erase entire application !!
 
 // timeout for double tap detection
 #define DBL_TAP_DELAY             500
@@ -62,6 +61,7 @@ uint8_t const RGB_OFF[]           = { 0x00, 0x00, 0x00 };
 extern uint32_t _board_dfu_dbl_tap[];
 #define DBL_TAP_REG   _board_dfu_dbl_tap[0]
 #endif
+
 static volatile uint32_t _timer_count = 0;
 
 // return true if start DFU mode, else App mode
@@ -169,9 +169,10 @@ void tud_umount_cb(void)
 // Invoked when received GET_REPORT control request
 // Application must fill buffer report's content and return its length.
 // Return zero will cause the stack to STALL request
-uint16_t tud_hid_get_report_cb(uint8_t report_id, hid_report_type_t report_type, uint8_t* buffer, uint16_t reqlen)
+uint16_t tud_hid_get_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t report_type, uint8_t* buffer, uint16_t reqlen)
 {
   // TODO not Implemented
+  (void) itf;
   (void) report_id;
   (void) report_type;
   (void) buffer;
@@ -182,9 +183,10 @@ uint16_t tud_hid_get_report_cb(uint8_t report_id, hid_report_type_t report_type,
 
 // Invoked when received SET_REPORT control request or
 // received data on OUT endpoint ( Report ID = 0, Type = 0 )
-void tud_hid_set_report_cb(uint8_t report_id, hid_report_type_t report_type, uint8_t const* buffer, uint16_t bufsize)
+void tud_hid_set_report_cb(uint8_t itf, uint8_t report_id, hid_report_type_t report_type, uint8_t const* buffer, uint16_t bufsize)
 {
   // This example doesn't use multiple report and report ID
+  (void) itf;
   (void) report_id;
   (void) report_type;
   (void) buffer;

--- a/src/usb_descriptors.c
+++ b/src/usb_descriptors.c
@@ -93,8 +93,9 @@ uint8_t const desc_hid_report[] =
 // Invoked when received GET HID REPORT DESCRIPTOR
 // Application return pointer to descriptor
 // Descriptor contents must exist long enough for transfer to complete
-uint8_t const * tud_hid_descriptor_report_cb(void)
+uint8_t const * tud_hid_descriptor_report_cb(uint8_t itf)
 {
+  (void) itf;
   return desc_hid_report;
 }
 


### PR DESCRIPTION
This PR fix #95  
- ground work for `erase_firmware-BOARD.uf2` for all ports
- new board API: board_reset() and board_flash_erase_app()
- add erase_firmware as std application that reset board with MAGIC ERASE_APP
- IMXRT implement board_flash_erase_app() add makefile to support erase_firmware. For iMXRT it is much quicker to perform chip erase and re-write bootloader from sram to flash. (sector/block erase probably takes longer).
- `erase_firmware-BOARD.uf2` is also uploaded as ci artifact/release if available.
- Also update tinyusb to latest as well (why not).