### PR TITLE
Add LilyGo TTGO T8 ESP32-S2-WROOM

### DIFF
--- a/.github/workflows/build_esp32.yml
+++ b/.github/workflows/build_esp32.yml
@@ -38,6 +38,7 @@ jobs:
         - 'gravitech_cucumberRIS_v1.1'
         - 'hexky_s2'
         - 'lilygo_ttgo_t8_s2_st7789'
+        - 'lilygo_ttgo_t8_s2_wroom'
         - 'lolin_s2_mini'
         - 'lolin_s2_pico'
         - 'microdev_micro_s2'

--- a/ports/espressif/README.md
+++ b/ports/espressif/README.md
@@ -11,6 +11,7 @@ Following boards are supported:
 - [Espressif Saola 1R (WROVER) and 1M (WROOM)](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-saola-1-v1.2.html)
 - [Gravitech Cucumber RIS ESP32-S2 w/Sensors ](https://www.gravitech.us/curisdebowis.html)
 - [LILYGO® TTGO T8 ESP32-S2 V1.1 ST7789 ](http://www.lilygo.cn/prod_view.aspx?TypeId=50033&Id=1321&FId=t3:50033:3)
+- [LILYGO® TTGO T8 ESP32-S2-WROOM](http://www.lilygo.cn/prod_view.aspx?TypeId=50063&Id=1320&FId=t3:50063:3)
 - [LOLIN Wemos® S2 Pico](https://www.wemos.cc/en/latest/s2/s2_pico.html)
 - [MicroDev microS2](https://github.com/microDev1/microS2/wiki)
 - [Morpheans MorphESP-240](https://github.com/ccadic/ESP32-S2-DevBoardTFT) or  [MorphESP CrowdSupply](https://www.crowdsupply.com/morpheans/morphesp-240)

--- a/ports/espressif/boards/lilygo_ttgo_t8_s2_wroom/board.cmake
+++ b/ports/espressif/boards/lilygo_ttgo_t8_s2_wroom/board.cmake
@@ -1,0 +1,2 @@
+# Apply board specific content here
+set(IDF_TARGET "esp32s2")

--- a/ports/espressif/boards/lilygo_ttgo_t8_s2_wroom/board.h
+++ b/ports/espressif/boards/lilygo_ttgo_t8_s2_wroom/board.h
@@ -1,0 +1,49 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Fabian Affolter <fabian@affolter-engineering.ch>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#pragma once
+
+//--------------------------------------------------------------------+
+// Button
+//--------------------------------------------------------------------+
+
+// Enter UF2 mode if GPIO is pressed while 2nd stage bootloader indicator
+// is on e.g RGB = Purple. If it is GPIO0, user should not hold this while
+// reset since that will instead run the 1st stage ROM bootloader
+#define PIN_BUTTON_UF2        0
+
+//--------------------------------------------------------------------+
+// USB UF2
+//--------------------------------------------------------------------+
+
+#define USB_VID           0x303A            // Espressif VID
+#define USB_PID           0x80EB            // Espressif assigned PID
+#define USB_MANUFACTURER  "LILYGO"
+#define USB_PRODUCT       "TTGO_T8_S2_WROOM"
+
+#define UF2_PRODUCT_NAME  USB_MANUFACTURER " " USB_PRODUCT
+#define UF2_BOARD_ID      "ESP32S2-TTGOS2-WROOM-v1.1"
+#define UF2_VOLUME_LABEL  "TTGOS2BOOT"
+#define UF2_INDEX_URL     "http://www.lilygo.cn/prod_view.aspx?TypeId=50063&Id=1320&FId=t3:50063:3"
+

--- a/ports/espressif/boards/lilygo_ttgo_t8_s2_wroom/sdkconfig
+++ b/ports/espressif/boards/lilygo_ttgo_t8_s2_wroom/sdkconfig
@@ -1,0 +1,7 @@
+# Board Specific Config
+
+# Partition Table
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-4MB.csv"
+
+# Serial flasher config
+CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y


### PR DESCRIPTION
Add [LilyGo TTGO T8 ESP32-S2-WROOM](http://www.lilygo.cn/prod_view.aspx?TypeId=50063&Id=1320&FId=t3:50063:3) which recently got CircuitPython support.

```bash
ESP-ROM:esp32s2-rc4-20191025
Build:Oct 25 2019
rst:0x1 (POWERON),boot:0x8 (SPI_FAST_FLASH_BOOT)
SPIWP:0xee
mode:DIO, clock div:1
load:0x3ffe6100,len:0x162c
load:0x4004c000,len:0xd94
load:0x40050000,len:0x2f04
entry 0x4004c258
I (21) boot: ESP-IDF v4.4-dev-3608-gbbe2a1bf34 2nd stage bootloader
I (21) boot: compile time 11:30:03
I (21) boot: chip revision: 0
I (25) qio_mode: Enabling default flash chip QIO
I (31) boot.esp32s2: SPI Speed      : 80MHz
I (36) boot.esp32s2: SPI Mode       : QIO
I (40) boot.esp32s2: SPI Flash Size : 4MB
I (45) boot: Enabling RNG early entropy source...
I (50) boot: Partition Table:
I (54) boot: ## Label            Usage          Type ST Offset   Length
I (61) boot:  0 nvs              WiFi data        01 02 00009000 00005000
I (69) boot:  1 otadata          OTA data         01 00 0000e000 00002000
I (76) boot:  2 ota_0            OTA app          00 10 00010000 00160000
I (84) boot:  3 ota_1            OTA app          00 11 00170000 00160000
I (91) boot:  4 uf2              factory app      00 00 002d0000 00040000
I (99) boot:  5 ffat             Unknown data     01 81 00310000 000f0000
I (106) boot: End of partition table
I (110) boot: Defaulting to factory image
I (115) esp_image: segment 0: paddr=002d0020 vaddr=3f000020 size=02e40h ( 11840) map
I (126) esp_image: segment 1: paddr=002d2e68 vaddr=3ffbb4d0 size=01240h (  4672) load
I (133) esp_image: segment 2: paddr=002d40b0 vaddr=40022000 size=094cch ( 38092) load
I (149) esp_image: segment 3: paddr=002dd584 vaddr=50000000 size=00010h (    16) load
I (149) esp_image: segment 4: paddr=002dd59c vaddr=00000000 size=02a7ch ( 10876) 
I (159) esp_image: segment 5: paddr=002e0020 vaddr=40080020 size=1001ch ( 65564) map
I (181) boot: Loaded app from partition at offset 0x2d0000
I (181) boot: Disabling RNG early entropy source...
I (193) c����fឆ~������֍�ѥ���cache       : size 8KB, 4Ways, cache line size 32Byte
I (194) cpu_start: Pro cpu up.
I (207) cpu_start: Pro cpu start user code
I (207) cpu_start: cpu freq: 160000000
I (207) cpu_start: Application information:
I (212) cpu_start: Project name:     tinyuf2
I (217) cpu_start: App version:      0.8.0-47-g2104d6f-dirty
I (223) cpu_start: Compile time:     Mar 21 2022 11:30:18
I (229) cpu_start: ELF file SHA256:  e239115a7f9f2ee6...
I (235) cpu_start: ESP-IDF:          v4.4-dev-3608-gbbe2a1bf34
I (242) heap_init: Initializing. RAM available for dynamic allocation:
I (249) heap_init: At 3FF9E000 len 00002000 (8 KiB): RTCRAM
I (255) heap_init: At 3FFCFC30 len 0002C3D0 (176 KiB): DRAM
I (261) heap_init: At 3FFFC000 len 00003A10 (14 KiB): DRAM
I (268) spi_flash: detected chip: generic
                                         I (272) spi_flash: flash io: qio
                                                                         I (276) cpu_start: Starting scheduler on PRO CPU.
```