### PR TITLE
accept custom BOARD_DIR or custom APP_START vector for stm32

### DIFF
--- a/ports/lpc55/port.mk
+++ b/ports/lpc55/port.mk
@@ -37,7 +37,7 @@ SRC_C += \
 # Port include
 INC += \
   $(TOP)/$(PORT_DIR) \
-  $(TOP)/$(BOARD_DIR) \
+  $(BOARD_DIR) \
 	$(TOP)/$(SDK_DIR)/CMSIS/Include \
 	$(TOP)/$(MCU_DIR) \
 	$(TOP)/$(MCU_DIR)/project_template \
@@ -49,4 +49,3 @@ INC += \
 	$(TOP)/$(SDK_DIR)/drivers/lpc_iocon \
 	$(TOP)/$(SDK_DIR)/drivers/lpc_rtc \
 	$(TOP)/$(SDK_DIR)/drivers/sctimer
-

--- a/ports/make.mk
+++ b/ports/make.mk
@@ -33,13 +33,18 @@ __check_defined = \
 # can be set manually by custom build such as flash_nuke
 PORT ?= $(notdir $(shell pwd))
 PORT_DIR = ports/$(PORT)
-BOARD_DIR = $(PORT_DIR)/boards/$(BOARD)
 
-ifeq ($(wildcard $(TOP)/$(BOARD_DIR)/),)
+# BOARD must be set manually. BOARD_DIR can be set by a custom build to
+# an absolute path or relative to where make was invoked.
+ifeq ($(BOARD),)
   $(info You must provide a BOARD parameter with 'BOARD=')
-  $(error Invalid BOARD specified)
+  $(error No BOARD specified)
 endif
-
+BOARD_DIR ?= $(TOP)/$(PORT_DIR)/boards/$(BOARD)
+ifeq ($(wildcard $(BOARD_DIR)/),)
+  $(info Check your BOARD parameter and optionally provide BOARD_DIR)
+  $(error Cannot find board directory)
+endif
 
 # Fetch submodules depended by family
 fetch_submodule_if_empty = $(if $(wildcard $(TOP)/lib/$1/*),,$(info $(shell git -C $(TOP)/lib submodule update --init $1)))
@@ -75,13 +80,13 @@ else
 # Bootloader src, board folder and TinyUSB stack
 SRC_C += \
   $(subst $(TOP)/,,$(wildcard $(TOP)/src/*.c)) \
-  $(subst $(TOP)/,,$(wildcard $(TOP)/$(BOARD_DIR)/*.c))
+  $(subst $(TOP)/,,$(wildcard $(BOARD_DIR)/*.c))
 
 # Include
 INC += \
   $(TOP)/src \
   $(TOP)/$(PORT_DIR) \
-  $(TOP)/$(BOARD_DIR)
+  $(BOARD_DIR)
 
 endif # BUILD_APPLICATION
 
@@ -178,4 +183,4 @@ ifneq ($(SKIP_NANOLIB), 1)
 endif
 
 # Board specific define
-include $(TOP)/$(BOARD_DIR)/board.mk
+include $(BOARD_DIR)/board.mk

--- a/ports/mimxrt10xx/port.mk
+++ b/ports/mimxrt10xx/port.mk
@@ -46,7 +46,7 @@ SRC_S += $(MCU_DIR)/gcc/startup_$(MCU).S
 # Port include
 INC += \
   $(TOP)/$(PORT_DIR) \
-  $(TOP)/$(BOARD_DIR) \
+  $(BOARD_DIR) \
 	$(TOP)/$(SDK_DIR)/CMSIS/Include \
 	$(TOP)/$(MCU_DIR) \
 	$(TOP)/$(MCU_DIR)/project_template \

--- a/ports/stm32f3/Makefile
+++ b/ports/stm32f3/Makefile
@@ -21,6 +21,11 @@ CFLAGS += \
   -nostdlib -nostartfiles \
   -DCFG_TUSB_MCU=OPT_MCU_STM32F3
 
+# Allow to override application start vector
+ifneq ($(APP_START),)
+  CFLAGS += -DBOARD_FLASH_APP_START=$(APP_START)
+endif
+
 # suppress warning caused by vendor mcu driver
 CFLAGS += -Wno-error=cast-align -Wno-error=unused-parameter
 

--- a/ports/stm32f3/boards.h
+++ b/ports/stm32f3/boards.h
@@ -35,7 +35,9 @@
 #include "board.h"
 
 // Flash Start Address of Application
+#ifndef BOARD_FLASH_APP_START
 #define BOARD_FLASH_APP_START   0x08004000
+#endif
 #define BOARD_RAM_START 0x20000000
 #define BOARD_RAM_SIZE 0x9FFF
 

--- a/ports/stm32f4/Makefile
+++ b/ports/stm32f4/Makefile
@@ -21,6 +21,11 @@ CFLAGS += \
   -nostdlib -nostartfiles \
   -DCFG_TUSB_MCU=OPT_MCU_STM32F4
 
+# Allow to override application start vector
+ifneq ($(APP_START),)
+  CFLAGS += -DBOARD_FLASH_APP_START=$(APP_START)
+endif
+
 # suppress warning caused by vendor mcu driver
 CFLAGS += -Wno-error=cast-align -Wno-error=unused-parameter
 

--- a/ports/stm32f4/boards.h
+++ b/ports/stm32f4/boards.h
@@ -35,7 +35,9 @@
 #include "board.h"
 
 // Flash Start Address of Application
+#ifndef BOARD_FLASH_APP_START
 #define BOARD_FLASH_APP_START   0x08010000
+#endif
 
 // Double Reset tap to enter DFU
 #define TINYUF2_DFU_DOUBLE_TAP  1

--- a/ports/test_ghostfat/Makefile
+++ b/ports/test_ghostfat/Makefile
@@ -30,6 +30,6 @@ SRC_S +=
 INC += \
   $(TOP)/src \
   $(TOP)/$(PORT_DIR) \
-  $(TOP)/$(BOARD_DIR) \
+  $(BOARD_DIR) \
 
 include ../rules.mk


### PR DESCRIPTION
A custom BOARD_DIR allows to use tinyuf2 for example as Git submodule in another project that has its own board.h and board.mk.
To set the (absolute or relative) path to your board directory just run:
`make BOARD=<my-board> BOARD_DIR=<path/of/my-board/> ...`

A custom APP_START allows to use tinyuf2 for applications with other start vectors than the hard-coded default in tinyuf2.
To set the start vector of your application just run:
`make APP_START=0x08020000 ...`
or define it in your "board.h" with:
`#define BOARD_FLASH_APP_START 0x08020000`
