### PR TITLE
NXP SPSDK for MIMXRT builds

### DIFF
--- a/ports/mimxrt10xx/Makefile
+++ b/ports/mimxrt10xx/Makefile
@@ -58,25 +58,8 @@ DBL_TAP_REG_ADDR = 0x400D410C
 # extract _fcfb_origin and _ivt_origin from linker file
 SDP_WRITE_ADDR := $(shell sed -n 's/_fcfb_origin.*\(0x.*\);/\1/p' $(TOP)/$(PORT_DIR)/linker/$(MCU)_ram.ld)
 SDP_JUMP_ADDR := $(shell sed -n 's/_ivt_origin.*\(0x.*\);/\1/p' $(TOP)/$(PORT_DIR)/linker/$(MCU)_ram.ld)
-
-ifeq ($(OS),Windows_NT)
-	SDPHOST = sdphost/win/sdphost.exe
-else
-	UNAME_S := $(shell uname -s)
-	UNAME_M := $(shell uname -m)
-
-	ifeq ($(UNAME_S),Darwin)
-		SDPHOST = sdphost/mac/sdphost
-	endif
-
-	ifeq ($(UNAME_S),Linux)
-		SDPHOST_x86_64 = amd64
-		SDPHOST_i386 = i386
-		SDPHOST_armv7l = arm32
-
-		SDPHOST = sdphost/linux/$(SDPHOST_$(UNAME_M))/sdphost
-	endif
-endif
+# SDPHOST is a variable if you need to change the path
+SDPHOST = sdphost
 
 flash-sdp: $(BUILD)/$(OUTNAME).bin
 	@if [ -z "$(SDPHOST)" ]; then echo SDPHOST is not found for this machine; exit 1; fi

--- a/ports/mimxrt10xx/README.md
+++ b/ports/mimxrt10xx/README.md
@@ -18,16 +18,16 @@ make BOARD=metro_m7_1011 flash-jlink-bin
 
 iMXRT has built-in BootROM that implements the Serial Download Protocol (SDP), which can be used to load & execute TinyUF2 to SRAM with `spdhost` tool via USB. You need to
 
