### PR TITLE
Add waveshare ESP32-S2-Pico-LCD

### DIFF
--- a/.github/workflows/build_esp32.yml
+++ b/.github/workflows/build_esp32.yml
@@ -57,6 +57,7 @@ jobs:
         - 'unexpectedmaker_feathers2'
         - 'unexpectedmaker_feathers2_neo'
         - 'unexpectedmaker_tinys2'
+        - 'waveshare_esp32_s2_pico_lcd'
         - 'waveshare_esp32s2_pico'
         # ----------------------
         # S3 Alphabetical order

--- a/ports/espressif/boards/waveshare_esp32_s2_pico_lcd/board.cmake
+++ b/ports/espressif/boards/waveshare_esp32_s2_pico_lcd/board.cmake
@@ -1,0 +1,2 @@
+# Apply board specific content here
+set(IDF_TARGET "esp32s2")

--- a/ports/espressif/boards/waveshare_esp32_s2_pico_lcd/board.h
+++ b/ports/espressif/boards/waveshare_esp32_s2_pico_lcd/board.h
@@ -1,0 +1,56 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef WAVESHARE_ESP32_S2_PICO_LCD_
+#define WAVESHARE_ESP32_S2_PICO_LCD_
+
+//--------------------------------------------------------------------+
+// Button
+//--------------------------------------------------------------------+
+
+#define PIN_BUTTON_UF2        0
+
+//--------------------------------------------------------------------+
+// LED
+//--------------------------------------------------------------------+
+
+
+// #define LED_PIN               9
+// #define LED_STATE_ON          0
+
+//--------------------------------------------------------------------+
+// USB UF2
+//--------------------------------------------------------------------+
+
+#define USB_VID           0x303a
+#define USB_PID           0x810b
+#define USB_MANUFACTURER  "Waveshare Electronics"
+#define USB_PRODUCT       "ESP32-S2-Pico-LCD"
+
+#define UF2_PRODUCT_NAME  USB_MANUFACTURER " " USB_PRODUCT
+#define UF2_BOARD_ID      "ESP32-S2-Pico-LCD"
+#define UF2_VOLUME_LABEL  "ESP32S2PICOLCD"
+#define UF2_INDEX_URL     "http://www.waveshare.com/wiki/ESP32-S2-Pico"
+
+#endif

--- a/ports/espressif/boards/waveshare_esp32_s2_pico_lcd/board.h
+++ b/ports/espressif/boards/waveshare_esp32_s2_pico_lcd/board.h
@@ -50,7 +50,7 @@
 
 #define UF2_PRODUCT_NAME  USB_MANUFACTURER " " USB_PRODUCT
 #define UF2_BOARD_ID      "ESP32-S2-Pico-LCD"
-#define UF2_VOLUME_LABEL  "ESP32S2PICOLCD"
+#define UF2_VOLUME_LABEL  "ESP32S2PICO"
 #define UF2_INDEX_URL     "http://www.waveshare.com/wiki/ESP32-S2-Pico"
 
 #endif

--- a/ports/espressif/boards/waveshare_esp32_s2_pico_lcd/sdkconfig
+++ b/ports/espressif/boards/waveshare_esp32_s2_pico_lcd/sdkconfig
@@ -1,0 +1,7 @@
+# Board Specific Config
+
+# Partition Table
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-4MB.csv"
+
+# Serial flasher config
+CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y


### PR DESCRIPTION
Adds support for the Waveshare ESP32-S2-Pico-LCD Board with USB PID from Espressif: [Espressif USB customer-allocated PID repository](https://github.com/espressif/usb-pids/blob/b39d288d4821bedfb589b7ec3cc8a3e2779e6237/allocated-pids.txt#L275)