### PR TITLE
mimxrt10xx: Also self-install when FCFB not valid

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
       id: idf-cache
       with:
         path: ${{ github.workspace }}/.idf_tools
-        key: ${{ runner.os }}-idf-tools-${{ hashFiles('.git/modules/lib/esp-idf/HEAD') }}-20201222
+        key: ${{ runner.os }}-idf-tools-${{ hashFiles('.git/modules/lib/esp-idf/HEAD') }}-20210412
 
     - name: Install IDF tools
       if: steps.idf-cache.outputs.cache-hit != 'true'

--- a/ports/mimxrt10xx/board_flash.c
+++ b/ports/mimxrt10xx/board_flash.c
@@ -76,6 +76,11 @@ void board_flash_init(void)
     TUF2_LOG1("BootMode = 01: ");
     write_tinyuf2_to_flash();
   } 
+  bool fcfb_valid = (*(uint32_t*) FCFB_START_ADDRESS == FLEXSPI_CFG_BLK_TAG);
+  if (!fcfb_valid) {
+    TUF2_LOG1("FCFB not present: ");
+    write_tinyuf2_to_flash();
+  }
 }
 
 uint32_t board_flash_size(void)

--- a/ports/mimxrt10xx/board_flash.c
+++ b/ports/mimxrt10xx/board_flash.c
@@ -71,16 +71,11 @@ void board_flash_init(void)
   // TinyUF2 will copy its image to flash if  Boot Mode is '01' i.e Serial Download Mode (BootRom)
   // Normally it is done once by SDPHost or used to recover an corrupted boards
   uint32_t const boot_mode = (SRC->SBMR2 & SRC_SBMR2_BMOD_MASK) >> SRC_SBMR2_BMOD_SHIFT;
-  if (boot_mode == 1)
+  bool fcfb_valid = (*(uint32_t*) FCFB_START_ADDRESS == FLEXSPI_CFG_BLK_TAG);
+  if (boot_mode == 1 || !fcfb_valid)
   {
-    TUF2_LOG1("BootMode = 01: ");
     write_tinyuf2_to_flash();
   } 
-  bool fcfb_valid = (*(uint32_t*) FCFB_START_ADDRESS == FLEXSPI_CFG_BLK_TAG);
-  if (!fcfb_valid) {
-    TUF2_LOG1("FCFB not present: ");
-    write_tinyuf2_to_flash();
-  }
 }
 
 uint32_t board_flash_size(void)


### PR DESCRIPTION
When starting with a blank flash chip, the board will enter sdp bootloader mode even if the jumpers are in the FlexSPI boot position.  However, since b28b83a24990624961b1af80be8257a91e24f14e, tinyuf2 would not write itself to flash in this situation. Make it do so in both the "boot switch" or "fcfb invalid" cases.