### PR TITLE
Add hiibot iots2

### DIFF
--- a/ports/espressif/boards/hiibot_iots2/board.cmake
+++ b/ports/espressif/boards/hiibot_iots2/board.cmake
@@ -1,0 +1,2 @@
+# Apply board specific content here
+set(IDF_TARGET "esp32s2")

--- a/ports/espressif/boards/hiibot_iots2/board.h
+++ b/ports/espressif/boards/hiibot_iots2/board.h
@@ -1,0 +1,95 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#pragma once
+
+//--------------------------------------------------------------------+
+// Button
+//--------------------------------------------------------------------+
+
+// Enter UF2 mode if GPIO is pressed while 2nd stage bootloader indicator
+// is on e.g RGB = Purple. If it is GPIO0, user should not hold this while
+// reset since that will instead run the 1st stage ROM bootloader
+#define PIN_BUTTON_UF2       21
+
+//--------------------------------------------------------------------+
+// LED
+//--------------------------------------------------------------------+
+
+// GPIO connected to Neopixel data
+#define NEOPIXEL_PIN          16
+
+//#define NEOPIXEL_POWER_PIN    21
+//#define NEOPIXEL_POWER_STATE  1
+
+// Brightness percentage from 1 to 255
+#define NEOPIXEL_BRIGHTNESS   0x10
+
+// Number of neopixels
+#define NEOPIXEL_NUMBER       1
+
+// LED for indicator and writing flash
+// If not defined neopixel will be use for flash writing instead
+#define LED_PIN               37
+#define LED_STATE_ON          1
+
+//--------------------------------------------------------------------+
+// TFT Display ST7789
+//--------------------------------------------------------------------+
+// #undef  CONFIG_LCD_TYPE_AUTO
+/*
+#define CONFIG_LCD_TYPE_ST7789V
+
+#define DISPLAY_PIN_MISO    -1              //No MISO connected to display.
+#define DISPLAY_PIN_MOSI    33
+#define DISPLAY_PIN_SCK     34
+#define DISPLAY_PIN_CS      36
+#define DISPLAY_PIN_DC      35
+#define DISPLAY_PIN_RST     -1
+#define DISPLAY_PIN_BL      38
+#define DISPLAY_BL_ON       14
+#define PIN_POWER           14
+
+#define DISPLAY_BL_STATE    1  // GPIO state to enable back light
+#define DISPLAY_WIDTH       240
+#define DISPLAY_HEIGHT      135
+#define DISPLAY_MADCTL      (TFT_MADCTL_MX | TFT_MADCTL_RGB)
+#define DISPLAY_VSCSAD      0
+#define DISPLAY_COL_OFFSET  53
+#define DISPLAY_ROW_OFFSET  40
+
+#define DISPLAY_TITLE        "IOTS2"
+*/
+//--------------------------------------------------------------------+
+// USB UF2
+//--------------------------------------------------------------------+
+
+#define USB_VID           0x303A            // Espressif VID
+#define USB_PID           0x8111            // Espressif assigned PID
+#define USB_MANUFACTURER  "HIIBOT"
+#define USB_PRODUCT       "HiiBot IoTs2"
+
+#define UF2_PRODUCT_NAME  USB_MANUFACTURER " " USB_PRODUCT
+#define UF2_BOARD_ID      "HiiBoT-IoTs2"
+#define UF2_VOLUME_LABEL  "IOTS2BOOT"
+#define UF2_INDEX_URL     "https://www.tindie.com/products/bradchan/hiibot-iots2/"

--- a/ports/espressif/boards/hiibot_iots2/board.h
+++ b/ports/espressif/boards/hiibot_iots2/board.h
@@ -57,7 +57,7 @@
 // TFT Display ST7789
 //--------------------------------------------------------------------+
 // #undef  CONFIG_LCD_TYPE_AUTO
-/*
+
 #define CONFIG_LCD_TYPE_ST7789V
 
 #define DISPLAY_PIN_MISO    -1              //No MISO connected to display.
@@ -78,13 +78,13 @@
 #define DISPLAY_COL_OFFSET  53
 #define DISPLAY_ROW_OFFSET  40
 
-#define DISPLAY_TITLE        "IOTS2"
-*/
+#define DISPLAY_TITLE        "IoTS2"
+
 //--------------------------------------------------------------------+
 // USB UF2
 //--------------------------------------------------------------------+
 
-#define USB_VID           0x303A            // Espressif VID
+#define USB_VID           0x80E7            // Espressif VID
 #define USB_PID           0x8111            // Espressif assigned PID
 #define USB_MANUFACTURER  "HIIBOT"
 #define USB_PRODUCT       "HiiBot IoTs2"

--- a/ports/espressif/boards/hiibot_iots2/sdkconfig
+++ b/ports/espressif/boards/hiibot_iots2/sdkconfig
@@ -1,0 +1,7 @@
+# Board Specific Config
+
+# Partition Table
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-8MB.csv"
+
+# Serial flasher config
+CONFIG_ESPTOOLPY_FLASHSIZE_8MB=y

--- a/ports/espressif/components/lcd/lcd.c
+++ b/ports/espressif/components/lcd/lcd.c
@@ -238,14 +238,18 @@ esp_err_t lcd_init(spi_device_handle_t spi)
     cfg.pin_bit_mask = (1ull << DISPLAY_PIN_DC);
     gpio_config(&cfg);
 
+    #if DISPLAY_PIN_RST != -1
     cfg.pin_bit_mask = (1ull << DISPLAY_PIN_RST);
     gpio_config(&cfg);
+    #endif
 
     cfg.pin_bit_mask = (1ull << DISPLAY_PIN_BL);
     gpio_config(&cfg);
 
     gpio_set_direction(DISPLAY_PIN_DC, GPIO_MODE_OUTPUT);
+    #if DISPLAY_PIN_RST != -1
     gpio_set_direction(DISPLAY_PIN_RST, GPIO_MODE_OUTPUT);
+    #endif
     gpio_set_direction(DISPLAY_PIN_BL, GPIO_MODE_OUTPUT);
 
 #ifdef DISPLAY_PIN_POWER
@@ -255,10 +259,12 @@ esp_err_t lcd_init(spi_device_handle_t spi)
 #endif
 
     /*!<  Reset the display */
+    #if DISPLAY_PIN_RST != -1
     gpio_set_level(DISPLAY_PIN_RST, 0);
     vTaskDelay(100 / portTICK_RATE_MS);
     gpio_set_level(DISPLAY_PIN_RST, 1);
     vTaskDelay(100 / portTICK_RATE_MS);
+    #endif
 
     int lcd_type;
 


### PR DESCRIPTION
Adding the Hiibot IOTS2.
PID from Espressif.

The IOTS2 board does not have a reset pin for the screen, it's pulled up.
So I set it to `-1` and added `#if DISPLAY_PIN_RST != -1` where appropriate so it compiles.
Don't know if it's the right way to do it.