### PR TITLE
Added IO13 Status LED on the FeatherS2 Neo

### DIFF
--- a/ports/esp32s2/boards/unexpectedmaker_feathers2_neo/board.h
+++ b/ports/esp32s2/boards/unexpectedmaker_feathers2_neo/board.h
@@ -54,6 +54,11 @@
 // Number of neopixels
 #define NEOPIXEL_NUMBER       1
 
+// LED for indicator and writing flash
+// If not defined neopixel will be use for flash writing instead
+#define LED_PIN               13
+#define LED_STATE_ON          1
+
 //--------------------------------------------------------------------+
 // USB UF2
 //--------------------------------------------------------------------+


### PR DESCRIPTION
As per title - I forgot to add the status LED