-1. Power up your board with the Boot Mode switch set to `BOOT_MODE[1:0]=01` to enter Serial Download mode. Note: Serial Download mode also automatically run with blank flash, therefore you don't have to manual change it in your production run.
-2. Run `flash-sdp` make target which in turn uses the `sdphost` with correct address and arguments to load and execute TinyUF2. While running, TinyUF2 will program the external flash with its SRAM's image.
+1. Instal the NXP SPSDK as described in the [SPSDK Installation Guide](https://spsdk.readthedocs.io/en/latest/usage/installation.html).
+2. If you are running linux, make sure your user has permission for accessing `hidraw` (more details below)
+3. Power up your board with the Boot Mode switch set to `BOOT_MODE[1:0]=01` to enter Serial Download mode. Note: Serial Download mode also automatically run with blank flash, therefore you don't have to manual change it in your production run.
+4. Run `flash-sdp` make target which in turn uses the `sdphost` with correct address and arguments to load and execute TinyUF2. While running, TinyUF2 will program the external flash with its SRAM's image.
 
   ```
   make BOARD=imxrt1010_evk flash-sdp
   ```
 
-Note: `sdphost` executable binaries for common platforms (windows/mac/linux/arm32) are included in sdphost folder. If you have issue with executable permission, just manually give it permission to run. Should binaries for your host platform is not included (e.g ARM, RISC-V etc ...), you could build it from source using [apexrtos/nxp_blhost_sdphost](https://github.com/apexrtos/nxp_blhost_sdphost).
-
-Note2: Since SDP with BootROM doesn't requires external debugger and always exists regardless of the external flash, this method can also be used to de-brick your board should it be needed.
+Note: Since SDP with BootROM doesn't requires external debugger and always exists regardless of the external flash, this method can also be used to de-brick your board should it be needed.
 
 ## Update to newer version
 
@@ -39,3 +39,18 @@ Double tap to enter bootloader mode, then simply drag & drop `update-tinyuf2_BOA
 - [MIMX RT1010 Evaluation Kit](https://www.nxp.com/design/development-boards/i.mx-evaluation-and-development-boards/i.mx-rt1010-evaluation-kit:MIMXRT1010-EVK)
 - [MIMX RT1020 Evaluation Kit](https://www.nxp.com/design/development-boards/i.mx-evaluation-and-development-boards/i.mx-rt1020-evaluation-kit:MIMXRT1020-EVK)
 - [MIMX RT1060 Evaluation Kit](https://www.nxp.com/design/development-boards/i.mx-evaluation-and-development-boards/mimxrt1060-evk-i.mx-rt1060-evaluation-kit:MIMXRT1060-EVK)
+
+## Linux hidraw access
+
+Linux requires setting permissions for accessing hidraw devices.  This is done by adding udev rules.  Follow these instructions to add permission.
+
+1. Create file named `50-nxp.rules` with these contents:
+  ```
+  KERNEL=="hidraw*", ATTRS{idVendor}=="1fc9", MODE="0666"
+  ```
+2. Copy `50-nxp.rules` to `/etc/udev/rules.d/50-nxp.rules`
+3. Reload the rules:
+  ```
+  sudo udevadm control --reload-rules
+  sudo udevadm trigger
+  ```

--- a/ports/mimxrt10xx/README.md
+++ b/ports/mimxrt10xx/README.md
@@ -19,9 +19,14 @@ make BOARD=metro_m7_1011 flash-jlink-bin
 iMXRT has built-in BootROM that implements the Serial Download Protocol (SDP), which can be used to load & execute TinyUF2 to SRAM with `spdhost` tool via USB. You need to
 
 1. Instal the NXP SPSDK as described in the [SPSDK Installation Guide](https://spsdk.readthedocs.io/en/latest/usage/installation.html).  
+
     a. Be sure to activate the venv before running sdphost.
-    b. If you are running linux, make sure your user has permission for accessing `hidraw` (more details below)
+
+    b. If you are running linux, make sure your user has permission for
+    accessing `hidraw` (more details below)
+
 2. Power up your board with the Boot Mode switch set to `BOOT_MODE[1:0]=01` to enter Serial Download mode. Note: Serial Download mode also automatically run with blank flash, therefore you don't have to manual change it in your production run.
+
 3. Run `flash-sdp` make target which in turn uses the `sdphost` with correct address and arguments to load and execute TinyUF2. While running, TinyUF2 will program the external flash with its SRAM's image.
 
   ```
@@ -49,7 +54,9 @@ Linux requires setting permissions for accessing hidraw devices.  This is done b
   ```
   KERNEL=="hidraw*", ATTRS{idVendor}=="1fc9", MODE="0666"
   ```
+
 2. Copy `50-nxp.rules` to `/etc/udev/rules.d/50-nxp.rules`
+
 3. Reload the rules:
   ```
   sudo udevadm control --reload-rules

--- a/ports/mimxrt10xx/README.md
+++ b/ports/mimxrt10xx/README.md
@@ -18,10 +18,11 @@ make BOARD=metro_m7_1011 flash-jlink-bin
 
 iMXRT has built-in BootROM that implements the Serial Download Protocol (SDP), which can be used to load & execute TinyUF2 to SRAM with `spdhost` tool via USB. You need to
 
-1. Instal the NXP SPSDK as described in the [SPSDK Installation Guide](https://spsdk.readthedocs.io/en/latest/usage/installation.html).
-2. If you are running linux, make sure your user has permission for accessing `hidraw` (more details below)
-3. Power up your board with the Boot Mode switch set to `BOOT_MODE[1:0]=01` to enter Serial Download mode. Note: Serial Download mode also automatically run with blank flash, therefore you don't have to manual change it in your production run.
-4. Run `flash-sdp` make target which in turn uses the `sdphost` with correct address and arguments to load and execute TinyUF2. While running, TinyUF2 will program the external flash with its SRAM's image.
+1. Instal the NXP SPSDK as described in the [SPSDK Installation Guide](https://spsdk.readthedocs.io/en/latest/usage/installation.html).  
+    a. Be sure to activate the venv before running sdphost.
+    b. If you are running linux, make sure your user has permission for accessing `hidraw` (more details below)
+2. Power up your board with the Boot Mode switch set to `BOOT_MODE[1:0]=01` to enter Serial Download mode. Note: Serial Download mode also automatically run with blank flash, therefore you don't have to manual change it in your production run.
+3. Run `flash-sdp` make target which in turn uses the `sdphost` with correct address and arguments to load and execute TinyUF2. While running, TinyUF2 will program the external flash with its SRAM's image.
 
   ```
   make BOARD=imxrt1010_evk flash-sdp

--- a/ports/mimxrt10xx/sdphost/sdphost.md
+++ b/ports/mimxrt10xx/sdphost/sdphost.md
@@ -1,3 +1,3 @@
 # SDPHOST
 
-The local binaries of sdphost will be depricated in a future release in favor of the [spsdk utilities available through PyPI](https://pypi.org/project/spsdk/).  [Documentation for spsdk is provided online](https://spsdk.readthedocs.io/en/latest/index.html).
+The local binaries of sdphost will be depricated in a future release in favor of the [NXP SPSDK utilities available through PyPI](https://pypi.org/project/spsdk/).  [Documentation for the NXP SPSDK is provided online](https://spsdk.readthedocs.io/en/latest/index.html).

--- a/ports/mimxrt10xx/sdphost/sdphost.md
+++ b/ports/mimxrt10xx/sdphost/sdphost.md
@@ -1,0 +1,3 @@
+# SDPHOST
+
+The local binaries of sdphost will be depricated in a future release in favor of the [spsdk utilities available through PyPI](https://pypi.org/project/spsdk/).  [Documentation for spsdk is provided online](https://spsdk.readthedocs.io/en/latest/index.html).


### PR DESCRIPTION
This pull request removes the OS checking for sdphost and instructs the user to install the NXP SPSDK from PyPI.
The directory with with sdphost binaries has a note that it is being depricated and where to find SPSDK.
Most of the edits are in mimxrt10xx/README.md 
Let me know if anything is unclear.