### PR TITLE
[STM32F4] Allow user defined amount of Neopixels as status indicator

### DIFF
--- a/ports/stm32f4/boards/feather_stm32f405_express/board.h
+++ b/ports/stm32f4/boards/feather_stm32f405_express/board.h
@@ -46,6 +46,7 @@
 
 #define NEOPIXEL_PORT         GPIOC
 #define NEOPIXEL_PIN          GPIO_PIN_0
+#define NEOPIXEL_PIN_MODE     GPIO_MODE_OUTPUT_PP
 
 //--------------------------------------------------------------------+
 // Flash

--- a/ports/stm32f4/boards/sparkfun_stm32_thing_plus/board.h
+++ b/ports/stm32f4/boards/sparkfun_stm32_thing_plus/board.h
@@ -43,6 +43,9 @@
 
 // Number of neopixels
 #define NEOPIXEL_NUMBER       0
+#define NEOPIXEL_PORT         GPIOC
+#define NEOPIXEL_PIN          GPIO_PIN_0
+#define NEOPIXEL_PIN_MODE     GPIO_MODE_OUTPUT_PP
 
 //--------------------------------------------------------------------+
 // Flash

--- a/ports/stm32f4/boards/stm32f401_blackpill/board.h
+++ b/ports/stm32f4/boards/stm32f401_blackpill/board.h
@@ -39,13 +39,12 @@
 
 //// Number of neopixels
 #define NEOPIXEL_NUMBER       0
+// Brightness percentage from 1 to 255
+#define NEOPIXEL_BRIGHTNESS   0x10
 
-//#define NEOPIXEL_PORT         GPIOC
-//#define NEOPIXEL_PIN          GPIO_PIN_0
-//
-//// Brightness percentage from 1 to 255
-//#define NEOPIXEL_BRIGHTNESS   0x10
-
+#define NEOPIXEL_PORT         GPIOC
+#define NEOPIXEL_PIN          GPIO_PIN_0
+#define NEOPIXEL_PIN_MODE     GPIO_MODE_OUTPUT_PP
 
 //--------------------------------------------------------------------+
 // Flash

--- a/ports/stm32f4/boards/stm32f411ce_blackpill/board.h
+++ b/ports/stm32f4/boards/stm32f411ce_blackpill/board.h
@@ -37,15 +37,14 @@
 // Neopixel
 //--------------------------------------------------------------------+
 
-//// Number of neopixels
+// Number of neopixels
 #define NEOPIXEL_NUMBER       0
+// Brightness percentage from 1 to 255
+#define NEOPIXEL_BRIGHTNESS   0x10
 
-//#define NEOPIXEL_PORT         GPIOC
-//#define NEOPIXEL_PIN          GPIO_PIN_0
-//
-//// Brightness percentage from 1 to 255
-//#define NEOPIXEL_BRIGHTNESS   0x10
-
+#define NEOPIXEL_PORT         GPIOC
+#define NEOPIXEL_PIN          GPIO_PIN_0
+#define NEOPIXEL_PIN_MODE     GPIO_MODE_OUTPUT_PP
 
 //--------------------------------------------------------------------+
 // Flash

--- a/ports/stm32f4/boards/stm32f411ve_discovery/board.h
+++ b/ports/stm32f4/boards/stm32f411ve_discovery/board.h
@@ -37,15 +37,14 @@
 // Neopixel
 //--------------------------------------------------------------------+
 
-//// Number of neopixels
+// Number of neopixels
 #define NEOPIXEL_NUMBER       0
+// Brightness percentage from 1 to 255
+#define NEOPIXEL_BRIGHTNESS   0x10
 
-//#define NEOPIXEL_PORT         GPIOC
-//#define NEOPIXEL_PIN          GPIO_PIN_0
-//
-//// Brightness percentage from 1 to 255
-//#define NEOPIXEL_BRIGHTNESS   0x10
-
+#define NEOPIXEL_PORT         GPIOC
+#define NEOPIXEL_PIN          GPIO_PIN_0
+#define NEOPIXEL_PIN_MODE     GPIO_MODE_OUTPUT_PP
 
 //--------------------------------------------------------------------+
 // Flash


### PR DESCRIPTION
...by defining NEOPIXEL_ NUMBER which now acts on values bigger than 1. Furthermore users can define a custom pin mode for the output pin, e.g. open-drain for applications where an pull-up resistor is used as a 3.3V to 5V logic level shifter.

This feature is handy for e.g. stm32f4 keyboards that have long external sk6812/ws2812 chains which can be used together with tinyuf2.