### PR TITLE
Fix stm32f3 application jump

### DIFF
--- a/ports/stm32f3/boards.c
+++ b/ports/stm32f3/boards.c
@@ -173,6 +173,16 @@ void board_app_jump(void)
   HAL_RCC_DeInit();
   HAL_DeInit();
 
+  SysTick->CTRL = 0;
+  SysTick->LOAD = 0;
+  SysTick->VAL = 0;
+
+  // Disable all Interrupts
+  NVIC->ICER[0] = 0xFFFFFFFF;
+  NVIC->ICER[1] = 0xFFFFFFFF;
+  NVIC->ICER[2] = 0xFFFFFFFF;
+  NVIC->ICER[3] = 0xFFFFFFFF;
+
   // TODO protect bootloader region
 
   volatile uint32_t const * app_vector = (volatile uint32_t const*) BOARD_FLASH_APP_START;


### PR DESCRIPTION
## Checklist

*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

- [x] Please provide specific title of the PR describing the change
- [ ] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
- [ ] If you are adding an new boards, please make sure
  - [ ] Provide link to your allocated VID/PID if applicable
  - [ ] Add your board to [action ci](/.github/workflows) in correct workflow and alphabet order for release binary
  - [ ] `UF2_BOARD_ID` in your board.h follow correct format from [uf2 specs](https://github.com/microsoft/uf2#files-exposed-by-bootloaders)

*This checklist items that are not applicable to your PR can be deleted.*

-----------

## Description of Change

Was required for running `qmk_firmware` on top of the bootloader. Without this change it just produced:
```
[142696.720934] usb usb3-port2: attempt power cycle
[142697.190853] usb 3-2: new full-speed USB device number 117 using xhci_hcd
[142697.191129] usb 3-2: Device not responding to setup address.
[142697.397654] usb 3-2: Device not responding to setup address.
[142697.604181] usb 3-2: device not accepting address 117, error -71
[142697.727445] usb 3-2: new full-speed USB device number 118 using xhci_hcd
[142697.727746] usb 3-2: Device not responding to setup address.
[142697.934453] usb 3-2: Device not responding to setup address.
[142698.140727] usb 3-2: device not accepting address 118, error -71
[142698.140962] usb usb3-port2: unable to enumerate USB device
[142698.450804] usb 3-2: new full-speed USB device number 119 using xhci_hcd
[142698.640845] usb 3-2: device descriptor read/64, error -71
[142698.937660] usb 3-2: device descriptor read/64, error -71
[142699.234117] usb 3-2: new full-speed USB device number 120 using xhci_hcd
[142699.424292] usb 3-2: device descriptor read/64, error -71
[142699.657638] usb 3-2: device descriptor read/64, error -71
[142699.764223] usb usb3-port2: attempt power cycle
```

Code was borrowed from the f4 port.