### PR TITLE
Espressif port: allow to override UF2_DETECTION_DELAY_MS in a board-specific code.

### DIFF
--- a/ports/espressif/components/bootloader/subproject/main/bootloader_start.c
+++ b/ports/espressif/components/bootloader/subproject/main/bootloader_start.c
@@ -44,8 +44,10 @@
 // Reset Reason Hint to enter UF2. Check out esp_reset_reason_t for other Espressif pre-defined values
 #define APP_REQUEST_UF2_RESET_HINT   0x11F2
 
-// Initial delay in milliseconds to detect user interaction to enter UF2.
-#define UF2_DETECTION_DELAY_MS       500
+#ifndef UF2_DETECTION_DELAY_MS
+  // Initial delay in milliseconds to detect user interaction to enter UF2.
+  #define UF2_DETECTION_DELAY_MS       500
+#endif
 
 uint8_t const RGB_DOUBLE_TAP[] = { 0x80, 0x00, 0xff }; // Purple
 uint8_t const RGB_OFF[]        = { 0x00, 0x00, 0x00 };


### PR DESCRIPTION
## Checklist

*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

- [x] Please provide specific title of the PR describing the change
- [ ] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
- [ ] If you are adding an new boards, please make sure
  - [ ] Provide link to your allocated VID/PID if applicable
  - [ ] Add your board to [action ci](/.github/workflows) in correct workflow and alphabet order for release binary
  - [ ] `UF2_BOARD_ID` in your board.h follow correct format from [uf2 specs](https://github.com/microsoft/uf2#files-exposed-by-bootloaders)

*This entire checklist section above can be deleted if all items are checked.*

-----------

## Description of Change

It is currently only 500 milliseconds given for a user to release RESET then press user defined UF2 button to enter into bootloader mode. No doubts that It is actually a very tight time interval.
This behavior is hardwired into bootloader code. It would be nice if this delay could be overridden by a value specified in BSP code. 
