### PR TITLE
esp_reset_reason_set_hint() replacement by NVS flag (ESP32-S2)

### DIFF
--- a/ports/esp32s2/components/bootloader/subproject/CMakeLists.txt
+++ b/ports/esp32s2/components/bootloader/subproject/CMakeLists.txt
@@ -24,6 +24,7 @@ set(COMPONENTS
     soc
     bootloader_support
     log
+    nvs_flash
     spi_flash
     micro-ecc
     main
@@ -32,7 +33,7 @@ set(COMPONENTS
     newlib)
 set(BOOTLOADER_BUILD 1)
 include("${IDF_PATH}/tools/cmake/project.cmake")
-set(common_req log esp_rom esp_common esp_hw_support hal newlib)
+set(common_req log nvs_flash esp_rom esp_common esp_hw_support hal newlib)
 if(LEGACY_INCLUDE_COMMON_HEADERS)
     list(APPEND common_req soc hal)
 endif()

--- a/ports/esp32s2/components/bootloader/subproject/Makefile
+++ b/ports/esp32s2/components/bootloader/subproject/Makefile
@@ -8,7 +8,7 @@ endif
 
 PROJECT_NAME := bootloader
 
-COMPONENTS := esp_hw_support esptool_py bootloader_support log spi_flash micro-ecc soc main efuse esp_rom hal
+COMPONENTS := esp_hw_support esptool_py bootloader_support log nvs_flash spi_flash micro-ecc soc main efuse esp_rom hal
 
 # Clear C and CXX from top level project
 CFLAGS =


### PR DESCRIPTION
Since `esp_reset_reason_set_hint()` is not working/supported anymore (see: https://github.com/espressif/esp-idf/issues/7230) I decided to rewrite the corresponding code using NVS storage instead.

Please note that this pull request does not work at the moment. There is still a compilation error:
```
tinyuf2/lib/esp-idf/components/nvs_flash/src/nvs_platform.hpp:31:10: fatal error: freertos/FreeRTOS.h: No such file or directory
 #include "freertos/FreeRTOS.h"
          ^~~~~~~~~~~~~~~~~~~~~
```

I hope someone can fix this.