### PR TITLE
Allow for a custom application start vector on stm32 boards

### DIFF
--- a/ports/stm32f3/boards.h
+++ b/ports/stm32f3/boards.h
@@ -35,7 +35,9 @@
 #include "board.h"
 
 // Flash Start Address of Application
+#ifndef BOARD_FLASH_APP_START
 #define BOARD_FLASH_APP_START   0x08004000
+#endif
 #define BOARD_RAM_START 0x20000000
 #define BOARD_RAM_SIZE 0x9FFF
 

--- a/ports/stm32f4/boards.h
+++ b/ports/stm32f4/boards.h
@@ -35,7 +35,9 @@
 #include "board.h"
 
 // Flash Start Address of Application
+#ifndef BOARD_FLASH_APP_START
 #define BOARD_FLASH_APP_START   0x08010000
+#endif
 
 // Double Reset tap to enter DFU
 #define TINYUF2_DFU_DOUBLE_TAP  1


### PR DESCRIPTION
With this PR we can set a custom application start in "board.h":
`#define BOARD_FLASH_APP_START 0x08020000`

The default start vectors are still 0x08004000 on stm32f3 and 0x08010000 on stm32f4.
Other common start vectors on stm32f4 are 0x08008000 and 0x08020000.

A script or makefile of another project can set the app start like that:
`CFLAGS="-DBOARD_FLASH_APP_START=0x08004000" make -C <path-to-tinyuf2> BOARD=... BOARD_DIR= ... all`

This works fine, but is not overly obvious. I agree to abandon the idea of a shorter name "APP_START" in my PR #162. But I would prefer to set the app start using `make ... BOARD_FLASH_APP_START=0x08004000 all`. However this requires some changes to tinyuf2 makefiles.