### PR TITLE
Add TCA9554 peripheral power control for neopixel support

### DIFF
--- a/ports/esp32s2/boards/espressif_hmi_1/board.h
+++ b/ports/esp32s2/boards/espressif_hmi_1/board.h
@@ -43,14 +43,30 @@
 //--------------------------------------------------------------------+
 
 // GPIO connected to Neopixel data
-// Note: Need to configure LED power rail via I2C, so does not actually light
-#define NEOPIXEL_PIN          45
+#define NEOPIXEL_PIN          21
 
 // Brightness percentage from 1 to 255
 #define NEOPIXEL_BRIGHTNESS   0x10
 
 // Number of neopixels
 #define NEOPIXEL_NUMBER       1
+
+//Peripheral power is enabled through I2C connected TCA9554
+#define I2C_MASTER_SCL_IO           39
+#define I2C_MASTER_SDA_IO           40
+#define I2C_MASTER_NUM              0
+#define I2C_MASTER_FREQ_HZ          400000
+#define I2C_MASTER_TX_BUF_DISABLE   0
+#define I2C_MASTER_RX_BUF_DISABLE   0
+#define I2C_MASTER_TIMEOUT_MS       1000
+
+#define TCA9554_ADDR                    0x20
+#define TCA9554_INPUT_PORT_REG          0x00
+#define TCA9554_OUTPUT_PORT_REG         0x01
+#define TCA9554_POLARITY_INVERSION_REG  0x02
+#define TCA9554_CONFIGURATION_REG       0x03
+#define TCA9554_DEFAULT_CONFIG          0b10100000            
+#define TCA9554_DEFAULT_VALUE           0b11100000             //Enable peripheral power and ws2812 data in
 
 //--------------------------------------------------------------------+
 // USB UF2


### PR DESCRIPTION
Added support for onboard neopixel that has its power control via the TCA9554
