### PR TITLE
try to implement esp32s2 boot2 stage update

### DIFF
--- a/apps/self_update/CMakeLists.txt
+++ b/apps/self_update/CMakeLists.txt
@@ -1,3 +1,3 @@
-idf_component_register(SRCS self_update.c bootloader_bin.c
+idf_component_register(SRCS self_update.c tinyuf2_bin.c
                     INCLUDE_DIRS "."
                     REQUIRES boards)

--- a/ports/esp32s2/Makefile
+++ b/ports/esp32s2/Makefile
@@ -60,9 +60,13 @@ $(BUILD)/combined.bin: app
 SELF_BUILD = apps/self_update/$(BUILD)
 
 $(SELF_BUILD)/update-tinyuf2.bin: app
-	$(PYTHON3) $(TOP)/lib/uf2/utils/uf2conv.py --carray $(BUILD)/tinyuf2.bin -o $(TOP)/apps/self_update/bootloader_bin.c
+	$(PYTHON3) $(TOP)/lib/uf2/utils/uf2conv.py --carray $(BUILD)/tinyuf2.bin -o $(TOP)/apps/self_update/tinyuf2_bin.c
+	$(PYTHON3) $(TOP)/lib/uf2/utils/uf2conv.py --carray $(BUILD)/bootloader/bootloader.bin -o boards/boot2_bin.h
+	# rename variable in boot2_bin to avoid conflict
+	@sed -i 's/bindata/binboot2/g' boards/boot2_bin.h
 	idf.py -C apps/self_update/ -B$(SELF_BUILD) -DBOARD=$(BOARD) app
-	@rm $(TOP)/apps/self_update/bootloader_bin.c
+	@rm $(TOP)/apps/self_update/tinyuf2_bin.c
+	@rm boards/boot2_bin.h
 
 $(SELF_BUILD)/update-tinyuf2.uf2: $(SELF_BUILD)/update-tinyuf2.bin
 	$(PYTHON3) $(TOP)/lib/uf2/utils/uf2conv.py -f 0xbfdd4eee -b 0x0000 -c -o $@ $^

--- a/ports/esp32s2/apps/self_update/CMakeLists.txt
+++ b/ports/esp32s2/apps/self_update/CMakeLists.txt
@@ -25,5 +25,6 @@ include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 set(SUPPORTED_TARGETS esp32s2)
 
 add_compile_definitions(TINYUF2_SELF_UPDATE)
+add_compile_definitions(CONFIG_SPI_FLASH_DANGEROUS_WRITE_ALLOWED)
 
 project(update-tinyuf2)

--- a/ports/test_ghostfat/boards.c
+++ b/ports/test_ghostfat/boards.c
@@ -24,43 +24,53 @@
 // Selected option #3.
 
 //------------- Flash -------------//
-uint32_t board_flash_size(void) { return CFG_UF2_FLASH_SIZE; }
-
-// not supported
-void     board_flash_write(uint32_t addr, void const *data, uint32_t len) {
-    (void)addr;
-    (void)data;
-    (void)len;
+uint32_t board_flash_size (void)
+{
+  return CFG_UF2_FLASH_SIZE;
 }
 
 // not supported
-void     board_self_update(const uint8_t * bootloader_bin, uint32_t bootloader_len) {
-    (void)bootloader_bin;
-    (void)bootloader_len;
+void board_flash_write (uint32_t addr, void const *data, uint32_t len)
+{
+  (void) addr;
+  (void) data;
+  (void) len;
 }
 
 // not supported
-void     board_flash_flush(void) {}
+void board_self_update (const uint8_t *bootloader_bin, uint32_t bootloader_len)
+{
+  (void) bootloader_bin;
+  (void) bootloader_len;
+}
+
+// not supported
+void board_flash_flush (void)
+{
+}
 
 //------------- Interesting part of flash support for this test -------------//
-void     board_flash_read (uint32_t addr, void* buffer, uint32_t len) {
-    if ((addr & 7) != 0) {
-        // TODO - need to copy part of the first eight bytes
-        exit(1); // failure exit
-        addr += 8 - (addr & 7);
-    }
+void board_flash_read (uint32_t addr, void *buffer, uint32_t len)
+{
+  if ( (addr & 7) != 0 )
+  {
+    // TODO - need to copy part of the first eight bytes
+    exit(1);    // failure exit
+    addr += 8 - (addr & 7);
+  }
 
-    // EMBED address in each 32 bits of the FLASH
-    uint32_t * dest = buffer;
-    size_t incBytes = sizeof(*dest);
-    uint32_t currentAddress = addr;
+  // EMBED address in each 32 bits of the FLASH
+  uint32_t *dest = buffer;
+  size_t incBytes = sizeof(*dest);
+  uint32_t currentAddress = addr;
 
-    while (len >= incBytes) {
-        memcpy(dest, &currentAddress, incBytes); // unaligned memory possible
+  while ( len >= incBytes )
+  {
+    memcpy(dest, &currentAddress, incBytes);    // unaligned memory possible
 
-        len -= incBytes;
-        dest++;
-        currentAddress += incBytes;
-    }
+    len -= incBytes;
+    dest++;
+    currentAddress += incBytes;
+  }
 }
 


### PR DESCRIPTION
Draft PR to allow boot2 stage update for esp32s2. I have tried to update the boot2 binary with update-uf2, there is a couple of issue
1. There is a macro check to validate the address, though it is easily by passed by enabling unsafed write https://github.com/espressif/esp-idf/blob/master/components/spi_flash/esp_flash_api.c#L51
2. There is some meta data required for boot2 bin
```
Invalid image block, can't boot.
ets_main.c 386 
```
Digging to esptool.py https://github.com/espressif/esptool/blob/master/esptool.py#L3488, look like it does some modification to bootlaoder image to add image size, flash mode, flash freq etc to the very frist 4 bytes (header). At this point, I don't think it is the worth effort to update it, since it seem rather unsafe. It is rather easy to flash boot2 update via rom bootloader. Boot2 won't change much anyway.

_Originally posted by @hathach in https://github.com/adafruit/tinyuf2/issues/134#issuecomment-885568543_

PS: after giving a bit more thought, I think it is still worth updating, since ROM loader is there to unbrick. However, I don't quite feel comfortable following the esptool code, maybe if someone know where is the specs for the layout. We could get this done. I push my interim work to the branch here https://github.com/adafruit/tinyuf2/tree/esp32s2-update-boot2 . If anyone could help with meta data part, that would nail it.