### PR TITLE
Update ESP32 GitHub Actions to upload to Amazon S3

### DIFF
--- a/.github/workflows/build_esp32.yml
+++ b/.github/workflows/build_esp32.yml
@@ -119,3 +119,12 @@ jobs:
         files: |
           tinyuf2-${{ matrix.board }}-*.zip
           update-tinyuf2-${{ matrix.board }}-*.uf2
+
+    - name: Upload Assets To AWS S3
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      if: ${{ github.event_name == 'release' }}
+      run: |
+        [ -z \"$AWS_ACCESS_KEY_ID\" ] || aws s3 cp tinyuf2-${{ matrix.board }}-*.zip s3://adafruit-circuit-python/bootloaders/esp32 --no-progress --region us-east-1
+        [ -z \"$AWS_ACCESS_KEY_ID\" ] || aws s3 cp update-tinyuf2-${{ matrix.board }}-*.uf2 s3://adafruit-circuit-python/bootloaders/esp32 --no-progress --region us-east-1


### PR DESCRIPTION
-----------

## Description of Change

This modifies the GitHub actions so that release files are uploaded to Amazon S3. I was unable to test this in my own repo. I already set up the AWS secrets, so this should work. I'll do a release to test after this is merged.

If the test works, then #277 should be done.
