### PR TITLE
Support sparkfun thing plus stm32

### DIFF
--- a/.github/workflows/build_arm.yml
+++ b/.github/workflows/build_arm.yml
@@ -36,6 +36,7 @@ jobs:
         - 'stm32f411ve_discovery'
         - 'stm32f411ce_blackpill'
         - 'stm32f401_blackpill'
+        - 'sparkfun_stm32_thing_plus'
 
     steps:
     - name: Setup Python

--- a/ports/stm32f4/boards/sparkfun_stm32_thing_plus/board.h
+++ b/ports/stm32f4/boards/sparkfun_stm32_thing_plus/board.h
@@ -1,0 +1,117 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Ha Thach for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef BOARD_H_
+#define BOARD_H_
+
+//--------------------------------------------------------------------+
+// Button
+//--------------------------------------------------------------------+
+
+//--------------------------------------------------------------------+
+// LED
+//--------------------------------------------------------------------+
+
+#define LED_PORT              GPIOC
+#define LED_PIN               GPIO_PIN_1
+#define LED_STATE_ON          1
+
+//--------------------------------------------------------------------+
+// Neopixel
+//--------------------------------------------------------------------+
+
+// Number of neopixels
+#define NEOPIXEL_NUMBER       0
+
+//--------------------------------------------------------------------+
+// Flash
+//--------------------------------------------------------------------+
+
+// Flash size of the board
+#define BOARD_FLASH_SIZE  (1024 * 1024)
+
+//--------------------------------------------------------------------+
+// USB UF2
+//--------------------------------------------------------------------+
+
+#define USB_VID           0x1B4F
+#define USB_PID           0x0028
+#define USB_MANUFACTURER  "SparkFun"
+#define USB_PRODUCT       "Thing Plus - STM32"
+
+#define UF2_PRODUCT_NAME  USB_MANUFACTURER " " USB_PRODUCT
+#define UF2_BOARD_ID      "STM32F405-ThingPlus-v1.0"
+#define UF2_VOLUME_LABEL  "THNG+32BOOT"
+#define UF2_INDEX_URL     "https://www.sparkfun.com/products/17712"
+
+//--------------------------------------------------------------------+
+// UART
+//--------------------------------------------------------------------+
+
+#define UART_DEV              USART3
+#define UART_CLOCK_ENABLE     __HAL_RCC_USART3_CLK_ENABLE
+#define UART_CLOCK_DISABLE    __HAL_RCC_USART3_CLK_DISABLE
+#define UART_GPIO_PORT        GPIOB
+#define UART_GPIO_AF          GPIO_AF7_USART3
+#define UART_TX_PIN           GPIO_PIN_10
+#define UART_RX_PIN           GPIO_PIN_11
+
+//--------------------------------------------------------------------+
+// RCC Clock
+//--------------------------------------------------------------------+
+static inline void clock_init(void)
+{
+  RCC_ClkInitTypeDef RCC_ClkInitStruct;
+  RCC_OscInitTypeDef RCC_OscInitStruct;
+
+  /* Enable Power Control clock */
+  __HAL_RCC_PWR_CLK_ENABLE();
+
+  /* The voltage scaling allows optimizing the power consumption when the device is
+     clocked below the maximum system frequency, to update the voltage scaling value
+     regarding system frequency refer to product datasheet.  */
+  __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);
+
+  /* Enable HSE Oscillator and activate PLL with HSE as source */
+  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE;
+  RCC_OscInitStruct.HSEState = RCC_HSE_ON;
+  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
+  RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;
+  RCC_OscInitStruct.PLL.PLLM = HSE_VALUE/1000000;
+  RCC_OscInitStruct.PLL.PLLN = 336;
+  RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV2;
+  RCC_OscInitStruct.PLL.PLLQ = 7;
+  HAL_RCC_OscConfig(&RCC_OscInitStruct);
+
+  /* Select PLL as system clock source and configure the HCLK, PCLK1 and PCLK2
+     clocks dividers */
+  RCC_ClkInitStruct.ClockType = (RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2);
+  RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
+  RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
+  RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV4;
+  RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV2;
+  HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_5);
+}
+
+#endif

--- a/ports/stm32f4/boards/sparkfun_stm32_thing_plus/board.h
+++ b/ports/stm32f4/boards/sparkfun_stm32_thing_plus/board.h
@@ -56,7 +56,7 @@
 //--------------------------------------------------------------------+
 
 #define USB_VID           0x1B4F
-#define USB_PID           0x0028
+#define USB_PID           0x002C
 #define USB_MANUFACTURER  "SparkFun"
 #define USB_PRODUCT       "Thing Plus - STM32"
 

--- a/ports/stm32f4/boards/sparkfun_stm32_thing_plus/board.mk
+++ b/ports/stm32f4/boards/sparkfun_stm32_thing_plus/board.mk
@@ -1,0 +1,12 @@
+CFLAGS += \
+  -DSTM32F405xx \
+  -DHSE_VALUE=12000000U
+
+SRC_S += \
+  $(ST_CMSIS)/Source/Templates/gcc/startup_stm32f405xx.s
+
+# For flash-jlink target
+JLINK_DEVICE = stm32f405rg
+
+flash: flash-dfu-util
+erase: erase-jlink


### PR DESCRIPTION
Hi,

Please consider accepting this MR which adds support for [SparkFun's Thing Plus STM32](https://www.sparkfun.com/products/17712) board. The USB VID and PID values were provided by SparkFun and are already in [CircuitPython](https://github.com/adafruit/circuitpython/blob/main/ports/stm/boards/sparkfun_stm32_thing_plus/mpconfigboard.mk)'s definition for this board.

Tested by using TinyUF2 to install CircuitPython 7.2.0 (alpha) to my own board.

Thanks!