### PR TITLE
Added support for I2C power control during boot2 phase

### DIFF
--- a/ports/esp32s2/Makefile
+++ b/ports/esp32s2/Makefile
@@ -11,6 +11,10 @@ BUILD = _build/$(BOARD)
 BIN = _bin/$(BOARD)
 TOP = ../..
 
+ifdef SERIAL
+SERIAL_OPT = --port $(SERIAL)
+endif
+
 all:
 	idf.py -B$(BUILD) -DBOARD=$(BOARD) build
 
@@ -28,13 +32,13 @@ fullclean:
 	@rm -rf $(BIN)
 
 flash:
-	idf.py -B$(BUILD) -DBOARD=$(BOARD) flash
+	idf.py -B$(BUILD) -DBOARD=$(BOARD) $(SERIAL_OPT) flash
 
 bootloader-flash:
-	idf.py -B$(BUILD) -DBOARD=$(BOARD) bootloader-flash
+	idf.py -B$(BUILD) -DBOARD=$(BOARD) $(SERIAL_OPT) bootloader-flash
 
 app-flash:
-	idf.py -B$(BUILD) -DBOARD=$(BOARD) app-flash
+	idf.py -B$(BUILD) -DBOARD=$(BOARD) $(SERIAL_OPT) app-flash
 
 erase:
 	idf.py -B$(BUILD) -DBOARD=$(BOARD) erase_flash

--- a/ports/esp32s2/boards/espressif_hmi_1/board.h
+++ b/ports/esp32s2/boards/espressif_hmi_1/board.h
@@ -46,7 +46,7 @@
 #define NEOPIXEL_PIN          21
 
 // Brightness percentage from 1 to 255
-#define NEOPIXEL_BRIGHTNESS   0x10
+#define NEOPIXEL_BRIGHTNESS   0x30
 
 // Number of neopixels
 #define NEOPIXEL_NUMBER       1
@@ -59,6 +59,7 @@
 #define I2C_MASTER_TX_BUF_DISABLE   0
 #define I2C_MASTER_RX_BUF_DISABLE   0
 #define I2C_MASTER_TIMEOUT_MS       1000
+#define I2C_WAIT                    40      //Timing (in microseconds) for I2C
 
 #define TCA9554_ADDR                    0x20
 #define TCA9554_INPUT_PORT_REG          0x00
@@ -67,6 +68,8 @@
 #define TCA9554_CONFIGURATION_REG       0x03
 #define TCA9554_DEFAULT_CONFIG          0b10100000            
 #define TCA9554_DEFAULT_VALUE           0b11100000             //Enable peripheral power and ws2812 data in
+#define TCA9554_PERI_POWER_ON_VALUE     0b11100000             //Enable peripheral power and ws2812 data in
+#define TCA9554_PERI_POWER_OFF_VALUE    0b11110000             //Disable Peripheral power
 
 //--------------------------------------------------------------------+
 // USB UF2

