### PR TITLE
switch ci docker image to v4.4.3

### DIFF
--- a/.github/workflows/build_esp32.yml
+++ b/.github/workflows/build_esp32.yml
@@ -99,7 +99,7 @@ jobs:
       run: echo BIN_PATH=ports/espressif/_bin/${{ matrix.board }} >> $GITHUB_ENV
 
     - name: Build
-      run: docker run --rm -v $PWD:/project -w /project espressif/idf:release-v4.4  /bin/bash -c "git config --global --add safe.directory /project && make -C ports/espressif/ BOARD=${{ matrix.board }} all self-update copy-artifact"
+      run: docker run --rm -v $PWD:/project -w /project espressif/idf:v4.4.3 /bin/bash -c "git config --global --add safe.directory /project && make -C ports/espressif/ BOARD=${{ matrix.board }} all self-update copy-artifact"
 
     - uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
## Description of Change

latest idf release v4.4 has issue generating image that couldn't enumerate on some specific S3 boards. It is probably an bug within IDF. This PR switch docker image from `release-v4.4` to `v4.4.3` as walkaround to fix #268
