### PR TITLE
Log warning if UF2 block skipped due to mismatching family IDs

### DIFF
--- a/ports/test_ghostfat/Makefile
+++ b/ports/test_ghostfat/Makefile
@@ -26,6 +26,10 @@ SRC_C += \
 
 SRC_S +=
 
+# Note: TinyUSB is only used for logging
+TINYUSB_DIR = $(TOP)/lib/tinyusb/src
+INC += $(TINYUSB_DIR)
+
 # Port include
 INC += \
   $(TOP)/src \

--- a/ports/test_ghostfat/tusb_config.h
+++ b/ports/test_ghostfat/tusb_config.h
@@ -1,0 +1,89 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ha Thach (tinyusb.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+#ifndef _TUSB_CONFIG_H_
+#define _TUSB_CONFIG_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//--------------------------------------------------------------------
+// COMMON CONFIGURATION
+//--------------------------------------------------------------------
+
+#define CFG_TUSB_MSU               OPT_MCU_NONE
+
+#define CFG_TUSB_RHPORT0_MODE      OPT_MODE_DEVICE
+#define CFG_TUSB_OS                OPT_OS_NONE
+
+// can be defined by compiler in DEBUG build
+#ifndef CFG_TUSB_DEBUG
+  #define CFG_TUSB_DEBUG           0
+#endif
+
+/* USB DMA on some MCUs can only access a specific SRAM region with restriction on alignment.
+ * Tinyusb use follows macros to declare transferring memory so that they can be put
+ * into those specific section.
+ * e.g
+ * - CFG_TUSB_MEM SECTION : __attribute__ (( section(".usb_ram") ))
+ * - CFG_TUSB_MEM_ALIGN   : __attribute__ ((aligned(4)))
+ */
+#ifndef CFG_TUSB_MEM_SECTION
+#define CFG_TUSB_MEM_SECTION
+#endif
+
+#ifndef CFG_TUSB_MEM_ALIGN
+#define CFG_TUSB_MEM_ALIGN          __attribute__ ((aligned(4)))
+#endif
+
+//--------------------------------------------------------------------
+// DEVICE CONFIGURATION
+//--------------------------------------------------------------------
+
+#ifndef CFG_TUD_ENDPOINT0_SIZE
+#define CFG_TUD_ENDPOINT0_SIZE    64
+#endif
+
+//------------- CLASS -------------//
+#define CFG_TUD_CDC              0
+#define CFG_TUD_MSC              1
+#define CFG_TUD_HID              1
+#define CFG_TUD_MIDI             0
+#define CFG_TUD_VENDOR           0
+
+// MSC Buffer size of Device Mass storage
+#define CFG_TUD_MSC_BUFSIZE      4096
+
+// HID buffer size Should be sufficient to hold ID (if any) + Data
+#define CFG_TUD_HID_BUFSIZE      64
+
+#define CFG_TUD_VENDOR_RX_BUFSIZE 0
+#define CFG_TUD_VENDOR_TX_BUFSIZE 0
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _TUSB_CONFIG_H_ */

--- a/src/ghostfat.c
+++ b/src/ghostfat.c
@@ -33,6 +33,7 @@
 #include "board_api.h"
 #include "uf2.h"
 
+#include "tusb.h" // for logging
 
 
 //--------------------------------------------------------------------+
@@ -498,6 +499,8 @@ int uf2_write_block (uint32_t block_no, uint8_t *data, WriteState *state)
     board_flash_write(bl->targetAddr, bl->data, bl->payloadSize);
   }else
   {
+    TU_LOG1("WARNING: Skipping UF2 block due to mismatch between block's family ID and expected - 0x%08lX vs 0x%08X\r\n", bl->familyID, BOARD_UF2_FAMILY_ID);
+
     // TODO family matches VID/PID
     return -1;
   }


### PR DESCRIPTION
This pull-request outputs a warning when a UF2 block is skipped due to mismatching UF2 family IDs. I found this  useful when debugging an issue on my STM32F405 board.

If you believe this needs a discussion first or should be part of a larger logging effort then please feel free to reject it :grin: 