--- a/ports/esp32s2/components/bootloader/subproject/main/bootloader_start.c
+++ b/ports/esp32s2/components/bootloader/subproject/main/bootloader_start.c
@@ -534,9 +534,9 @@ static void board_led_off(void)
 {
 #ifdef NEOPIXEL_PIN
   board_neopixel_set(NEOPIXEL_PIN, RGB_OFF);
-  delay_cycle( NEOPIXEL_RESET_DELAY ) ;
 
   // Neopixel reset time
+  delay_cycle( NEOPIXEL_RESET_DELAY ) ;
 
   // TODO how to de-select GPIO pad to set it back to default state !?
   gpio_ll_output_disable(&GPIO, NEOPIXEL_PIN);

--- a/ports/esp32s2/components/bootloader/subproject/main/bootloader_start.c
+++ b/ports/esp32s2/components/bootloader/subproject/main/bootloader_start.c
@@ -22,8 +22,10 @@
 #include "hal/gpio_ll.h"
 #include "esp_rom_sys.h"
 #include "esp_rom_gpio.h"
+
 // Specific board header specified with -DBOARD=
 #include "board.h"
+
 #ifdef TCA9554_ADDR
 #include "hal/i2c_types.h"
 #endif
@@ -261,14 +263,12 @@ static inline uint32_t delay_cycle(uint32_t cycle)
 #ifdef TCA9554_ADDR
 
 //  Derived from https://github.com/bitbank2/BitBang_I2C  Larry Bank
-// 
 #define LOW   0x00
 #define HIGH  0x01
 #define ACK   0x00
 #define NACK  0x01
 #define CLOCK_STRETCH_TIMEOUT   1000 
 
-// static bool i2c_started;
 #endif
 
 #ifdef NEOPIXEL_PIN
@@ -284,7 +284,6 @@ static void board_neopixel_set(uint32_t num_pin, uint8_t const rgb[])
   uint32_t const time0  = ns2cycle(400);
   uint32_t const time1  = ns2cycle(800);
   uint32_t const period = ns2cycle(1250);
-
   
   uint8_t pixels[3*NEOPIXEL_NUMBER];
   for(uint32_t i=0; i<NEOPIXEL_NUMBER; i++)
@@ -371,21 +370,28 @@ static void board_dotstar_set(uint32_t pin_data, uint32_t pin_sck, uint8_t const
 
 #ifdef TCA9554_ADDR
 // Write one byte to I2C bus
-uint8_t sw_i2c_write_byte(uint8_t b) {
-    uint8_t ack;
+uint8_t sw_i2c_write_byte(uint8_t b)
+{
+  uint8_t ack;
 
-//Shift out 8 bits
-  for (uint8_t mask=0x80; mask!=0; mask>>=1) {
+  //Shift out 8 bits
+  for (uint8_t mask=0x80; mask!=0; mask>>=1)
+  {
     if (mask & b) 
+    {
       gpio_ll_set_level(&GPIO, I2C_MASTER_SDA_IO, HIGH);
+    }
     else
+    {
       gpio_ll_set_level(&GPIO, I2C_MASTER_SDA_IO, LOW);
+    }
     delay_cycle( ns2cycle(I2C_WAIT/2*1000) ) ;
     gpio_ll_set_level(&GPIO, I2C_MASTER_SCL_IO, HIGH);
     delay_cycle( ns2cycle(I2C_WAIT/2*1000) ) ;
     gpio_ll_set_level(&GPIO, I2C_MASTER_SCL_IO, LOW);
   }
-// Wait for ACK/NACK 
+
+  // Wait for ACK/NACK
   delay_cycle( ns2cycle(I2C_WAIT/2*1000) ) ;
   gpio_ll_set_level(&GPIO, I2C_MASTER_SDA_IO, HIGH);
   gpio_ll_set_level(&GPIO, I2C_MASTER_SCL_IO, HIGH);
@@ -397,16 +403,19 @@ uint8_t sw_i2c_write_byte(uint8_t b) {
 }
 
 // I2C Start and Address
-void sw_i2c_begin(uint8_t address) {
-// Start signal
+void sw_i2c_begin(uint8_t address)
+{
+  // Start signal
   gpio_ll_set_level(&GPIO, I2C_MASTER_SDA_IO, LOW);
   delay_cycle( ns2cycle(I2C_WAIT*1000) ) ;
   gpio_ll_set_level(&GPIO, I2C_MASTER_SCL_IO, LOW);
-// Address the device
+
+  // Address the device
   sw_i2c_write_byte(address);
 }
 
-void sw_i2c_end() {
+void sw_i2c_end()
+{
   gpio_ll_set_level(&GPIO, I2C_MASTER_SDA_IO, LOW);
   delay_cycle( ns2cycle(I2C_WAIT*1000) ) ;  
   gpio_ll_set_level(&GPIO, I2C_MASTER_SCL_IO, HIGH);
@@ -415,7 +424,8 @@ void sw_i2c_end() {
 }
 
 // Initialize I2C pins
-void sw_i2c_init() {
+void sw_i2c_init()
+{
   gpio_pad_select_gpio(I2C_MASTER_SDA_IO);
   gpio_ll_input_enable(&GPIO, I2C_MASTER_SDA_IO);
   gpio_ll_output_enable(&GPIO, I2C_MASTER_SDA_IO);
@@ -436,7 +446,8 @@ void sw_i2c_init() {
 }
 
 //Turn on Peripheral power. 
-void init_tca9554() {
+void init_tca9554()
+{
   sw_i2c_begin(TCA9554_ADDR << 1);
   sw_i2c_write_byte(TCA9554_CONFIGURATION_REG);
   sw_i2c_write_byte(TCA9554_DEFAULT_CONFIG);
@@ -530,7 +541,6 @@ static void board_led_off(void)
 
   // TODO how to de-select GPIO pad to set it back to default state !?
   gpio_ll_output_disable(&GPIO, NEOPIXEL_PIN);
-
 
   #ifdef TCA9554_ADDR
   sw_i2c_begin(TCA9554_ADDR << 1);

--- a/ports/esp32s2/components/bootloader/subproject/main/bootloader_start.c
+++ b/ports/esp32s2/components/bootloader/subproject/main/bootloader_start.c
@@ -533,8 +533,8 @@ static void board_led_on(void)
 static void board_led_off(void)
 {
 #ifdef NEOPIXEL_PIN
-  delay_cycle( NEOPIXEL_RESET_DELAY ) ;
   board_neopixel_set(NEOPIXEL_PIN, RGB_OFF);
+  delay_cycle( NEOPIXEL_RESET_DELAY ) ;
 
   // Neopixel reset time
 

--- a/ports/esp32s2/components/bootloader/subproject/main/bootloader_start.c
+++ b/ports/esp32s2/components/bootloader/subproject/main/bootloader_start.c
@@ -20,9 +20,14 @@
 #include "esp32s2/rom/gpio.h"
 #include "soc/cpu.h"
 #include "hal/gpio_ll.h"
-
+#include "esp_rom_sys.h"
+#include "esp_rom_gpio.h"
 // Specific board header specified with -DBOARD=
 #include "board.h"
+#ifdef TCA9554_ADDR
+#include "hal/i2c_types.h"
+#endif
+
 
 // Reset Reason Hint to enter UF2. Check out esp_reset_reason_t for other Espressif pre-defined values
 #define APP_REQUEST_UF2_RESET_HINT   0x11F2
@@ -253,6 +258,19 @@ static inline uint32_t delay_cycle(uint32_t cycle)
   return ccount;
 }
 
+#ifdef TCA9554_ADDR
+
+//  Derived from https://github.com/bitbank2/BitBang_I2C  Larry Bank
+// 
+#define LOW   0x00
+#define HIGH  0x01
+#define ACK   0x00
+#define NACK  0x01
+#define CLOCK_STRETCH_TIMEOUT   1000 
+
+// static bool i2c_started;
+#endif
+
 #ifdef NEOPIXEL_PIN
 
 static inline uint8_t color_brightness(uint8_t color, uint8_t brightness)
@@ -267,6 +285,7 @@ static void board_neopixel_set(uint32_t num_pin, uint8_t const rgb[])
   uint32_t const time1  = ns2cycle(800);
   uint32_t const period = ns2cycle(1250);
 
+  
   uint8_t pixels[3*NEOPIXEL_NUMBER];
   for(uint32_t i=0; i<NEOPIXEL_NUMBER; i++)
   {
@@ -350,10 +369,100 @@ static void board_dotstar_set(uint32_t pin_data, uint32_t pin_sck, uint8_t const
 }
 #endif
 
+#ifdef TCA9554_ADDR
+// Write one byte to I2C bus
+uint8_t sw_i2c_write_byte(uint8_t b) {
+    uint8_t ack;
+
+//Shift out 8 bits
+  for (uint8_t mask=0x80; mask!=0; mask>>=1) {
+    if (mask & b) 
+      gpio_ll_set_level(&GPIO, I2C_MASTER_SDA_IO, HIGH);
+    else
+      gpio_ll_set_level(&GPIO, I2C_MASTER_SDA_IO, LOW);
+    delay_cycle( ns2cycle(I2C_WAIT/2*1000) ) ;
+    gpio_ll_set_level(&GPIO, I2C_MASTER_SCL_IO, HIGH);
+    delay_cycle( ns2cycle(I2C_WAIT/2*1000) ) ;
+    gpio_ll_set_level(&GPIO, I2C_MASTER_SCL_IO, LOW);
+  }
+// Wait for ACK/NACK 
+  delay_cycle( ns2cycle(I2C_WAIT/2*1000) ) ;
+  gpio_ll_set_level(&GPIO, I2C_MASTER_SDA_IO, HIGH);
+  gpio_ll_set_level(&GPIO, I2C_MASTER_SCL_IO, HIGH);
+  esp_rom_delay_us(I2C_WAIT);
+  ack = gpio_ll_get_level( &GPIO, I2C_MASTER_SDA_IO);
+  gpio_ll_set_level( &GPIO, I2C_MASTER_SCL_IO, LOW);
+  gpio_ll_set_level(&GPIO, I2C_MASTER_SDA_IO, LOW);
+  return ack == 0;
+}
+
+// I2C Start and Address
+void sw_i2c_begin(uint8_t address) {
+// Start signal
+  gpio_ll_set_level(&GPIO, I2C_MASTER_SDA_IO, LOW);
+  delay_cycle( ns2cycle(I2C_WAIT*1000) ) ;
+  gpio_ll_set_level(&GPIO, I2C_MASTER_SCL_IO, LOW);
+// Address the device
+  sw_i2c_write_byte(address);
+}
+
+void sw_i2c_end() {
+  gpio_ll_set_level(&GPIO, I2C_MASTER_SDA_IO, LOW);
+  delay_cycle( ns2cycle(I2C_WAIT*1000) ) ;  
+  gpio_ll_set_level(&GPIO, I2C_MASTER_SCL_IO, HIGH);
+  delay_cycle( ns2cycle(I2C_WAIT*1000) ) ;  
+  gpio_ll_set_level(&GPIO, I2C_MASTER_SDA_IO, HIGH);
+}
+
+// Initialize I2C pins
+void sw_i2c_init() {
+  gpio_pad_select_gpio(I2C_MASTER_SDA_IO);
+  gpio_ll_input_enable(&GPIO, I2C_MASTER_SDA_IO);
+  gpio_ll_output_enable(&GPIO, I2C_MASTER_SDA_IO);
+  gpio_ll_od_enable(&GPIO, I2C_MASTER_SDA_IO);
+  gpio_ll_pullup_en(&GPIO, I2C_MASTER_SDA_IO);
+  gpio_ll_pulldown_dis(&GPIO, I2C_MASTER_SDA_IO);
+  gpio_ll_intr_disable(&GPIO, I2C_MASTER_SDA_IO);
+  gpio_ll_set_level(&GPIO, I2C_MASTER_SDA_IO, HIGH);
+
+  gpio_pad_select_gpio(I2C_MASTER_SCL_IO);
+  gpio_ll_input_disable(&GPIO, I2C_MASTER_SCL_IO);
+  gpio_ll_output_enable(&GPIO, I2C_MASTER_SCL_IO);
+  gpio_ll_od_enable(&GPIO, I2C_MASTER_SCL_IO);
+  gpio_ll_pullup_en(&GPIO, I2C_MASTER_SCL_IO); 
+  gpio_ll_pulldown_dis(&GPIO, I2C_MASTER_SCL_IO);
+  gpio_ll_intr_disable(&GPIO, I2C_MASTER_SCL_IO); 
+  gpio_ll_set_level(&GPIO, I2C_MASTER_SCL_IO, HIGH);
+}
+
+//Turn on Peripheral power. 
+void init_tca9554() {
+  sw_i2c_begin(TCA9554_ADDR << 1);
+  sw_i2c_write_byte(TCA9554_CONFIGURATION_REG);
+  sw_i2c_write_byte(TCA9554_DEFAULT_CONFIG);
+  sw_i2c_end();
+
+  delay_cycle( ns2cycle(30000*1000) ) ;
+
+  sw_i2c_begin(TCA9554_ADDR << 1);
+  sw_i2c_write_byte(TCA9554_OUTPUT_PORT_REG);
+  sw_i2c_write_byte(TCA9554_PERI_POWER_ON_VALUE);
+  sw_i2c_end();
+}
+#endif
+
 static void board_led_on(void)
 {
+
 #ifdef NEOPIXEL_PIN
 
+  #ifdef TCA9554_ADDR
+  sw_i2c_init();
+  // For some reason this delay is required after the pins are initialized before being used. 
+  delay_cycle( ns2cycle(30000*1000) );
+  init_tca9554();
+  #endif
+  
   #ifdef NEOPIXEL_POWER_PIN
   gpio_pad_select_gpio(NEOPIXEL_POWER_PIN);
   gpio_ll_input_disable(&GPIO, NEOPIXEL_POWER_PIN);
@@ -394,7 +503,9 @@ static void board_led_on(void)
 #endif
 
   // Need at least 200 us for initial delay although Neopixel reset time is only 50 us
-  delay_cycle( ns2cycle(200000) ) ;
+  // Changed to 1000usec as the HMI WS2812 seems to need a longer reset. 
+  // Tested with the Gravitech Cucumber board neopixel.  
+  delay_cycle( ns2cycle(1000*1000) ) ;
 
 #ifdef NEOPIXEL_PIN
   board_neopixel_set(NEOPIXEL_PIN, RGB_DOUBLE_TAP);
@@ -412,13 +523,23 @@ static void board_led_on(void)
 static void board_led_off(void)
 {
 #ifdef NEOPIXEL_PIN
+  delay_cycle( ns2cycle(1000*1000) ) ;
   board_neopixel_set(NEOPIXEL_PIN, RGB_OFF);
 
   // Neopixel reset time
-  delay_cycle( ns2cycle(200000) ) ;
 
   // TODO how to de-select GPIO pad to set it back to default state !?
   gpio_ll_output_disable(&GPIO, NEOPIXEL_PIN);
+
+
+  #ifdef TCA9554_ADDR
+  sw_i2c_begin(TCA9554_ADDR << 1);
+  sw_i2c_write_byte(TCA9554_OUTPUT_PORT_REG);
+  sw_i2c_write_byte(TCA9554_PERI_POWER_OFF_VALUE);
+  sw_i2c_end();
+  gpio_ll_output_disable(&GPIO, I2C_MASTER_SCL_IO);
+  gpio_ll_output_disable(&GPIO, I2C_MASTER_SDA_IO);
+  #endif
 
   #ifdef NEOPIXEL_POWER_PIN
   gpio_ll_set_level(&GPIO, NEOPIXEL_POWER_PIN, 1-NEOPIXEL_POWER_STATE);


### PR DESCRIPTION
Added support for I2C TCA9554 peripheral power control during the boot2 phase.
Uses software I2C. 
Made a small change to the neopixel reset timing (increased to 1000usec) as it seems to be needed on this board.
I tested this timing with another neopixel equipped board (Gravitech Cucumber) and it worked. 