### PR TITLE
Teensy 4.0 and 4.1 support

### DIFF
--- a/.github/workflows/build_arm.yml
+++ b/.github/workflows/build_arm.yml
@@ -40,6 +40,9 @@ jobs:
         - 'sparkfun_stm32_thing_plus'
         # stm32l4
         - 'swan_r5'
+        # Teensy 4.0/4.1
+        - 'teensy40'
+        - 'teensy41'
         
     steps:
     - name: Setup Python

--- a/.github/workflows/build_arm.yml
+++ b/.github/workflows/build_arm.yml
@@ -19,30 +19,33 @@ jobs:
       fail-fast: false
       matrix:
         board:
-        # Alphabetical order
+        # Alphabetical order by family
         # lpc55
         - 'double_m33_express'
         - 'lpcxpresso55s28'
         - 'lpcxpresso55s69'
+
         # mimxrt10xx
         - 'imxrt1010_evk'
         - 'imxrt1020_evk'
         - 'imxrt1024_evk'
         - 'imxrt1060_evk'
         - 'metro_m7_1011'
+        - 'teensy40'
+        - 'teensy41'
+
         # stm32f3
         - 'stm32f303disco'
+
         # stm32f4
         - 'feather_stm32f405_express'
         - 'stm32f411ve_discovery'
         - 'stm32f411ce_blackpill'
         - 'stm32f401_blackpill'
         - 'sparkfun_stm32_thing_plus'
+
         # stm32l4
         - 'swan_r5'
-        # Teensy 4.0/4.1
-        - 'teensy40'
-        - 'teensy41'
         
     steps:
     - name: Setup Python

--- a/ports/mimxrt10xx/Makefile
+++ b/ports/mimxrt10xx/Makefile
@@ -62,6 +62,10 @@ DBL_TAP_REG_ADDR = 0x400D410C
 SDP_WRITE_ADDR := $(shell sed -n 's/_fcfb_origin.*\(0x.*\);/\1/p' $(TOP)/$(PORT_DIR)/linker/$(MCU)_ram.ld)
 SDP_JUMP_ADDR := $(shell sed -n 's/_ivt_origin.*\(0x.*\);/\1/p' $(TOP)/$(PORT_DIR)/linker/$(MCU)_ram.ld)
 
+$(BUILD)/$(OUTNAME).hex: $(BUILD)/$(OUTNAME).elf
+	@echo CREATE $@
+	@$(OBJCOPY) -O ihex --change-addresses $(UF2_$(MCU)_WRITE_ADDR) $^ $@
+
 # SDPHOST is a variable if you need to change the path
 SDPHOST = sdphost
 

--- a/ports/mimxrt10xx/README.md
+++ b/ports/mimxrt10xx/README.md
@@ -49,8 +49,8 @@ Double tap to enter bootloader mode, then simply drag & drop `update-tinyuf2_BOA
 - [MIMX RT1010 Evaluation Kit](https://www.nxp.com/design/development-boards/i.mx-evaluation-and-development-boards/i.mx-rt1010-evaluation-kit:MIMXRT1010-EVK)
 - [MIMX RT1020 Evaluation Kit](https://www.nxp.com/design/development-boards/i.mx-evaluation-and-development-boards/i.mx-rt1020-evaluation-kit:MIMXRT1020-EVK)
 - [MIMX RT1060 Evaluation Kit](https://www.nxp.com/design/development-boards/i.mx-evaluation-and-development-boards/mimxrt1060-evk-i.mx-rt1060-evaluation-kit:MIMXRT1060-EVK)
-- [Teensy 4.0](boards/teensy40)
-- [Teensy 4.1](boards/teensy41)
+- [Teensy 4.0](https://www.pjrc.com/store/teensy40.html)
+- [Teensy 4.1](https://www.pjrc.com/store/teensy41.html)
 
 
 ## Linux hidraw access

--- a/ports/mimxrt10xx/README.md
+++ b/ports/mimxrt10xx/README.md
@@ -49,6 +49,9 @@ Double tap to enter bootloader mode, then simply drag & drop `update-tinyuf2_BOA
 - [MIMX RT1010 Evaluation Kit](https://www.nxp.com/design/development-boards/i.mx-evaluation-and-development-boards/i.mx-rt1010-evaluation-kit:MIMXRT1010-EVK)
 - [MIMX RT1020 Evaluation Kit](https://www.nxp.com/design/development-boards/i.mx-evaluation-and-development-boards/i.mx-rt1020-evaluation-kit:MIMXRT1020-EVK)
 - [MIMX RT1060 Evaluation Kit](https://www.nxp.com/design/development-boards/i.mx-evaluation-and-development-boards/mimxrt1060-evk-i.mx-rt1060-evaluation-kit:MIMXRT1060-EVK)
+- [Teensy 4.0](boards/teensy40)
+- [Teensy 4.1](boards/teensy41)
+
 
 ## Linux hidraw access
 

--- a/ports/mimxrt10xx/boards.c
+++ b/ports/mimxrt10xx/boards.c
@@ -95,6 +95,7 @@ void board_teardown(void)
 
 void board_usb_init(void)
 {
+#if TUD_OPT_RHPORT == 0
   // Clock
   CLOCK_EnableUsbhs0PhyPllClock(kCLOCK_Usbphy480M, 480000000U);
   CLOCK_EnableUsbhs0Clock(kCLOCK_Usb480M, 480000000U);
@@ -103,6 +104,15 @@ void board_usb_init(void)
   USBPHY_Type* usb_phy = USBPHY1;
 #else
   USBPHY_Type* usb_phy = USBPHY;
+#endif
+
+#elif TUD_OPT_RHPORT == 1
+  // USB1
+  CLOCK_EnableUsbhs1PhyPllClock(kCLOCK_Usbphy480M, 480000000U);
+  CLOCK_EnableUsbhs1Clock(kCLOCK_Usb480M, 480000000U);
+  USBPHY_Type* usb_phy = USBPHY2;
+#else
+#  error
 #endif
 
   // Enable PHY support for Low speed device + LS via FS Hub
@@ -116,10 +126,6 @@ void board_usb_init(void)
   phytx &= ~(USBPHY_TX_D_CAL_MASK | USBPHY_TX_TXCAL45DM_MASK | USBPHY_TX_TXCAL45DP_MASK);
   phytx |= USBPHY_TX_D_CAL(0x0C) | USBPHY_TX_TXCAL45DP(0x06) | USBPHY_TX_TXCAL45DM(0x06);
   usb_phy->TX = phytx;
-
-  // USB1
-//  CLOCK_EnableUsbhs1PhyPllClock(kCLOCK_Usbphy480M, 480000000U);
-//  CLOCK_EnableUsbhs1Clock(kCLOCK_Usb480M, 480000000U);
 }
 
 void board_dfu_init(void)

--- a/ports/mimxrt10xx/boards.c
+++ b/ports/mimxrt10xx/boards.c
@@ -95,7 +95,7 @@ void board_teardown(void)
 
 void board_usb_init(void)
 {
-#if TUD_OPT_RHPORT == 0
+#if BOARD_TUD_RHPORT == 0
   // Clock
   CLOCK_EnableUsbhs0PhyPllClock(kCLOCK_Usbphy480M, 480000000U);
   CLOCK_EnableUsbhs0Clock(kCLOCK_Usb480M, 480000000U);
@@ -106,7 +106,7 @@ void board_usb_init(void)
   USBPHY_Type* usb_phy = USBPHY;
 #endif
 
-#elif TUD_OPT_RHPORT == 1
+#elif BOARD_TUD_RHPORT == 1
   // USB1
   CLOCK_EnableUsbhs1PhyPllClock(kCLOCK_Usbphy480M, 480000000U);
   CLOCK_EnableUsbhs1Clock(kCLOCK_Usb480M, 480000000U);

--- a/ports/mimxrt10xx/boards.c
+++ b/ports/mimxrt10xx/boards.c
@@ -95,24 +95,24 @@ void board_teardown(void)
 
 void board_usb_init(void)
 {
+  USBPHY_Type* usb_phy;
+
 #if BOARD_TUD_RHPORT == 0
   // Clock
   CLOCK_EnableUsbhs0PhyPllClock(kCLOCK_Usbphy480M, 480000000U);
   CLOCK_EnableUsbhs0Clock(kCLOCK_Usb480M, 480000000U);
 
-#ifdef USBPHY1
-  USBPHY_Type* usb_phy = USBPHY1;
-#else
-  USBPHY_Type* usb_phy = USBPHY;
-#endif
+  #ifdef USBPHY1
+  usb_phy = USBPHY1;
+  #else
+  usb_phy = USBPHY;
+  #endif
 
 #elif BOARD_TUD_RHPORT == 1
   // USB1
   CLOCK_EnableUsbhs1PhyPllClock(kCLOCK_Usbphy480M, 480000000U);
   CLOCK_EnableUsbhs1Clock(kCLOCK_Usb480M, 480000000U);
-  USBPHY_Type* usb_phy = USBPHY2;
-#else
-#  error
+  usb_phy = USBPHY2;
 #endif
 
   // Enable PHY support for Low speed device + LS via FS Hub

--- a/ports/mimxrt10xx/boards/teensy40/README.md
+++ b/ports/mimxrt10xx/boards/teensy40/README.md
@@ -1,0 +1,23 @@
+# Teensy 4.0 support
+
+The [Teensy](https://www.pjrc.com/store/teensy40.html) is based on a MIMXRT1062, so is very similar to the imxrt1060_evk.
+
+## Why tinyuf2 for the Teensy?
+
+1. The primary purpose is if you want to use the OTG2 as the main USB interface to the teensy, instead of the built-in micro-USB connector (OTG1).  The teensy built-in bootloader does not operated with the secondary USB port.  For the Teensy 4.0 board, this isn't possible.
+2. You're running non-arduino code and want to emulate other 1060 boards.
+
+
+## Flashing
+Initial flashing to load tinyUF2 must be done via the teensy CLI, or the teensy loader.  It must be done via the built-in micro USB connector.
+
+1. Ensure that you *do* have the `teensy_loader_cli` program installed.  It's available [here](https://www.pjrc.com/teensy/loader_cli.html).
+1. Connect a micro-USB cable directly to the teensy (as opposed to any secondary USB connector you might have on a daughter board)
+1. press the teensy flash button.  Make sure that the teensy GUI does *NOT* come up.  The little red light adjacent to the USB connector should be on.
+1. Flash the board:
+```make BOARD=teensy40 flash```
+
+At this point, the board should be flashed, the red light adjacent to the micro USB connector should be off, and the orange light next to the teensy button should be flashing intermittently.  There should also be a new disk that appears called TEENSY40BT.
+
+## Building and flashing for the secondary USB port
+This is not a valid configuration for the teensy 4.0 board because the second USB port isn't brought out to pads.

--- a/ports/mimxrt10xx/boards/teensy40/board.h
+++ b/ports/mimxrt10xx/boards/teensy40/board.h
@@ -1,0 +1,82 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Ha Thach for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+
+#ifndef BOARD_H_
+#define BOARD_H_
+
+// Size of on-board external flash
+#define BOARD_FLASH_SIZE      (2*1024*1024)
+
+//--------------------------------------------------------------------+
+// LED
+//--------------------------------------------------------------------+
+
+#define LED_PINMUX            IOMUXC_GPIO_B0_03_GPIO2_IO03
+#define LED_PORT              GPIO2
+#define LED_PIN               3
+#define LED_STATE_ON          0
+
+//--------------------------------------------------------------------+
+// Neopixel
+//--------------------------------------------------------------------+
+
+// Number of neopixels
+#define NEOPIXEL_NUMBER       0
+
+//--------------------------------------------------------------------+
+// Button
+//--------------------------------------------------------------------+
+
+// SW8 button
+#define BUTTON_PINMUX         IOMUXC_GPIO_B1_09_GPIO2_IO25
+#define BUTTON_PORT           GPIO2
+#define BUTTON_PIN            25
+#define BUTTON_STATE_ACTIVE   0
+
+//--------------------------------------------------------------------+
+// USB UF2
+//--------------------------------------------------------------------+
+
+#define USB_VID           0x239A
+#define USB_PID           0x0083
+#define USB_MANUFACTURER  "PJRC"
+#define USB_PRODUCT       "TEENSY-4.0"
+
+#define UF2_PRODUCT_NAME  USB_MANUFACTURER " " USB_PRODUCT
+#define UF2_BOARD_ID      "MIMXRT1060-TEENSY-40"
+#define UF2_VOLUME_LABEL  "TEENSY40BT"
+#define UF2_INDEX_URL     "https://www.pjrc.com/store/teensy40.html"
+
+//--------------------------------------------------------------------+
+// UART
+//--------------------------------------------------------------------+
+
+#define UART_DEV              LPUART1
+#define UART_RX_PINMUX        IOMUXC_GPIO_AD_B0_13_LPUART1_RX
+#define UART_TX_PINMUX        IOMUXC_GPIO_AD_B0_12_LPUART1_TX
+
+#endif /* BOARD_H_ */

--- a/ports/mimxrt10xx/boards/teensy40/board.h
+++ b/ports/mimxrt10xx/boards/teensy40/board.h
@@ -51,9 +51,9 @@
 // Button
 //--------------------------------------------------------------------+
 
-// SW8 button
-#define BUTTON_PINMUX         IOMUXC_GPIO_B1_09_GPIO2_IO25
-#define BUTTON_PORT           GPIO2
+// Teensy 4.1 pin 23.
+#define BUTTON_PINMUX         IOMUXC_GPIO_AD_B1_09_GPIO1_IO25
+#define BUTTON_PORT           GPIO1
 #define BUTTON_PIN            25
 #define BUTTON_STATE_ACTIVE   0
 
@@ -62,13 +62,13 @@
 //--------------------------------------------------------------------+
 
 #define USB_VID           0x239A
-#define USB_PID           0x0083
+#define USB_PID           0x0085
 #define USB_MANUFACTURER  "PJRC"
-#define USB_PRODUCT       "TEENSY-4.0"
+#define USB_PRODUCT       "Teensy 4.0"
 
 #define UF2_PRODUCT_NAME  USB_MANUFACTURER " " USB_PRODUCT
 #define UF2_BOARD_ID      "MIMXRT1060-TEENSY-40"
-#define UF2_VOLUME_LABEL  "TEENSY40BT"
+#define UF2_VOLUME_LABEL  "TNSY40BOOT"
 #define UF2_INDEX_URL     "https://www.pjrc.com/store/teensy40.html"
 
 //--------------------------------------------------------------------+

--- a/ports/mimxrt10xx/boards/teensy40/board.mk
+++ b/ports/mimxrt10xx/boards/teensy40/board.mk
@@ -1,0 +1,17 @@
+MCU = MIMXRT1062
+CFLAGS += -DCPU_MIMXRT1062DVL6A
+
+# For flash-pyocd target
+PYOCD_TARGET = mimxrt1060
+
+# Convert the .bin file to a teensy loadable .hex file
+$(BUILD)/$(OUTNAME)-loadable.hex: $(BUILD)/$(OUTNAME).bin
+	$(OBJCOPY) -I binary -O ihex --change-addresses 0x60000000 $< $@
+
+# Add the teensy loadable hex file to the 'all' target
+all: $(BUILD)/$(OUTNAME)-loadable.hex
+
+# Flash using the teensy loader
+flash: $(BUILD)/$(OUTNAME)-loadable.hex
+	@echo "Waiting for teensy to attach.  If you haven't already, make sure to press the teensy button, and make sure you don't have the teensy app running in auto mode."
+	teensy_loader_cli -w --mcu TEENSY40 $<

--- a/ports/mimxrt10xx/boards/teensy40/board.mk
+++ b/ports/mimxrt10xx/boards/teensy40/board.mk
@@ -4,14 +4,7 @@ CFLAGS += -DCPU_MIMXRT1062DVL6A
 # For flash-pyocd target
 PYOCD_TARGET = mimxrt1060
 
-# Convert the .bin file to a teensy loadable .hex file
-$(BUILD)/$(OUTNAME)-loadable.hex: $(BUILD)/$(OUTNAME).bin
-	$(OBJCOPY) -I binary -O ihex --change-addresses 0x60000000 $< $@
-
-# Add the teensy loadable hex file to the 'all' target
-all: $(BUILD)/$(OUTNAME)-loadable.hex
-
 # Flash using the teensy loader
-flash: $(BUILD)/$(OUTNAME)-loadable.hex
+flash: $(BUILD)/$(OUTNAME).hex
 	@echo "Waiting for teensy to attach.  If you haven't already, make sure to press the teensy button, and make sure you don't have the teensy app running in auto mode."
 	teensy_loader_cli -w --mcu TEENSY40 $<

--- a/ports/mimxrt10xx/boards/teensy40/clock_config.c
+++ b/ports/mimxrt10xx/boards/teensy40/clock_config.c
@@ -1,0 +1,493 @@
+/*
+ * Copyright 2018-2019 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * How to setup clock using clock driver functions:
+ *
+ * 1. Call CLOCK_InitXXXPLL() to configure corresponding PLL clock.
+ *
+ * 2. Call CLOCK_InitXXXpfd() to configure corresponding PLL pfd clock.
+ *
+ * 3. Call CLOCK_SetMux() to configure corresponding clock source for target clock out.
+ *
+ * 4. Call CLOCK_SetDiv() to configure corresponding clock divider for target clock out.
+ *
+ * 5. Call CLOCK_SetXtalFreq() to set XTAL frequency based on board settings.
+ *
+ */
+
+/* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
+!!GlobalInfo
+product: Clocks v5.0
+processor: MIMXRT1062xxxxA
+package_id: MIMXRT1062DVL6A
+mcu_data: ksdk2_0
+processor_version: 0.0.0
+board: MIMXRT1060-EVK
+ * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
+
+#include "clock_config.h"
+#include "fsl_iomuxc.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+/* System clock frequency. */
+extern uint32_t SystemCoreClock;
+
+/*******************************************************************************
+ ************************ BOARD_InitBootClocks function ************************
+ ******************************************************************************/
+void BOARD_InitBootClocks(void)
+{
+    BOARD_BootClockRUN();
+}
+
+/*******************************************************************************
+ ********************** Configuration BOARD_BootClockRUN ***********************
+ ******************************************************************************/
+/* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
+!!Configuration
+name: BOARD_BootClockRUN
+called_from_default_init: true
+outputs:
+- {id: AHB_CLK_ROOT.outFreq, value: 600 MHz}
+- {id: CAN_CLK_ROOT.outFreq, value: 40 MHz}
+- {id: CKIL_SYNC_CLK_ROOT.outFreq, value: 32.768 kHz}
+- {id: CLK_1M.outFreq, value: 1 MHz}
+- {id: CLK_24M.outFreq, value: 24 MHz}
+- {id: CSI_CLK_ROOT.outFreq, value: 12 MHz}
+- {id: ENET1_TX_CLK.outFreq, value: 2.4 MHz}
+- {id: ENET2_125M_CLK.outFreq, value: 1.2 MHz}
+- {id: ENET2_TX_CLK.outFreq, value: 1.2 MHz}
+- {id: ENET_125M_CLK.outFreq, value: 2.4 MHz}
+- {id: ENET_25M_REF_CLK.outFreq, value: 1.2 MHz}
+- {id: FLEXIO1_CLK_ROOT.outFreq, value: 30 MHz}
+- {id: FLEXIO2_CLK_ROOT.outFreq, value: 30 MHz}
+- {id: FLEXSPI2_CLK_ROOT.outFreq, value: 1440/11 MHz}
+- {id: FLEXSPI_CLK_ROOT.outFreq, value: 1440/11 MHz}
+- {id: GPT1_ipg_clk_highfreq.outFreq, value: 75 MHz}
+- {id: GPT2_ipg_clk_highfreq.outFreq, value: 75 MHz}
+- {id: IPG_CLK_ROOT.outFreq, value: 150 MHz}
+- {id: LCDIF_CLK_ROOT.outFreq, value: 67.5/7 MHz}
+- {id: LPI2C_CLK_ROOT.outFreq, value: 60 MHz}
+- {id: LPSPI_CLK_ROOT.outFreq, value: 105.6 MHz}
+- {id: LVDS1_CLK.outFreq, value: 1.2 GHz}
+- {id: MQS_MCLK.outFreq, value: 1080/17 MHz}
+- {id: PERCLK_CLK_ROOT.outFreq, value: 75 MHz}
+- {id: PLL7_MAIN_CLK.outFreq, value: 24 MHz}
+- {id: SAI1_CLK_ROOT.outFreq, value: 1080/17 MHz}
+- {id: SAI1_MCLK1.outFreq, value: 1080/17 MHz}
+- {id: SAI1_MCLK2.outFreq, value: 1080/17 MHz}
+- {id: SAI1_MCLK3.outFreq, value: 30 MHz}
+- {id: SAI2_CLK_ROOT.outFreq, value: 1080/17 MHz}
+- {id: SAI2_MCLK1.outFreq, value: 1080/17 MHz}
+- {id: SAI2_MCLK3.outFreq, value: 30 MHz}
+- {id: SAI3_CLK_ROOT.outFreq, value: 1080/17 MHz}
+- {id: SAI3_MCLK1.outFreq, value: 1080/17 MHz}
+- {id: SAI3_MCLK3.outFreq, value: 30 MHz}
+- {id: SEMC_CLK_ROOT.outFreq, value: 75 MHz}
+- {id: SPDIF0_CLK_ROOT.outFreq, value: 30 MHz}
+- {id: TRACE_CLK_ROOT.outFreq, value: 352/3 MHz}
+- {id: UART_CLK_ROOT.outFreq, value: 80 MHz}
+- {id: USDHC1_CLK_ROOT.outFreq, value: 198 MHz}
+- {id: USDHC2_CLK_ROOT.outFreq, value: 198 MHz}
+settings:
+- {id: CCM.AHB_PODF.scale, value: '1', locked: true}
+- {id: CCM.ARM_PODF.scale, value: '2', locked: true}
+- {id: CCM.FLEXSPI2_PODF.scale, value: '2', locked: true}
+- {id: CCM.FLEXSPI2_SEL.sel, value: CCM_ANALOG.PLL3_PFD0_CLK}
+- {id: CCM.FLEXSPI_PODF.scale, value: '2', locked: true}
+- {id: CCM.FLEXSPI_SEL.sel, value: CCM_ANALOG.PLL3_PFD0_CLK}
+- {id: CCM.LPSPI_PODF.scale, value: '5', locked: true}
+- {id: CCM.PERCLK_PODF.scale, value: '2', locked: true}
+- {id: CCM.SEMC_PODF.scale, value: '8'}
+- {id: CCM.TRACE_PODF.scale, value: '3', locked: true}
+- {id: CCM_ANALOG.PLL1_BYPASS.sel, value: CCM_ANALOG.PLL1}
+- {id: CCM_ANALOG.PLL1_PREDIV.scale, value: '1', locked: true}
+- {id: CCM_ANALOG.PLL1_VDIV.scale, value: '50', locked: true}
+- {id: CCM_ANALOG.PLL2.denom, value: '1', locked: true}
+- {id: CCM_ANALOG.PLL2.num, value: '0', locked: true}
+- {id: CCM_ANALOG.PLL2_BYPASS.sel, value: CCM_ANALOG.PLL2_OUT_CLK}
+- {id: CCM_ANALOG.PLL2_PFD0_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD0}
+- {id: CCM_ANALOG.PLL2_PFD1_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD1}
+- {id: CCM_ANALOG.PLL2_PFD2_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD2}
+- {id: CCM_ANALOG.PLL2_PFD3_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD3}
+- {id: CCM_ANALOG.PLL3_BYPASS.sel, value: CCM_ANALOG.PLL3}
+- {id: CCM_ANALOG.PLL3_PFD0_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD0}
+- {id: CCM_ANALOG.PLL3_PFD0_DIV.scale, value: '33', locked: true}
+- {id: CCM_ANALOG.PLL3_PFD0_MUL.scale, value: '18', locked: true}
+- {id: CCM_ANALOG.PLL3_PFD1_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD1}
+- {id: CCM_ANALOG.PLL3_PFD2_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD2}
+- {id: CCM_ANALOG.PLL3_PFD3_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD3}
+- {id: CCM_ANALOG.PLL4.denom, value: '50'}
+- {id: CCM_ANALOG.PLL4.div, value: '47'}
+- {id: CCM_ANALOG.PLL5.denom, value: '1'}
+- {id: CCM_ANALOG.PLL5.div, value: '40'}
+- {id: CCM_ANALOG.PLL5.num, value: '0'}
+- {id: CCM_ANALOG_PLL_ENET_POWERDOWN_CFG, value: 'Yes'}
+- {id: CCM_ANALOG_PLL_USB1_POWER_CFG, value: 'Yes'}
+sources:
+- {id: XTALOSC24M.OSC.outFreq, value: 24 MHz, enabled: true}
+- {id: XTALOSC24M.RTC_OSC.outFreq, value: 32.768 kHz, enabled: true}
+ * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
+
+/*******************************************************************************
+ * Variables for BOARD_BootClockRUN configuration
+ ******************************************************************************/
+const clock_arm_pll_config_t armPllConfig_BOARD_BootClockRUN = {
+    .loopDivider = 100, /* PLL loop divider, Fout = Fin * 50 */
+    .src         = 0,   /* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+};
+const clock_sys_pll_config_t sysPllConfig_BOARD_BootClockRUN = {
+    .loopDivider = 1, /* PLL loop divider, Fout = Fin * ( 20 + loopDivider*2 + numerator / denominator ) */
+    .numerator   = 0, /* 30 bit numerator of fractional loop divider */
+    .denominator = 1, /* 30 bit denominator of fractional loop divider */
+    .src         = 0, /* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+};
+const clock_usb_pll_config_t usb1PllConfig_BOARD_BootClockRUN = {
+    .loopDivider = 0, /* PLL loop divider, Fout = Fin * 20 */
+    .src         = 0, /* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+};
+/*******************************************************************************
+ * Code for BOARD_BootClockRUN configuration
+ ******************************************************************************/
+void BOARD_BootClockRUN(void)
+{
+    /* Init RTC OSC clock frequency. */
+    CLOCK_SetRtcXtalFreq(32768U);
+    /* Enable 1MHz clock output. */
+    XTALOSC24M->OSC_CONFIG2 |= XTALOSC24M_OSC_CONFIG2_ENABLE_1M_MASK;
+    /* Use free 1MHz clock output. */
+    XTALOSC24M->OSC_CONFIG2 &= ~XTALOSC24M_OSC_CONFIG2_MUX_1M_MASK;
+    /* Set XTAL 24MHz clock frequency. */
+    CLOCK_SetXtalFreq(24000000U);
+    /* Enable XTAL 24MHz clock source. */
+    CLOCK_InitExternalClk(0);
+    /* Enable internal RC. */
+    CLOCK_InitRcOsc24M();
+    /* Switch clock source to external OSC. */
+    CLOCK_SwitchOsc(kCLOCK_XtalOsc);
+    /* Set Oscillator ready counter value. */
+    CCM->CCR = (CCM->CCR & (~CCM_CCR_OSCNT_MASK)) | CCM_CCR_OSCNT(127);
+    /* Setting PeriphClk2Mux and PeriphMux to provide stable clock before PLLs are initialed */
+    CLOCK_SetMux(kCLOCK_PeriphClk2Mux, 1); /* Set PERIPH_CLK2 MUX to OSC */
+    CLOCK_SetMux(kCLOCK_PeriphMux, 1);     /* Set PERIPH_CLK MUX to PERIPH_CLK2 */
+    /* Setting the VDD_SOC to 1.275V. It is necessary to config AHB to 600Mhz. */
+    DCDC->REG3 = (DCDC->REG3 & (~DCDC_REG3_TRG_MASK)) | DCDC_REG3_TRG(0x13);
+    /* Waiting for DCDC_STS_DC_OK bit is asserted */
+    while (DCDC_REG0_STS_DC_OK_MASK != (DCDC_REG0_STS_DC_OK_MASK & DCDC->REG0))
+    {
+    }
+    /* Set AHB_PODF. */
+    CLOCK_SetDiv(kCLOCK_AhbDiv, 0);
+    /* Disable IPG clock gate. */
+    CLOCK_DisableClock(kCLOCK_Adc1);
+    CLOCK_DisableClock(kCLOCK_Adc2);
+    CLOCK_DisableClock(kCLOCK_Xbar1);
+    CLOCK_DisableClock(kCLOCK_Xbar2);
+    CLOCK_DisableClock(kCLOCK_Xbar3);
+    /* Set IPG_PODF. */
+    CLOCK_SetDiv(kCLOCK_IpgDiv, 3);
+    /* Set ARM_PODF. */
+    CLOCK_SetDiv(kCLOCK_ArmDiv, 1);
+    /* Set PERIPH_CLK2_PODF. */
+    CLOCK_SetDiv(kCLOCK_PeriphClk2Div, 0);
+    /* Disable PERCLK clock gate. */
+    CLOCK_DisableClock(kCLOCK_Gpt1);
+    CLOCK_DisableClock(kCLOCK_Gpt1S);
+    CLOCK_DisableClock(kCLOCK_Gpt2);
+    CLOCK_DisableClock(kCLOCK_Gpt2S);
+    CLOCK_DisableClock(kCLOCK_Pit);
+    /* Set PERCLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_PerclkDiv, 1);
+    /* Disable USDHC1 clock gate. */
+    CLOCK_DisableClock(kCLOCK_Usdhc1);
+    /* Set USDHC1_PODF. */
+    CLOCK_SetDiv(kCLOCK_Usdhc1Div, 1);
+    /* Set Usdhc1 clock source. */
+    CLOCK_SetMux(kCLOCK_Usdhc1Mux, 0);
+    /* Disable USDHC2 clock gate. */
+    CLOCK_DisableClock(kCLOCK_Usdhc2);
+    /* Set USDHC2_PODF. */
+    CLOCK_SetDiv(kCLOCK_Usdhc2Div, 1);
+    /* Set Usdhc2 clock source. */
+    CLOCK_SetMux(kCLOCK_Usdhc2Mux, 0);
+    /* In SDK projects, SDRAM (configured by SEMC) will be initialized in either debug script or dcd.
+     * With this macro SKIP_SYSCLK_INIT, system pll (selected to be SEMC source clock in SDK projects) will be left
+     * unchanged. Note: If another clock source is selected for SEMC, user may want to avoid changing that clock as
+     * well.*/
+#ifndef SKIP_SYSCLK_INIT
+    /* Disable Semc clock gate. */
+    CLOCK_DisableClock(kCLOCK_Semc);
+    /* Set SEMC_PODF. */
+    CLOCK_SetDiv(kCLOCK_SemcDiv, 7);
+    /* Set Semc alt clock source. */
+    CLOCK_SetMux(kCLOCK_SemcAltMux, 0);
+    /* Set Semc clock source. */
+    CLOCK_SetMux(kCLOCK_SemcMux, 0);
+#endif
+    /* In SDK projects, external flash (configured by FLEXSPI) will be initialized by dcd.
+     * With this macro XIP_EXTERNAL_FLASH, usb1 pll (selected to be FLEXSPI clock source in SDK projects) will be left
+     * unchanged. Note: If another clock source is selected for FLEXSPI, user may want to avoid changing that clock as
+     * well.*/
+#if !(defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
+    /* Disable Flexspi clock gate. */
+    CLOCK_DisableClock(kCLOCK_FlexSpi);
+    /* Set FLEXSPI_PODF. */
+    CLOCK_SetDiv(kCLOCK_FlexspiDiv, 1);
+    /* Set Flexspi clock source. */
+    CLOCK_SetMux(kCLOCK_FlexspiMux, 3);
+#endif
+    /* Disable Flexspi2 clock gate. */
+    CLOCK_DisableClock(kCLOCK_FlexSpi2);
+    /* Set FLEXSPI2_PODF. */
+    CLOCK_SetDiv(kCLOCK_Flexspi2Div, 1);
+    /* Set Flexspi2 clock source. */
+    CLOCK_SetMux(kCLOCK_Flexspi2Mux, 1);
+    /* Disable CSI clock gate. */
+    CLOCK_DisableClock(kCLOCK_Csi);
+    /* Set CSI_PODF. */
+    CLOCK_SetDiv(kCLOCK_CsiDiv, 1);
+    /* Set Csi clock source. */
+    CLOCK_SetMux(kCLOCK_CsiMux, 0);
+    /* Disable LPSPI clock gate. */
+    CLOCK_DisableClock(kCLOCK_Lpspi1);
+    CLOCK_DisableClock(kCLOCK_Lpspi2);
+    CLOCK_DisableClock(kCLOCK_Lpspi3);
+    CLOCK_DisableClock(kCLOCK_Lpspi4);
+    /* Set LPSPI_PODF. */
+    CLOCK_SetDiv(kCLOCK_LpspiDiv, 4);
+    /* Set Lpspi clock source. */
+    CLOCK_SetMux(kCLOCK_LpspiMux, 2);
+    /* Disable TRACE clock gate. */
+    CLOCK_DisableClock(kCLOCK_Trace);
+    /* Set TRACE_PODF. */
+    CLOCK_SetDiv(kCLOCK_TraceDiv, 2);
+    /* Set Trace clock source. */
+    CLOCK_SetMux(kCLOCK_TraceMux, 2);
+    /* Disable SAI1 clock gate. */
+    CLOCK_DisableClock(kCLOCK_Sai1);
+    /* Set SAI1_CLK_PRED. */
+    CLOCK_SetDiv(kCLOCK_Sai1PreDiv, 3);
+    /* Set SAI1_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Sai1Div, 1);
+    /* Set Sai1 clock source. */
+    CLOCK_SetMux(kCLOCK_Sai1Mux, 0);
+    /* Disable SAI2 clock gate. */
+    CLOCK_DisableClock(kCLOCK_Sai2);
+    /* Set SAI2_CLK_PRED. */
+    CLOCK_SetDiv(kCLOCK_Sai2PreDiv, 3);
+    /* Set SAI2_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Sai2Div, 1);
+    /* Set Sai2 clock source. */
+    CLOCK_SetMux(kCLOCK_Sai2Mux, 0);
+    /* Disable SAI3 clock gate. */
+    CLOCK_DisableClock(kCLOCK_Sai3);
+    /* Set SAI3_CLK_PRED. */
+    CLOCK_SetDiv(kCLOCK_Sai3PreDiv, 3);
+    /* Set SAI3_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Sai3Div, 1);
+    /* Set Sai3 clock source. */
+    CLOCK_SetMux(kCLOCK_Sai3Mux, 0);
+    /* Disable Lpi2c clock gate. */
+    CLOCK_DisableClock(kCLOCK_Lpi2c1);
+    CLOCK_DisableClock(kCLOCK_Lpi2c2);
+    CLOCK_DisableClock(kCLOCK_Lpi2c3);
+    /* Set LPI2C_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Lpi2cDiv, 0);
+    /* Set Lpi2c clock source. */
+    CLOCK_SetMux(kCLOCK_Lpi2cMux, 0);
+    /* Disable CAN clock gate. */
+    CLOCK_DisableClock(kCLOCK_Can1);
+    CLOCK_DisableClock(kCLOCK_Can2);
+    CLOCK_DisableClock(kCLOCK_Can3);
+    CLOCK_DisableClock(kCLOCK_Can1S);
+    CLOCK_DisableClock(kCLOCK_Can2S);
+    CLOCK_DisableClock(kCLOCK_Can3S);
+    /* Set CAN_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_CanDiv, 1);
+    /* Set Can clock source. */
+    CLOCK_SetMux(kCLOCK_CanMux, 2);
+    /* Disable UART clock gate. */
+    CLOCK_DisableClock(kCLOCK_Lpuart1);
+    CLOCK_DisableClock(kCLOCK_Lpuart2);
+    CLOCK_DisableClock(kCLOCK_Lpuart3);
+    CLOCK_DisableClock(kCLOCK_Lpuart4);
+    CLOCK_DisableClock(kCLOCK_Lpuart5);
+    CLOCK_DisableClock(kCLOCK_Lpuart6);
+    CLOCK_DisableClock(kCLOCK_Lpuart7);
+    CLOCK_DisableClock(kCLOCK_Lpuart8);
+    /* Set UART_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_UartDiv, 0);
+    /* Set Uart clock source. */
+    CLOCK_SetMux(kCLOCK_UartMux, 0);
+    /* Disable LCDIF clock gate. */
+    CLOCK_DisableClock(kCLOCK_LcdPixel);
+    /* Set LCDIF_PRED. */
+    CLOCK_SetDiv(kCLOCK_LcdifPreDiv, 1);
+    /* Set LCDIF_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_LcdifDiv, 3);
+    /* Set Lcdif pre clock source. */
+    CLOCK_SetMux(kCLOCK_LcdifPreMux, 5);
+    /* Disable SPDIF clock gate. */
+    CLOCK_DisableClock(kCLOCK_Spdif);
+    /* Set SPDIF0_CLK_PRED. */
+    CLOCK_SetDiv(kCLOCK_Spdif0PreDiv, 1);
+    /* Set SPDIF0_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Spdif0Div, 7);
+    /* Set Spdif clock source. */
+    CLOCK_SetMux(kCLOCK_SpdifMux, 3);
+    /* Disable Flexio1 clock gate. */
+    CLOCK_DisableClock(kCLOCK_Flexio1);
+    /* Set FLEXIO1_CLK_PRED. */
+    CLOCK_SetDiv(kCLOCK_Flexio1PreDiv, 1);
+    /* Set FLEXIO1_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Flexio1Div, 7);
+    /* Set Flexio1 clock source. */
+    CLOCK_SetMux(kCLOCK_Flexio1Mux, 3);
+    /* Disable Flexio2 clock gate. */
+    CLOCK_DisableClock(kCLOCK_Flexio2);
+    /* Set FLEXIO2_CLK_PRED. */
+    CLOCK_SetDiv(kCLOCK_Flexio2PreDiv, 1);
+    /* Set FLEXIO2_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Flexio2Div, 7);
+    /* Set Flexio2 clock source. */
+    CLOCK_SetMux(kCLOCK_Flexio2Mux, 3);
+    /* Set Pll3 sw clock source. */
+    CLOCK_SetMux(kCLOCK_Pll3SwMux, 0);
+    /* Init ARM PLL. */
+    CLOCK_InitArmPll(&armPllConfig_BOARD_BootClockRUN);
+    /* In SDK projects, SDRAM (configured by SEMC) will be initialized in either debug script or dcd.
+     * With this macro SKIP_SYSCLK_INIT, system pll (selected to be SEMC source clock in SDK projects) will be left
+     * unchanged. Note: If another clock source is selected for SEMC, user may want to avoid changing that clock as
+     * well.*/
+#ifndef SKIP_SYSCLK_INIT
+    /* Init System PLL. */
+    CLOCK_InitSysPll(&sysPllConfig_BOARD_BootClockRUN);
+    /* Init System pfd0. */
+    CLOCK_InitSysPfd(kCLOCK_Pfd0, 27);
+    /* Init System pfd1. */
+    CLOCK_InitSysPfd(kCLOCK_Pfd1, 16);
+    /* Init System pfd2. */
+    CLOCK_InitSysPfd(kCLOCK_Pfd2, 24);
+    /* Init System pfd3. */
+    CLOCK_InitSysPfd(kCLOCK_Pfd3, 16);
+#endif
+    /* In SDK projects, external flash (configured by FLEXSPI) will be initialized by dcd.
+     * With this macro XIP_EXTERNAL_FLASH, usb1 pll (selected to be FLEXSPI clock source in SDK projects) will be left
+     * unchanged. Note: If another clock source is selected for FLEXSPI, user may want to avoid changing that clock as
+     * well.*/
+#if !(defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
+    /* Init Usb1 PLL. */
+    CLOCK_InitUsb1Pll(&usb1PllConfig_BOARD_BootClockRUN);
+    /* Init Usb1 pfd0. */
+    CLOCK_InitUsb1Pfd(kCLOCK_Pfd0, 33);
+    /* Init Usb1 pfd1. */
+    CLOCK_InitUsb1Pfd(kCLOCK_Pfd1, 16);
+    /* Init Usb1 pfd2. */
+    CLOCK_InitUsb1Pfd(kCLOCK_Pfd2, 17);
+    /* Init Usb1 pfd3. */
+    CLOCK_InitUsb1Pfd(kCLOCK_Pfd3, 19);
+    /* Disable Usb1 PLL output for USBPHY1. */
+    CCM_ANALOG->PLL_USB1 &= ~CCM_ANALOG_PLL_USB1_EN_USB_CLKS_MASK;
+#endif
+    /* DeInit Audio PLL. */
+    CLOCK_DeinitAudioPll();
+    /* Bypass Audio PLL. */
+    CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllAudio, 1);
+    /* Set divider for Audio PLL. */
+    CCM_ANALOG->MISC2 &= ~CCM_ANALOG_MISC2_AUDIO_DIV_LSB_MASK;
+    CCM_ANALOG->MISC2 &= ~CCM_ANALOG_MISC2_AUDIO_DIV_MSB_MASK;
+    /* Enable Audio PLL output. */
+    CCM_ANALOG->PLL_AUDIO |= CCM_ANALOG_PLL_AUDIO_ENABLE_MASK;
+    /* DeInit Video PLL. */
+    CLOCK_DeinitVideoPll();
+    /* Bypass Video PLL. */
+    CCM_ANALOG->PLL_VIDEO |= CCM_ANALOG_PLL_VIDEO_BYPASS_MASK;
+    /* Set divider for Video PLL. */
+    CCM_ANALOG->MISC2 = (CCM_ANALOG->MISC2 & (~CCM_ANALOG_MISC2_VIDEO_DIV_MASK)) | CCM_ANALOG_MISC2_VIDEO_DIV(0);
+    /* Enable Video PLL output. */
+    CCM_ANALOG->PLL_VIDEO |= CCM_ANALOG_PLL_VIDEO_ENABLE_MASK;
+    /* DeInit Enet PLL. */
+    CLOCK_DeinitEnetPll();
+    /* Bypass Enet PLL. */
+    CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllEnet, 1);
+    /* Set Enet output divider. */
+    CCM_ANALOG->PLL_ENET =
+        (CCM_ANALOG->PLL_ENET & (~CCM_ANALOG_PLL_ENET_DIV_SELECT_MASK)) | CCM_ANALOG_PLL_ENET_DIV_SELECT(1);
+    /* Enable Enet output. */
+    CCM_ANALOG->PLL_ENET |= CCM_ANALOG_PLL_ENET_ENABLE_MASK;
+    /* Set Enet2 output divider. */
+    CCM_ANALOG->PLL_ENET =
+        (CCM_ANALOG->PLL_ENET & (~CCM_ANALOG_PLL_ENET_ENET2_DIV_SELECT_MASK)) | CCM_ANALOG_PLL_ENET_ENET2_DIV_SELECT(0);
+    /* Enable Enet2 output. */
+    CCM_ANALOG->PLL_ENET |= CCM_ANALOG_PLL_ENET_ENET2_REF_EN_MASK;
+    /* Enable Enet25M output. */
+    CCM_ANALOG->PLL_ENET |= CCM_ANALOG_PLL_ENET_ENET_25M_REF_EN_MASK;
+    /* DeInit Usb2 PLL. */
+    CLOCK_DeinitUsb2Pll();
+    /* Bypass Usb2 PLL. */
+    CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllUsb2, 1);
+    /* Enable Usb2 PLL output. */
+    CCM_ANALOG->PLL_USB2 |= CCM_ANALOG_PLL_USB2_ENABLE_MASK;
+    /* Set preperiph clock source. */
+    CLOCK_SetMux(kCLOCK_PrePeriphMux, 3);
+    /* Set periph clock source. */
+    CLOCK_SetMux(kCLOCK_PeriphMux, 0);
+    /* Set periph clock2 clock source. */
+    CLOCK_SetMux(kCLOCK_PeriphClk2Mux, 0);
+    /* Set per clock source. */
+    CLOCK_SetMux(kCLOCK_PerclkMux, 0);
+    /* Set lvds1 clock source. */
+    CCM_ANALOG->MISC1 =
+        (CCM_ANALOG->MISC1 & (~CCM_ANALOG_MISC1_LVDS1_CLK_SEL_MASK)) | CCM_ANALOG_MISC1_LVDS1_CLK_SEL(0);
+    /* Set clock out1 divider. */
+    CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO1_DIV_MASK)) | CCM_CCOSR_CLKO1_DIV(0);
+    /* Set clock out1 source. */
+    CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO1_SEL_MASK)) | CCM_CCOSR_CLKO1_SEL(1);
+    /* Set clock out2 divider. */
+    CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO2_DIV_MASK)) | CCM_CCOSR_CLKO2_DIV(0);
+    /* Set clock out2 source. */
+    CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO2_SEL_MASK)) | CCM_CCOSR_CLKO2_SEL(18);
+    /* Set clock out1 drives clock out1. */
+    CCM->CCOSR &= ~CCM_CCOSR_CLK_OUT_SEL_MASK;
+    /* Disable clock out1. */
+    CCM->CCOSR &= ~CCM_CCOSR_CLKO1_EN_MASK;
+    /* Disable clock out2. */
+    CCM->CCOSR &= ~CCM_CCOSR_CLKO2_EN_MASK;
+    /* Set SAI1 MCLK1 clock source. */
+    IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk1Sel, 0);
+    /* Set SAI1 MCLK2 clock source. */
+    IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk2Sel, 0);
+    /* Set SAI1 MCLK3 clock source. */
+    IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk3Sel, 0);
+    /* Set SAI2 MCLK3 clock source. */
+    IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI2MClk3Sel, 0);
+    /* Set SAI3 MCLK3 clock source. */
+    IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI3MClk3Sel, 0);
+    /* Set MQS configuration. */
+    IOMUXC_MQSConfig(IOMUXC_GPR, kIOMUXC_MqsPwmOverSampleRate32, 0);
+    /* Set ENET1 Tx clock source. */
+    IOMUXC_EnableMode(IOMUXC_GPR, kIOMUXC_GPR_ENET1RefClkMode, false);
+    /* Set ENET2 Tx clock source. */
+#if defined(FSL_IOMUXC_DRIVER_VERSION) && (FSL_IOMUXC_DRIVER_VERSION != (MAKE_VERSION(2, 0, 0)))
+    IOMUXC_EnableMode(IOMUXC_GPR, kIOMUXC_GPR_ENET2RefClkMode, false);
+#else
+    IOMUXC_EnableMode(IOMUXC_GPR, IOMUXC_GPR_GPR1_ENET2_CLK_SEL_MASK, false);
+#endif
+    /* Set GPT1 High frequency reference clock source. */
+    IOMUXC_GPR->GPR5 &= ~IOMUXC_GPR_GPR5_VREF_1M_CLK_GPT1_MASK;
+    /* Set GPT2 High frequency reference clock source. */
+    IOMUXC_GPR->GPR5 &= ~IOMUXC_GPR_GPR5_VREF_1M_CLK_GPT2_MASK;
+    /* Set SystemCoreClock variable. */
+    SystemCoreClock = BOARD_BOOTCLOCKRUN_CORE_CLOCK;
+}

--- a/ports/mimxrt10xx/boards/teensy40/clock_config.h
+++ b/ports/mimxrt10xx/boards/teensy40/clock_config.h
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2018-2019 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _CLOCK_CONFIG_H_
+#define _CLOCK_CONFIG_H_
+
+#include "fsl_common.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+#define BOARD_XTAL0_CLK_HZ 24000000U /*!< Board xtal0 frequency in Hz */
+
+#define BOARD_XTAL32K_CLK_HZ 32768U /*!< Board xtal32k frequency in Hz */
+/*******************************************************************************
+ ************************ BOARD_InitBootClocks function ************************
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+/*!
+ * @brief This function executes default configuration of clocks.
+ *
+ */
+void BOARD_InitBootClocks(void);
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus*/
+
+/*******************************************************************************
+ ********************** Configuration BOARD_BootClockRUN ***********************
+ ******************************************************************************/
+/*******************************************************************************
+ * Definitions for BOARD_BootClockRUN configuration
+ ******************************************************************************/
+#define BOARD_BOOTCLOCKRUN_CORE_CLOCK 600000000U /*!< Core clock frequency: 600000000Hz */
+
+/* Clock outputs (values are in Hz): */
+#define BOARD_BOOTCLOCKRUN_AHB_CLK_ROOT 600000000UL
+#define BOARD_BOOTCLOCKRUN_CAN_CLK_ROOT 40000000UL
+#define BOARD_BOOTCLOCKRUN_CKIL_SYNC_CLK_ROOT 32768UL
+#define BOARD_BOOTCLOCKRUN_CLKO1_CLK 0UL
+#define BOARD_BOOTCLOCKRUN_CLKO2_CLK 0UL
+#define BOARD_BOOTCLOCKRUN_CLK_1M 1000000UL
+#define BOARD_BOOTCLOCKRUN_CLK_24M 24000000UL
+#define BOARD_BOOTCLOCKRUN_CSI_CLK_ROOT 12000000UL
+#define BOARD_BOOTCLOCKRUN_ENET1_TX_CLK 2400000UL
+#define BOARD_BOOTCLOCKRUN_ENET2_125M_CLK 1200000UL
+#define BOARD_BOOTCLOCKRUN_ENET2_TX_CLK 1200000UL
+#define BOARD_BOOTCLOCKRUN_ENET_125M_CLK 2400000UL
+#define BOARD_BOOTCLOCKRUN_ENET_25M_REF_CLK 1200000UL
+#define BOARD_BOOTCLOCKRUN_FLEXIO1_CLK_ROOT 30000000UL
+#define BOARD_BOOTCLOCKRUN_FLEXIO2_CLK_ROOT 30000000UL
+#define BOARD_BOOTCLOCKRUN_FLEXSPI2_CLK_ROOT 130909090UL
+#define BOARD_BOOTCLOCKRUN_FLEXSPI_CLK_ROOT 130909090UL
+#define BOARD_BOOTCLOCKRUN_GPT1_IPG_CLK_HIGHFREQ 75000000UL
+#define BOARD_BOOTCLOCKRUN_GPT2_IPG_CLK_HIGHFREQ 75000000UL
+#define BOARD_BOOTCLOCKRUN_IPG_CLK_ROOT 150000000UL
+#define BOARD_BOOTCLOCKRUN_LCDIF_CLK_ROOT 9642857UL
+#define BOARD_BOOTCLOCKRUN_LPI2C_CLK_ROOT 60000000UL
+#define BOARD_BOOTCLOCKRUN_LPSPI_CLK_ROOT 105600000UL
+#define BOARD_BOOTCLOCKRUN_LVDS1_CLK 1200000000UL
+#define BOARD_BOOTCLOCKRUN_MQS_MCLK 63529411UL
+#define BOARD_BOOTCLOCKRUN_PERCLK_CLK_ROOT 75000000UL
+#define BOARD_BOOTCLOCKRUN_PLL7_MAIN_CLK 24000000UL
+#define BOARD_BOOTCLOCKRUN_SAI1_CLK_ROOT 63529411UL
+#define BOARD_BOOTCLOCKRUN_SAI1_MCLK1 63529411UL
+#define BOARD_BOOTCLOCKRUN_SAI1_MCLK2 63529411UL
+#define BOARD_BOOTCLOCKRUN_SAI1_MCLK3 30000000UL
+#define BOARD_BOOTCLOCKRUN_SAI2_CLK_ROOT 63529411UL
+#define BOARD_BOOTCLOCKRUN_SAI2_MCLK1 63529411UL
+#define BOARD_BOOTCLOCKRUN_SAI2_MCLK2 0UL
+#define BOARD_BOOTCLOCKRUN_SAI2_MCLK3 30000000UL
+#define BOARD_BOOTCLOCKRUN_SAI3_CLK_ROOT 63529411UL
+#define BOARD_BOOTCLOCKRUN_SAI3_MCLK1 63529411UL
+#define BOARD_BOOTCLOCKRUN_SAI3_MCLK2 0UL
+#define BOARD_BOOTCLOCKRUN_SAI3_MCLK3 30000000UL
+#define BOARD_BOOTCLOCKRUN_SEMC_CLK_ROOT 75000000UL
+#define BOARD_BOOTCLOCKRUN_SPDIF0_CLK_ROOT 30000000UL
+#define BOARD_BOOTCLOCKRUN_SPDIF0_EXTCLK_OUT 0UL
+#define BOARD_BOOTCLOCKRUN_TRACE_CLK_ROOT 117333333UL
+#define BOARD_BOOTCLOCKRUN_UART_CLK_ROOT 80000000UL
+#define BOARD_BOOTCLOCKRUN_USBPHY1_CLK 0UL
+#define BOARD_BOOTCLOCKRUN_USBPHY2_CLK 0UL
+#define BOARD_BOOTCLOCKRUN_USDHC1_CLK_ROOT 198000000UL
+#define BOARD_BOOTCLOCKRUN_USDHC2_CLK_ROOT 198000000UL
+
+/*! @brief Arm PLL set for BOARD_BootClockRUN configuration.
+ */
+extern const clock_arm_pll_config_t armPllConfig_BOARD_BootClockRUN;
+/*! @brief Usb1 PLL set for BOARD_BootClockRUN configuration.
+ */
+extern const clock_usb_pll_config_t usb1PllConfig_BOARD_BootClockRUN;
+/*! @brief Sys PLL for BOARD_BootClockRUN configuration.
+ */
+extern const clock_sys_pll_config_t sysPllConfig_BOARD_BootClockRUN;
+
+/*******************************************************************************
+ * API for BOARD_BootClockRUN configuration
+ ******************************************************************************/
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+/*!
+ * @brief This function executes configuration of clocks.
+ *
+ */
+void BOARD_BootClockRUN(void);
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus*/
+
+#endif /* _CLOCK_CONFIG_H_ */

--- a/ports/mimxrt10xx/boards/teensy40/flash_config.c
+++ b/ports/mimxrt10xx/boards/teensy40/flash_config.c
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2017 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "flexspi_nor_flash.h"
+#include "fsl_flexspi_nor_boot.h"
+#include "boards.h"
+
+
+__attribute__((section(".boot_hdr.ivt")))
+/*************************************
+ *  IVT Data
+ *************************************/
+const ivt image_vector_table = {
+  IVT_HEADER,                         /* IVT Header */
+  IMAGE_ENTRY_ADDRESS,                /* Image Entry Function */
+  IVT_RSVD,                           /* Reserved = 0 */
+  (uint32_t)DCD_ADDRESS,              /* Address where DCD information is stored */
+  (uint32_t)BOOT_DATA_ADDRESS,        /* Address where BOOT Data Structure is stored */
+  (uint32_t)&image_vector_table,      /* Pointer to IVT Self (absolute address) */
+  (uint32_t)CSF_ADDRESS,              /* Address where CSF file is stored */
+  IVT_RSVD                            /* Reserved = 0 */
+};
+
+__attribute__((section(".boot_hdr.boot_data")))
+/*************************************
+ *  Boot Data
+ *************************************/
+const BOOT_DATA_T g_boot_data = {
+  BOARD_BOOT_START,           /* boot start location */
+  BOARD_BOOT_LENGTH,          /* bootloader size 48K */
+  PLUGIN_FLAG,                /* Plugin flag */
+  0xFFFFFFFF                  /* empty - extra data word */
+};
+
+// Config for on-chip W25Q64JVXGIM Q64JVXGIM with QSPI routed.
+__attribute__((section(".boot_hdr.conf")))
+const flexspi_nor_config_t qspiflash_config = {
+    .pageSize           = 256u,
+    .sectorSize         = 4u * 1024u,
+    .ipcmdSerialClkFreq = kFlexSpiSerialClk_30MHz,
+    .blockSize          = 0x00010000,
+    .isUniformBlockSize = false,
+    .memConfig =
+    {
+        .tag              = FLEXSPI_CFG_BLK_TAG,
+        .version          = 0x56010000,
+        .readSampleClkSrc = kFlexSPIReadSampleClk_LoopbackFromDqsPad,
+        .csHoldTime       = 3u,
+        .csSetupTime      = 3u,
+
+        .busyOffset = 0u, // Status bit 0 indicates busy.
+        .busyBitPolarity = 0u, // Busy when the bit is 1.
+
+        .deviceModeCfgEnable = 0u,
+        .deviceModeArg = 0x0000,
+        .configCmdEnable = 0u,
+        .configModeType[0] = kDeviceConfigCmdType_Generic,
+        .deviceType = kFlexSpiDeviceType_SerialNOR,
+        .sflashPadType = kSerialFlash_4Pads,
+        .serialClkFreq = kFlexSpiSerialClk_133MHz,
+        .sflashA1Size  = BOARD_FLASH_SIZE,
+        .lookupTable =
+        {
+            // FLEXSPI_LUT_SEQ(cmd0, pad0, op0, cmd1, pad1, op1)
+            // The high 16 bits is command 1 and the low are command 0.
+            // Within a command, the top 6 bits are the opcode, the next two are the number
+            // of pads and then last byte is the operand. The operand's meaning changes
+            // per opcode.
+
+            // Indices with ROM should always have the same function because the ROM
+            // bootloader uses it.
+
+            // 0: ROM: Read LUTs
+            // Quad version
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR,   FLEXSPI_1PAD, 0xEB /* the command to send */,
+                                     RADDR_SDR, FLEXSPI_4PAD, 24 /* bits to transmit */),
+                     FLEXSPI_LUT_SEQ(DUMMY_SDR, FLEXSPI_4PAD, 6 /* 6 dummy cycles, 2 for M7-0 and 4 dummy */,
+                                     READ_SDR,  FLEXSPI_4PAD, 0x04),
+            // Single fast read version, good for debugging.
+            // FLEXSPI_LUT_SEQ(CMD_SDR,   FLEXSPI_1PAD, 0x0B /* the command to send */,
+            //                 RADDR_SDR, FLEXSPI_1PAD, 24  /* bits to transmit */),
+            // FLEXSPI_LUT_SEQ(DUMMY_SDR, FLEXSPI_1PAD, 8 /* 8 dummy clocks */,
+            //                 READ_SDR,  FLEXSPI_1PAD, 0x04),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 1: ROM: Read status
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR,  FLEXSPI_1PAD, 0x05  /* the command to send */,
+                                     READ_SDR, FLEXSPI_1PAD, 0x04),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 2: Empty
+            0x00000000, 0x00000000, 0x00000000, 0x00000000,
+
+            // 3: ROM: Write Enable
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x06  /* the command to send */,
+                                     STOP,    FLEXSPI_1PAD, 0x00),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 4: Config: Write Status
+            0x00000000, 0x00000000, 0x00000000, 0x00000000,
+
+            // 5: ROM: Erase Sector
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR,   FLEXSPI_1PAD, 0x20  /* the command to send */,
+                                     RADDR_SDR, FLEXSPI_1PAD, 24 /* bits to transmit */),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 6: Empty
+            EMPTY_SEQUENCE,
+
+            // 7: Empty
+            EMPTY_SEQUENCE,
+
+            // 8: Block Erase
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR,   FLEXSPI_1PAD, 0xD8  /* the command to send */,
+                                     RADDR_SDR, FLEXSPI_1PAD, 24 /* bits to transmit */),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 9: ROM: Page program
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR,   FLEXSPI_1PAD, 0x02  /* the command to send */,
+                                     RADDR_SDR, FLEXSPI_1PAD, 24 /* bits to transmit */),
+
+                     FLEXSPI_LUT_SEQ(WRITE_SDR, FLEXSPI_1PAD, 0x04  /* data out */,
+                                     STOP,      FLEXSPI_1PAD, 0),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 10: Empty
+            EMPTY_SEQUENCE,
+
+            // 11: ROM: Chip erase
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x60  /* the command to send */,
+                                     STOP,    FLEXSPI_1PAD, 0),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 12: Empty
+            EMPTY_SEQUENCE,
+
+            // 13: ROM: Read SFDP
+            EMPTY_SEQUENCE,
+
+            // 14: ROM: Restore no cmd
+            EMPTY_SEQUENCE,
+
+            // 15: ROM: Dummy
+            EMPTY_SEQUENCE
+        },
+    },
+};

--- a/ports/mimxrt10xx/boards/teensy41/README.md
+++ b/ports/mimxrt10xx/boards/teensy41/README.md
@@ -1,0 +1,25 @@
+# Teensy 4.1 support
+
+The [Teensy](https://www.pjrc.com/store/teensy41.html) is based on a MIMXRT1062, so is very similar to the imxrt1060_evk.
+
+## Why tinyuf2 for the Teensy?
+
+1. The primary purpose is if you want to use the OTG2 as the main USB interface to the teensy, instead of the built-in micro-USB connector (OTG1).  The teensy built-in bootloader does not operated with the secondary USB port.
+2. You're running non-arduino code and want to emulate other 1060 boards.
+
+
+## Flashing
+Initial flashing to load tinyUF2 must be done via the teensy CLI, or the teensy loader.  It must be done via the built-in micro USB connector.
+
+1. Ensure that you *do* have the `teensy_loader_cli` program installed.  It's available [here](https://www.pjrc.com/teensy/loader_cli.html).
+1. Connect a micro-USB cable directly to the teensy (as opposed to any secondary USB connector you might have on a daughter board)
+1. press the teensy flash button.  Make sure that the teensy GUI does *NOT* come up.  The little red light adjacent to the USB connector should be on.
+1. Flash the board:
+```make BOARD=teensy41 flash```
+
+At this point, the board should be flashed, the red light adjacent to the micro USB connector should be off, and the orange light next to the teensy button should be flashing intermittently.  There should also be a new disk that appears called TEENSY41BT.
+
+## Building and flashing for the secondary USB port
+If you're using the secondary USB port, and want the tinyUF2 bootloader to run from that, follow the directions for flashing, but use this command instead:
+
+```make TUD_OPT_RHPORT=1 BOARD=teensy41 -j flash```

--- a/ports/mimxrt10xx/boards/teensy41/README.md
+++ b/ports/mimxrt10xx/boards/teensy41/README.md
@@ -22,4 +22,4 @@ At this point, the board should be flashed, the red light adjacent to the micro 
 ## Building and flashing for the secondary USB port
 If you're using the secondary USB port, and want the tinyUF2 bootloader to run from that, follow the directions for flashing, but use this command instead:
 
-```make TUD_OPT_RHPORT=1 BOARD=teensy41 -j flash```
+```make BOARD_TUD_RHPORT=1 BOARD=teensy41 -j flash```

--- a/ports/mimxrt10xx/boards/teensy41/board.h
+++ b/ports/mimxrt10xx/boards/teensy41/board.h
@@ -51,9 +51,9 @@
 // Button
 //--------------------------------------------------------------------+
 
-// SW8 button
-#define BUTTON_PINMUX         IOMUXC_GPIO_B1_09_GPIO2_IO25
-#define BUTTON_PORT           GPIO2
+// Teensy 4.1 pin 23.
+#define BUTTON_PINMUX         IOMUXC_GPIO_AD_B1_09_GPIO1_IO25
+#define BUTTON_PORT           GPIO1
 #define BUTTON_PIN            25
 #define BUTTON_STATE_ACTIVE   0
 
@@ -62,13 +62,13 @@
 //--------------------------------------------------------------------+
 
 #define USB_VID           0x239A
-#define USB_PID           0x0083
+#define USB_PID           0x00AD
 #define USB_MANUFACTURER  "PJRC"
-#define USB_PRODUCT       "TEENSY-4.1"
+#define USB_PRODUCT       "Teensy 4.1"
 
 #define UF2_PRODUCT_NAME  USB_MANUFACTURER " " USB_PRODUCT
 #define UF2_BOARD_ID      "MIMXRT1060-TEENSY-41"
-#define UF2_VOLUME_LABEL  "TEENSY41BT"
+#define UF2_VOLUME_LABEL  "TNSY41BOOT"
 #define UF2_INDEX_URL     "https://www.pjrc.com/store/teensy41.html"
 
 //--------------------------------------------------------------------+

--- a/ports/mimxrt10xx/boards/teensy41/board.h
+++ b/ports/mimxrt10xx/boards/teensy41/board.h
@@ -1,0 +1,82 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Ha Thach for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+
+#ifndef BOARD_H_
+#define BOARD_H_
+
+// Size of on-board external flash
+#define BOARD_FLASH_SIZE      (8*1024*1024)
+
+//--------------------------------------------------------------------+
+// LED
+//--------------------------------------------------------------------+
+
+#define LED_PINMUX            IOMUXC_GPIO_B0_03_GPIO2_IO03
+#define LED_PORT              GPIO2
+#define LED_PIN               3
+#define LED_STATE_ON          0
+
+//--------------------------------------------------------------------+
+// Neopixel
+//--------------------------------------------------------------------+
+
+// Number of neopixels
+#define NEOPIXEL_NUMBER       0
+
+//--------------------------------------------------------------------+
+// Button
+//--------------------------------------------------------------------+
+
+// SW8 button
+#define BUTTON_PINMUX         IOMUXC_GPIO_B1_09_GPIO2_IO25
+#define BUTTON_PORT           GPIO2
+#define BUTTON_PIN            25
+#define BUTTON_STATE_ACTIVE   0
+
+//--------------------------------------------------------------------+
+// USB UF2
+//--------------------------------------------------------------------+
+
+#define USB_VID           0x239A
+#define USB_PID           0x0083
+#define USB_MANUFACTURER  "PJRC"
+#define USB_PRODUCT       "TEENSY-4.1"
+
+#define UF2_PRODUCT_NAME  USB_MANUFACTURER " " USB_PRODUCT
+#define UF2_BOARD_ID      "MIMXRT1060-TEENSY-41"
+#define UF2_VOLUME_LABEL  "TEENSY41BT"
+#define UF2_INDEX_URL     "https://www.pjrc.com/store/teensy41.html"
+
+//--------------------------------------------------------------------+
+// UART
+//--------------------------------------------------------------------+
+
+#define UART_DEV              LPUART1
+#define UART_RX_PINMUX        IOMUXC_GPIO_AD_B0_13_LPUART1_RX
+#define UART_TX_PINMUX        IOMUXC_GPIO_AD_B0_12_LPUART1_TX
+
+#endif /* BOARD_H_ */

--- a/ports/mimxrt10xx/boards/teensy41/board.mk
+++ b/ports/mimxrt10xx/boards/teensy41/board.mk
@@ -1,0 +1,17 @@
+MCU = MIMXRT1062
+CFLAGS += -DCPU_MIMXRT1062DVL6A
+
+# For flash-pyocd target
+PYOCD_TARGET = mimxrt1060
+
+# Convert the .bin file to a teensy loadable .hex file
+$(BUILD)/$(OUTNAME)-loadable.hex: $(BUILD)/$(OUTNAME).bin
+	$(OBJCOPY) -I binary -O ihex --change-addresses 0x60000000 $< $@
+
+# Add the teensy loadable hex file to the 'all' target
+all: $(BUILD)/$(OUTNAME)-loadable.hex
+
+# Flash using the teensy loader
+flash: $(BUILD)/$(OUTNAME)-loadable.hex
+	@echo "Waiting for teensy to attach.  If you haven't already, make sure to press the teensy button, and make sure you don't have the teensy app running in auto mode."
+	teensy_loader_cli -w --mcu TEENSY41 $<

--- a/ports/mimxrt10xx/boards/teensy41/board.mk
+++ b/ports/mimxrt10xx/boards/teensy41/board.mk
@@ -4,14 +4,7 @@ CFLAGS += -DCPU_MIMXRT1062DVL6A
 # For flash-pyocd target
 PYOCD_TARGET = mimxrt1060
 
-# Convert the .bin file to a teensy loadable .hex file
-$(BUILD)/$(OUTNAME)-loadable.hex: $(BUILD)/$(OUTNAME).bin
-	$(OBJCOPY) -I binary -O ihex --change-addresses 0x60000000 $< $@
-
-# Add the teensy loadable hex file to the 'all' target
-all: $(BUILD)/$(OUTNAME)-loadable.hex
-
 # Flash using the teensy loader
-flash: $(BUILD)/$(OUTNAME)-loadable.hex
+flash: $(BUILD)/$(OUTNAME).hex
 	@echo "Waiting for teensy to attach.  If you haven't already, make sure to press the teensy button, and make sure you don't have the teensy app running in auto mode."
 	teensy_loader_cli -w --mcu TEENSY41 $<

--- a/ports/mimxrt10xx/boards/teensy41/clock_config.c
+++ b/ports/mimxrt10xx/boards/teensy41/clock_config.c
@@ -1,0 +1,493 @@
+/*
+ * Copyright 2018-2019 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * How to setup clock using clock driver functions:
+ *
+ * 1. Call CLOCK_InitXXXPLL() to configure corresponding PLL clock.
+ *
+ * 2. Call CLOCK_InitXXXpfd() to configure corresponding PLL pfd clock.
+ *
+ * 3. Call CLOCK_SetMux() to configure corresponding clock source for target clock out.
+ *
+ * 4. Call CLOCK_SetDiv() to configure corresponding clock divider for target clock out.
+ *
+ * 5. Call CLOCK_SetXtalFreq() to set XTAL frequency based on board settings.
+ *
+ */
+
+/* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
+!!GlobalInfo
+product: Clocks v5.0
+processor: MIMXRT1062xxxxA
+package_id: MIMXRT1062DVL6A
+mcu_data: ksdk2_0
+processor_version: 0.0.0
+board: MIMXRT1060-EVK
+ * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
+
+#include "clock_config.h"
+#include "fsl_iomuxc.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+/* System clock frequency. */
+extern uint32_t SystemCoreClock;
+
+/*******************************************************************************
+ ************************ BOARD_InitBootClocks function ************************
+ ******************************************************************************/
+void BOARD_InitBootClocks(void)
+{
+    BOARD_BootClockRUN();
+}
+
+/*******************************************************************************
+ ********************** Configuration BOARD_BootClockRUN ***********************
+ ******************************************************************************/
+/* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
+!!Configuration
+name: BOARD_BootClockRUN
+called_from_default_init: true
+outputs:
+- {id: AHB_CLK_ROOT.outFreq, value: 600 MHz}
+- {id: CAN_CLK_ROOT.outFreq, value: 40 MHz}
+- {id: CKIL_SYNC_CLK_ROOT.outFreq, value: 32.768 kHz}
+- {id: CLK_1M.outFreq, value: 1 MHz}
+- {id: CLK_24M.outFreq, value: 24 MHz}
+- {id: CSI_CLK_ROOT.outFreq, value: 12 MHz}
+- {id: ENET1_TX_CLK.outFreq, value: 2.4 MHz}
+- {id: ENET2_125M_CLK.outFreq, value: 1.2 MHz}
+- {id: ENET2_TX_CLK.outFreq, value: 1.2 MHz}
+- {id: ENET_125M_CLK.outFreq, value: 2.4 MHz}
+- {id: ENET_25M_REF_CLK.outFreq, value: 1.2 MHz}
+- {id: FLEXIO1_CLK_ROOT.outFreq, value: 30 MHz}
+- {id: FLEXIO2_CLK_ROOT.outFreq, value: 30 MHz}
+- {id: FLEXSPI2_CLK_ROOT.outFreq, value: 1440/11 MHz}
+- {id: FLEXSPI_CLK_ROOT.outFreq, value: 1440/11 MHz}
+- {id: GPT1_ipg_clk_highfreq.outFreq, value: 75 MHz}
+- {id: GPT2_ipg_clk_highfreq.outFreq, value: 75 MHz}
+- {id: IPG_CLK_ROOT.outFreq, value: 150 MHz}
+- {id: LCDIF_CLK_ROOT.outFreq, value: 67.5/7 MHz}
+- {id: LPI2C_CLK_ROOT.outFreq, value: 60 MHz}
+- {id: LPSPI_CLK_ROOT.outFreq, value: 105.6 MHz}
+- {id: LVDS1_CLK.outFreq, value: 1.2 GHz}
+- {id: MQS_MCLK.outFreq, value: 1080/17 MHz}
+- {id: PERCLK_CLK_ROOT.outFreq, value: 75 MHz}
+- {id: PLL7_MAIN_CLK.outFreq, value: 24 MHz}
+- {id: SAI1_CLK_ROOT.outFreq, value: 1080/17 MHz}
+- {id: SAI1_MCLK1.outFreq, value: 1080/17 MHz}
+- {id: SAI1_MCLK2.outFreq, value: 1080/17 MHz}
+- {id: SAI1_MCLK3.outFreq, value: 30 MHz}
+- {id: SAI2_CLK_ROOT.outFreq, value: 1080/17 MHz}
+- {id: SAI2_MCLK1.outFreq, value: 1080/17 MHz}
+- {id: SAI2_MCLK3.outFreq, value: 30 MHz}
+- {id: SAI3_CLK_ROOT.outFreq, value: 1080/17 MHz}
+- {id: SAI3_MCLK1.outFreq, value: 1080/17 MHz}
+- {id: SAI3_MCLK3.outFreq, value: 30 MHz}
+- {id: SEMC_CLK_ROOT.outFreq, value: 75 MHz}
+- {id: SPDIF0_CLK_ROOT.outFreq, value: 30 MHz}
+- {id: TRACE_CLK_ROOT.outFreq, value: 352/3 MHz}
+- {id: UART_CLK_ROOT.outFreq, value: 80 MHz}
+- {id: USDHC1_CLK_ROOT.outFreq, value: 198 MHz}
+- {id: USDHC2_CLK_ROOT.outFreq, value: 198 MHz}
+settings:
+- {id: CCM.AHB_PODF.scale, value: '1', locked: true}
+- {id: CCM.ARM_PODF.scale, value: '2', locked: true}
+- {id: CCM.FLEXSPI2_PODF.scale, value: '2', locked: true}
+- {id: CCM.FLEXSPI2_SEL.sel, value: CCM_ANALOG.PLL3_PFD0_CLK}
+- {id: CCM.FLEXSPI_PODF.scale, value: '2', locked: true}
+- {id: CCM.FLEXSPI_SEL.sel, value: CCM_ANALOG.PLL3_PFD0_CLK}
+- {id: CCM.LPSPI_PODF.scale, value: '5', locked: true}
+- {id: CCM.PERCLK_PODF.scale, value: '2', locked: true}
+- {id: CCM.SEMC_PODF.scale, value: '8'}
+- {id: CCM.TRACE_PODF.scale, value: '3', locked: true}
+- {id: CCM_ANALOG.PLL1_BYPASS.sel, value: CCM_ANALOG.PLL1}
+- {id: CCM_ANALOG.PLL1_PREDIV.scale, value: '1', locked: true}
+- {id: CCM_ANALOG.PLL1_VDIV.scale, value: '50', locked: true}
+- {id: CCM_ANALOG.PLL2.denom, value: '1', locked: true}
+- {id: CCM_ANALOG.PLL2.num, value: '0', locked: true}
+- {id: CCM_ANALOG.PLL2_BYPASS.sel, value: CCM_ANALOG.PLL2_OUT_CLK}
+- {id: CCM_ANALOG.PLL2_PFD0_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD0}
+- {id: CCM_ANALOG.PLL2_PFD1_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD1}
+- {id: CCM_ANALOG.PLL2_PFD2_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD2}
+- {id: CCM_ANALOG.PLL2_PFD3_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD3}
+- {id: CCM_ANALOG.PLL3_BYPASS.sel, value: CCM_ANALOG.PLL3}
+- {id: CCM_ANALOG.PLL3_PFD0_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD0}
+- {id: CCM_ANALOG.PLL3_PFD0_DIV.scale, value: '33', locked: true}
+- {id: CCM_ANALOG.PLL3_PFD0_MUL.scale, value: '18', locked: true}
+- {id: CCM_ANALOG.PLL3_PFD1_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD1}
+- {id: CCM_ANALOG.PLL3_PFD2_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD2}
+- {id: CCM_ANALOG.PLL3_PFD3_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD3}
+- {id: CCM_ANALOG.PLL4.denom, value: '50'}
+- {id: CCM_ANALOG.PLL4.div, value: '47'}
+- {id: CCM_ANALOG.PLL5.denom, value: '1'}
+- {id: CCM_ANALOG.PLL5.div, value: '40'}
+- {id: CCM_ANALOG.PLL5.num, value: '0'}
+- {id: CCM_ANALOG_PLL_ENET_POWERDOWN_CFG, value: 'Yes'}
+- {id: CCM_ANALOG_PLL_USB1_POWER_CFG, value: 'Yes'}
+sources:
+- {id: XTALOSC24M.OSC.outFreq, value: 24 MHz, enabled: true}
+- {id: XTALOSC24M.RTC_OSC.outFreq, value: 32.768 kHz, enabled: true}
+ * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
+
+/*******************************************************************************
+ * Variables for BOARD_BootClockRUN configuration
+ ******************************************************************************/
+const clock_arm_pll_config_t armPllConfig_BOARD_BootClockRUN = {
+    .loopDivider = 100, /* PLL loop divider, Fout = Fin * 50 */
+    .src         = 0,   /* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+};
+const clock_sys_pll_config_t sysPllConfig_BOARD_BootClockRUN = {
+    .loopDivider = 1, /* PLL loop divider, Fout = Fin * ( 20 + loopDivider*2 + numerator / denominator ) */
+    .numerator   = 0, /* 30 bit numerator of fractional loop divider */
+    .denominator = 1, /* 30 bit denominator of fractional loop divider */
+    .src         = 0, /* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+};
+const clock_usb_pll_config_t usb1PllConfig_BOARD_BootClockRUN = {
+    .loopDivider = 0, /* PLL loop divider, Fout = Fin * 20 */
+    .src         = 0, /* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+};
+/*******************************************************************************
+ * Code for BOARD_BootClockRUN configuration
+ ******************************************************************************/
+void BOARD_BootClockRUN(void)
+{
+    /* Init RTC OSC clock frequency. */
+    CLOCK_SetRtcXtalFreq(32768U);
+    /* Enable 1MHz clock output. */
+    XTALOSC24M->OSC_CONFIG2 |= XTALOSC24M_OSC_CONFIG2_ENABLE_1M_MASK;
+    /* Use free 1MHz clock output. */
+    XTALOSC24M->OSC_CONFIG2 &= ~XTALOSC24M_OSC_CONFIG2_MUX_1M_MASK;
+    /* Set XTAL 24MHz clock frequency. */
+    CLOCK_SetXtalFreq(24000000U);
+    /* Enable XTAL 24MHz clock source. */
+    CLOCK_InitExternalClk(0);
+    /* Enable internal RC. */
+    CLOCK_InitRcOsc24M();
+    /* Switch clock source to external OSC. */
+    CLOCK_SwitchOsc(kCLOCK_XtalOsc);
+    /* Set Oscillator ready counter value. */
+    CCM->CCR = (CCM->CCR & (~CCM_CCR_OSCNT_MASK)) | CCM_CCR_OSCNT(127);
+    /* Setting PeriphClk2Mux and PeriphMux to provide stable clock before PLLs are initialed */
+    CLOCK_SetMux(kCLOCK_PeriphClk2Mux, 1); /* Set PERIPH_CLK2 MUX to OSC */
+    CLOCK_SetMux(kCLOCK_PeriphMux, 1);     /* Set PERIPH_CLK MUX to PERIPH_CLK2 */
+    /* Setting the VDD_SOC to 1.275V. It is necessary to config AHB to 600Mhz. */
+    DCDC->REG3 = (DCDC->REG3 & (~DCDC_REG3_TRG_MASK)) | DCDC_REG3_TRG(0x13);
+    /* Waiting for DCDC_STS_DC_OK bit is asserted */
+    while (DCDC_REG0_STS_DC_OK_MASK != (DCDC_REG0_STS_DC_OK_MASK & DCDC->REG0))
+    {
+    }
+    /* Set AHB_PODF. */
+    CLOCK_SetDiv(kCLOCK_AhbDiv, 0);
+    /* Disable IPG clock gate. */
+    CLOCK_DisableClock(kCLOCK_Adc1);
+    CLOCK_DisableClock(kCLOCK_Adc2);
+    CLOCK_DisableClock(kCLOCK_Xbar1);
+    CLOCK_DisableClock(kCLOCK_Xbar2);
+    CLOCK_DisableClock(kCLOCK_Xbar3);
+    /* Set IPG_PODF. */
+    CLOCK_SetDiv(kCLOCK_IpgDiv, 3);
+    /* Set ARM_PODF. */
+    CLOCK_SetDiv(kCLOCK_ArmDiv, 1);
+    /* Set PERIPH_CLK2_PODF. */
+    CLOCK_SetDiv(kCLOCK_PeriphClk2Div, 0);
+    /* Disable PERCLK clock gate. */
+    CLOCK_DisableClock(kCLOCK_Gpt1);
+    CLOCK_DisableClock(kCLOCK_Gpt1S);
+    CLOCK_DisableClock(kCLOCK_Gpt2);
+    CLOCK_DisableClock(kCLOCK_Gpt2S);
+    CLOCK_DisableClock(kCLOCK_Pit);
+    /* Set PERCLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_PerclkDiv, 1);
+    /* Disable USDHC1 clock gate. */
+    CLOCK_DisableClock(kCLOCK_Usdhc1);
+    /* Set USDHC1_PODF. */
+    CLOCK_SetDiv(kCLOCK_Usdhc1Div, 1);
+    /* Set Usdhc1 clock source. */
+    CLOCK_SetMux(kCLOCK_Usdhc1Mux, 0);
+    /* Disable USDHC2 clock gate. */
+    CLOCK_DisableClock(kCLOCK_Usdhc2);
+    /* Set USDHC2_PODF. */
+    CLOCK_SetDiv(kCLOCK_Usdhc2Div, 1);
+    /* Set Usdhc2 clock source. */
+    CLOCK_SetMux(kCLOCK_Usdhc2Mux, 0);
+    /* In SDK projects, SDRAM (configured by SEMC) will be initialized in either debug script or dcd.
+     * With this macro SKIP_SYSCLK_INIT, system pll (selected to be SEMC source clock in SDK projects) will be left
+     * unchanged. Note: If another clock source is selected for SEMC, user may want to avoid changing that clock as
+     * well.*/
+#ifndef SKIP_SYSCLK_INIT
+    /* Disable Semc clock gate. */
+    CLOCK_DisableClock(kCLOCK_Semc);
+    /* Set SEMC_PODF. */
+    CLOCK_SetDiv(kCLOCK_SemcDiv, 7);
+    /* Set Semc alt clock source. */
+    CLOCK_SetMux(kCLOCK_SemcAltMux, 0);
+    /* Set Semc clock source. */
+    CLOCK_SetMux(kCLOCK_SemcMux, 0);
+#endif
+    /* In SDK projects, external flash (configured by FLEXSPI) will be initialized by dcd.
+     * With this macro XIP_EXTERNAL_FLASH, usb1 pll (selected to be FLEXSPI clock source in SDK projects) will be left
+     * unchanged. Note: If another clock source is selected for FLEXSPI, user may want to avoid changing that clock as
+     * well.*/
+#if !(defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
+    /* Disable Flexspi clock gate. */
+    CLOCK_DisableClock(kCLOCK_FlexSpi);
+    /* Set FLEXSPI_PODF. */
+    CLOCK_SetDiv(kCLOCK_FlexspiDiv, 1);
+    /* Set Flexspi clock source. */
+    CLOCK_SetMux(kCLOCK_FlexspiMux, 3);
+#endif
+    /* Disable Flexspi2 clock gate. */
+    CLOCK_DisableClock(kCLOCK_FlexSpi2);
+    /* Set FLEXSPI2_PODF. */
+    CLOCK_SetDiv(kCLOCK_Flexspi2Div, 1);
+    /* Set Flexspi2 clock source. */
+    CLOCK_SetMux(kCLOCK_Flexspi2Mux, 1);
+    /* Disable CSI clock gate. */
+    CLOCK_DisableClock(kCLOCK_Csi);
+    /* Set CSI_PODF. */
+    CLOCK_SetDiv(kCLOCK_CsiDiv, 1);
+    /* Set Csi clock source. */
+    CLOCK_SetMux(kCLOCK_CsiMux, 0);
+    /* Disable LPSPI clock gate. */
+    CLOCK_DisableClock(kCLOCK_Lpspi1);
+    CLOCK_DisableClock(kCLOCK_Lpspi2);
+    CLOCK_DisableClock(kCLOCK_Lpspi3);
+    CLOCK_DisableClock(kCLOCK_Lpspi4);
+    /* Set LPSPI_PODF. */
+    CLOCK_SetDiv(kCLOCK_LpspiDiv, 4);
+    /* Set Lpspi clock source. */
+    CLOCK_SetMux(kCLOCK_LpspiMux, 2);
+    /* Disable TRACE clock gate. */
+    CLOCK_DisableClock(kCLOCK_Trace);
+    /* Set TRACE_PODF. */
+    CLOCK_SetDiv(kCLOCK_TraceDiv, 2);
+    /* Set Trace clock source. */
+    CLOCK_SetMux(kCLOCK_TraceMux, 2);
+    /* Disable SAI1 clock gate. */
+    CLOCK_DisableClock(kCLOCK_Sai1);
+    /* Set SAI1_CLK_PRED. */
+    CLOCK_SetDiv(kCLOCK_Sai1PreDiv, 3);
+    /* Set SAI1_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Sai1Div, 1);
+    /* Set Sai1 clock source. */
+    CLOCK_SetMux(kCLOCK_Sai1Mux, 0);
+    /* Disable SAI2 clock gate. */
+    CLOCK_DisableClock(kCLOCK_Sai2);
+    /* Set SAI2_CLK_PRED. */
+    CLOCK_SetDiv(kCLOCK_Sai2PreDiv, 3);
+    /* Set SAI2_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Sai2Div, 1);
+    /* Set Sai2 clock source. */
+    CLOCK_SetMux(kCLOCK_Sai2Mux, 0);
+    /* Disable SAI3 clock gate. */
+    CLOCK_DisableClock(kCLOCK_Sai3);
+    /* Set SAI3_CLK_PRED. */
+    CLOCK_SetDiv(kCLOCK_Sai3PreDiv, 3);
+    /* Set SAI3_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Sai3Div, 1);
+    /* Set Sai3 clock source. */
+    CLOCK_SetMux(kCLOCK_Sai3Mux, 0);
+    /* Disable Lpi2c clock gate. */
+    CLOCK_DisableClock(kCLOCK_Lpi2c1);
+    CLOCK_DisableClock(kCLOCK_Lpi2c2);
+    CLOCK_DisableClock(kCLOCK_Lpi2c3);
+    /* Set LPI2C_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Lpi2cDiv, 0);
+    /* Set Lpi2c clock source. */
+    CLOCK_SetMux(kCLOCK_Lpi2cMux, 0);
+    /* Disable CAN clock gate. */
+    CLOCK_DisableClock(kCLOCK_Can1);
+    CLOCK_DisableClock(kCLOCK_Can2);
+    CLOCK_DisableClock(kCLOCK_Can3);
+    CLOCK_DisableClock(kCLOCK_Can1S);
+    CLOCK_DisableClock(kCLOCK_Can2S);
+    CLOCK_DisableClock(kCLOCK_Can3S);
+    /* Set CAN_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_CanDiv, 1);
+    /* Set Can clock source. */
+    CLOCK_SetMux(kCLOCK_CanMux, 2);
+    /* Disable UART clock gate. */
+    CLOCK_DisableClock(kCLOCK_Lpuart1);
+    CLOCK_DisableClock(kCLOCK_Lpuart2);
+    CLOCK_DisableClock(kCLOCK_Lpuart3);
+    CLOCK_DisableClock(kCLOCK_Lpuart4);
+    CLOCK_DisableClock(kCLOCK_Lpuart5);
+    CLOCK_DisableClock(kCLOCK_Lpuart6);
+    CLOCK_DisableClock(kCLOCK_Lpuart7);
+    CLOCK_DisableClock(kCLOCK_Lpuart8);
+    /* Set UART_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_UartDiv, 0);
+    /* Set Uart clock source. */
+    CLOCK_SetMux(kCLOCK_UartMux, 0);
+    /* Disable LCDIF clock gate. */
+    CLOCK_DisableClock(kCLOCK_LcdPixel);
+    /* Set LCDIF_PRED. */
+    CLOCK_SetDiv(kCLOCK_LcdifPreDiv, 1);
+    /* Set LCDIF_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_LcdifDiv, 3);
+    /* Set Lcdif pre clock source. */
+    CLOCK_SetMux(kCLOCK_LcdifPreMux, 5);
+    /* Disable SPDIF clock gate. */
+    CLOCK_DisableClock(kCLOCK_Spdif);
+    /* Set SPDIF0_CLK_PRED. */
+    CLOCK_SetDiv(kCLOCK_Spdif0PreDiv, 1);
+    /* Set SPDIF0_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Spdif0Div, 7);
+    /* Set Spdif clock source. */
+    CLOCK_SetMux(kCLOCK_SpdifMux, 3);
+    /* Disable Flexio1 clock gate. */
+    CLOCK_DisableClock(kCLOCK_Flexio1);
+    /* Set FLEXIO1_CLK_PRED. */
+    CLOCK_SetDiv(kCLOCK_Flexio1PreDiv, 1);
+    /* Set FLEXIO1_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Flexio1Div, 7);
+    /* Set Flexio1 clock source. */
+    CLOCK_SetMux(kCLOCK_Flexio1Mux, 3);
+    /* Disable Flexio2 clock gate. */
+    CLOCK_DisableClock(kCLOCK_Flexio2);
+    /* Set FLEXIO2_CLK_PRED. */
+    CLOCK_SetDiv(kCLOCK_Flexio2PreDiv, 1);
+    /* Set FLEXIO2_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Flexio2Div, 7);
+    /* Set Flexio2 clock source. */
+    CLOCK_SetMux(kCLOCK_Flexio2Mux, 3);
+    /* Set Pll3 sw clock source. */
+    CLOCK_SetMux(kCLOCK_Pll3SwMux, 0);
+    /* Init ARM PLL. */
+    CLOCK_InitArmPll(&armPllConfig_BOARD_BootClockRUN);
+    /* In SDK projects, SDRAM (configured by SEMC) will be initialized in either debug script or dcd.
+     * With this macro SKIP_SYSCLK_INIT, system pll (selected to be SEMC source clock in SDK projects) will be left
+     * unchanged. Note: If another clock source is selected for SEMC, user may want to avoid changing that clock as
+     * well.*/
+#ifndef SKIP_SYSCLK_INIT
+    /* Init System PLL. */
+    CLOCK_InitSysPll(&sysPllConfig_BOARD_BootClockRUN);
+    /* Init System pfd0. */
+    CLOCK_InitSysPfd(kCLOCK_Pfd0, 27);
+    /* Init System pfd1. */
+    CLOCK_InitSysPfd(kCLOCK_Pfd1, 16);
+    /* Init System pfd2. */
+    CLOCK_InitSysPfd(kCLOCK_Pfd2, 24);
+    /* Init System pfd3. */
+    CLOCK_InitSysPfd(kCLOCK_Pfd3, 16);
+#endif
+    /* In SDK projects, external flash (configured by FLEXSPI) will be initialized by dcd.
+     * With this macro XIP_EXTERNAL_FLASH, usb1 pll (selected to be FLEXSPI clock source in SDK projects) will be left
+     * unchanged. Note: If another clock source is selected for FLEXSPI, user may want to avoid changing that clock as
+     * well.*/
+#if !(defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
+    /* Init Usb1 PLL. */
+    CLOCK_InitUsb1Pll(&usb1PllConfig_BOARD_BootClockRUN);
+    /* Init Usb1 pfd0. */
+    CLOCK_InitUsb1Pfd(kCLOCK_Pfd0, 33);
+    /* Init Usb1 pfd1. */
+    CLOCK_InitUsb1Pfd(kCLOCK_Pfd1, 16);
+    /* Init Usb1 pfd2. */
+    CLOCK_InitUsb1Pfd(kCLOCK_Pfd2, 17);
+    /* Init Usb1 pfd3. */
+    CLOCK_InitUsb1Pfd(kCLOCK_Pfd3, 19);
+    /* Disable Usb1 PLL output for USBPHY1. */
+    CCM_ANALOG->PLL_USB1 &= ~CCM_ANALOG_PLL_USB1_EN_USB_CLKS_MASK;
+#endif
+    /* DeInit Audio PLL. */
+    CLOCK_DeinitAudioPll();
+    /* Bypass Audio PLL. */
+    CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllAudio, 1);
+    /* Set divider for Audio PLL. */
+    CCM_ANALOG->MISC2 &= ~CCM_ANALOG_MISC2_AUDIO_DIV_LSB_MASK;
+    CCM_ANALOG->MISC2 &= ~CCM_ANALOG_MISC2_AUDIO_DIV_MSB_MASK;
+    /* Enable Audio PLL output. */
+    CCM_ANALOG->PLL_AUDIO |= CCM_ANALOG_PLL_AUDIO_ENABLE_MASK;
+    /* DeInit Video PLL. */
+    CLOCK_DeinitVideoPll();
+    /* Bypass Video PLL. */
+    CCM_ANALOG->PLL_VIDEO |= CCM_ANALOG_PLL_VIDEO_BYPASS_MASK;
+    /* Set divider for Video PLL. */
+    CCM_ANALOG->MISC2 = (CCM_ANALOG->MISC2 & (~CCM_ANALOG_MISC2_VIDEO_DIV_MASK)) | CCM_ANALOG_MISC2_VIDEO_DIV(0);
+    /* Enable Video PLL output. */
+    CCM_ANALOG->PLL_VIDEO |= CCM_ANALOG_PLL_VIDEO_ENABLE_MASK;
+    /* DeInit Enet PLL. */
+    CLOCK_DeinitEnetPll();
+    /* Bypass Enet PLL. */
+    CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllEnet, 1);
+    /* Set Enet output divider. */
+    CCM_ANALOG->PLL_ENET =
+        (CCM_ANALOG->PLL_ENET & (~CCM_ANALOG_PLL_ENET_DIV_SELECT_MASK)) | CCM_ANALOG_PLL_ENET_DIV_SELECT(1);
+    /* Enable Enet output. */
+    CCM_ANALOG->PLL_ENET |= CCM_ANALOG_PLL_ENET_ENABLE_MASK;
+    /* Set Enet2 output divider. */
+    CCM_ANALOG->PLL_ENET =
+        (CCM_ANALOG->PLL_ENET & (~CCM_ANALOG_PLL_ENET_ENET2_DIV_SELECT_MASK)) | CCM_ANALOG_PLL_ENET_ENET2_DIV_SELECT(0);
+    /* Enable Enet2 output. */
+    CCM_ANALOG->PLL_ENET |= CCM_ANALOG_PLL_ENET_ENET2_REF_EN_MASK;
+    /* Enable Enet25M output. */
+    CCM_ANALOG->PLL_ENET |= CCM_ANALOG_PLL_ENET_ENET_25M_REF_EN_MASK;
+    /* DeInit Usb2 PLL. */
+    CLOCK_DeinitUsb2Pll();
+    /* Bypass Usb2 PLL. */
+    CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllUsb2, 1);
+    /* Enable Usb2 PLL output. */
+    CCM_ANALOG->PLL_USB2 |= CCM_ANALOG_PLL_USB2_ENABLE_MASK;
+    /* Set preperiph clock source. */
+    CLOCK_SetMux(kCLOCK_PrePeriphMux, 3);
+    /* Set periph clock source. */
+    CLOCK_SetMux(kCLOCK_PeriphMux, 0);
+    /* Set periph clock2 clock source. */
+    CLOCK_SetMux(kCLOCK_PeriphClk2Mux, 0);
+    /* Set per clock source. */
+    CLOCK_SetMux(kCLOCK_PerclkMux, 0);
+    /* Set lvds1 clock source. */
+    CCM_ANALOG->MISC1 =
+        (CCM_ANALOG->MISC1 & (~CCM_ANALOG_MISC1_LVDS1_CLK_SEL_MASK)) | CCM_ANALOG_MISC1_LVDS1_CLK_SEL(0);
+    /* Set clock out1 divider. */
+    CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO1_DIV_MASK)) | CCM_CCOSR_CLKO1_DIV(0);
+    /* Set clock out1 source. */
+    CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO1_SEL_MASK)) | CCM_CCOSR_CLKO1_SEL(1);
+    /* Set clock out2 divider. */
+    CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO2_DIV_MASK)) | CCM_CCOSR_CLKO2_DIV(0);
+    /* Set clock out2 source. */
+    CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO2_SEL_MASK)) | CCM_CCOSR_CLKO2_SEL(18);
+    /* Set clock out1 drives clock out1. */
+    CCM->CCOSR &= ~CCM_CCOSR_CLK_OUT_SEL_MASK;
+    /* Disable clock out1. */
+    CCM->CCOSR &= ~CCM_CCOSR_CLKO1_EN_MASK;
+    /* Disable clock out2. */
+    CCM->CCOSR &= ~CCM_CCOSR_CLKO2_EN_MASK;
+    /* Set SAI1 MCLK1 clock source. */
+    IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk1Sel, 0);
+    /* Set SAI1 MCLK2 clock source. */
+    IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk2Sel, 0);
+    /* Set SAI1 MCLK3 clock source. */
+    IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk3Sel, 0);
+    /* Set SAI2 MCLK3 clock source. */
+    IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI2MClk3Sel, 0);
+    /* Set SAI3 MCLK3 clock source. */
+    IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI3MClk3Sel, 0);
+    /* Set MQS configuration. */
+    IOMUXC_MQSConfig(IOMUXC_GPR, kIOMUXC_MqsPwmOverSampleRate32, 0);
+    /* Set ENET1 Tx clock source. */
+    IOMUXC_EnableMode(IOMUXC_GPR, kIOMUXC_GPR_ENET1RefClkMode, false);
+    /* Set ENET2 Tx clock source. */
+#if defined(FSL_IOMUXC_DRIVER_VERSION) && (FSL_IOMUXC_DRIVER_VERSION != (MAKE_VERSION(2, 0, 0)))
+    IOMUXC_EnableMode(IOMUXC_GPR, kIOMUXC_GPR_ENET2RefClkMode, false);
+#else
+    IOMUXC_EnableMode(IOMUXC_GPR, IOMUXC_GPR_GPR1_ENET2_CLK_SEL_MASK, false);
+#endif
+    /* Set GPT1 High frequency reference clock source. */
+    IOMUXC_GPR->GPR5 &= ~IOMUXC_GPR_GPR5_VREF_1M_CLK_GPT1_MASK;
+    /* Set GPT2 High frequency reference clock source. */
+    IOMUXC_GPR->GPR5 &= ~IOMUXC_GPR_GPR5_VREF_1M_CLK_GPT2_MASK;
+    /* Set SystemCoreClock variable. */
+    SystemCoreClock = BOARD_BOOTCLOCKRUN_CORE_CLOCK;
+}

--- a/ports/mimxrt10xx/boards/teensy41/clock_config.h
+++ b/ports/mimxrt10xx/boards/teensy41/clock_config.h
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2018-2019 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _CLOCK_CONFIG_H_
+#define _CLOCK_CONFIG_H_
+
+#include "fsl_common.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+#define BOARD_XTAL0_CLK_HZ 24000000U /*!< Board xtal0 frequency in Hz */
+
+#define BOARD_XTAL32K_CLK_HZ 32768U /*!< Board xtal32k frequency in Hz */
+/*******************************************************************************
+ ************************ BOARD_InitBootClocks function ************************
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+/*!
+ * @brief This function executes default configuration of clocks.
+ *
+ */
+void BOARD_InitBootClocks(void);
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus*/
+
+/*******************************************************************************
+ ********************** Configuration BOARD_BootClockRUN ***********************
+ ******************************************************************************/
+/*******************************************************************************
+ * Definitions for BOARD_BootClockRUN configuration
+ ******************************************************************************/
+#define BOARD_BOOTCLOCKRUN_CORE_CLOCK 600000000U /*!< Core clock frequency: 600000000Hz */
+
+/* Clock outputs (values are in Hz): */
+#define BOARD_BOOTCLOCKRUN_AHB_CLK_ROOT 600000000UL
+#define BOARD_BOOTCLOCKRUN_CAN_CLK_ROOT 40000000UL
+#define BOARD_BOOTCLOCKRUN_CKIL_SYNC_CLK_ROOT 32768UL
+#define BOARD_BOOTCLOCKRUN_CLKO1_CLK 0UL
+#define BOARD_BOOTCLOCKRUN_CLKO2_CLK 0UL
+#define BOARD_BOOTCLOCKRUN_CLK_1M 1000000UL
+#define BOARD_BOOTCLOCKRUN_CLK_24M 24000000UL
+#define BOARD_BOOTCLOCKRUN_CSI_CLK_ROOT 12000000UL
+#define BOARD_BOOTCLOCKRUN_ENET1_TX_CLK 2400000UL
+#define BOARD_BOOTCLOCKRUN_ENET2_125M_CLK 1200000UL
+#define BOARD_BOOTCLOCKRUN_ENET2_TX_CLK 1200000UL
+#define BOARD_BOOTCLOCKRUN_ENET_125M_CLK 2400000UL
+#define BOARD_BOOTCLOCKRUN_ENET_25M_REF_CLK 1200000UL
+#define BOARD_BOOTCLOCKRUN_FLEXIO1_CLK_ROOT 30000000UL
+#define BOARD_BOOTCLOCKRUN_FLEXIO2_CLK_ROOT 30000000UL
+#define BOARD_BOOTCLOCKRUN_FLEXSPI2_CLK_ROOT 130909090UL
+#define BOARD_BOOTCLOCKRUN_FLEXSPI_CLK_ROOT 130909090UL
+#define BOARD_BOOTCLOCKRUN_GPT1_IPG_CLK_HIGHFREQ 75000000UL
+#define BOARD_BOOTCLOCKRUN_GPT2_IPG_CLK_HIGHFREQ 75000000UL
+#define BOARD_BOOTCLOCKRUN_IPG_CLK_ROOT 150000000UL
+#define BOARD_BOOTCLOCKRUN_LCDIF_CLK_ROOT 9642857UL
+#define BOARD_BOOTCLOCKRUN_LPI2C_CLK_ROOT 60000000UL
+#define BOARD_BOOTCLOCKRUN_LPSPI_CLK_ROOT 105600000UL
+#define BOARD_BOOTCLOCKRUN_LVDS1_CLK 1200000000UL
+#define BOARD_BOOTCLOCKRUN_MQS_MCLK 63529411UL
+#define BOARD_BOOTCLOCKRUN_PERCLK_CLK_ROOT 75000000UL
+#define BOARD_BOOTCLOCKRUN_PLL7_MAIN_CLK 24000000UL
+#define BOARD_BOOTCLOCKRUN_SAI1_CLK_ROOT 63529411UL
+#define BOARD_BOOTCLOCKRUN_SAI1_MCLK1 63529411UL
+#define BOARD_BOOTCLOCKRUN_SAI1_MCLK2 63529411UL
+#define BOARD_BOOTCLOCKRUN_SAI1_MCLK3 30000000UL
+#define BOARD_BOOTCLOCKRUN_SAI2_CLK_ROOT 63529411UL
+#define BOARD_BOOTCLOCKRUN_SAI2_MCLK1 63529411UL
+#define BOARD_BOOTCLOCKRUN_SAI2_MCLK2 0UL
+#define BOARD_BOOTCLOCKRUN_SAI2_MCLK3 30000000UL
+#define BOARD_BOOTCLOCKRUN_SAI3_CLK_ROOT 63529411UL
+#define BOARD_BOOTCLOCKRUN_SAI3_MCLK1 63529411UL
+#define BOARD_BOOTCLOCKRUN_SAI3_MCLK2 0UL
+#define BOARD_BOOTCLOCKRUN_SAI3_MCLK3 30000000UL
+#define BOARD_BOOTCLOCKRUN_SEMC_CLK_ROOT 75000000UL
+#define BOARD_BOOTCLOCKRUN_SPDIF0_CLK_ROOT 30000000UL
+#define BOARD_BOOTCLOCKRUN_SPDIF0_EXTCLK_OUT 0UL
+#define BOARD_BOOTCLOCKRUN_TRACE_CLK_ROOT 117333333UL
+#define BOARD_BOOTCLOCKRUN_UART_CLK_ROOT 80000000UL
+#define BOARD_BOOTCLOCKRUN_USBPHY1_CLK 0UL
+#define BOARD_BOOTCLOCKRUN_USBPHY2_CLK 0UL
+#define BOARD_BOOTCLOCKRUN_USDHC1_CLK_ROOT 198000000UL
+#define BOARD_BOOTCLOCKRUN_USDHC2_CLK_ROOT 198000000UL
+
+/*! @brief Arm PLL set for BOARD_BootClockRUN configuration.
+ */
+extern const clock_arm_pll_config_t armPllConfig_BOARD_BootClockRUN;
+/*! @brief Usb1 PLL set for BOARD_BootClockRUN configuration.
+ */
+extern const clock_usb_pll_config_t usb1PllConfig_BOARD_BootClockRUN;
+/*! @brief Sys PLL for BOARD_BootClockRUN configuration.
+ */
+extern const clock_sys_pll_config_t sysPllConfig_BOARD_BootClockRUN;
+
+/*******************************************************************************
+ * API for BOARD_BootClockRUN configuration
+ ******************************************************************************/
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+/*!
+ * @brief This function executes configuration of clocks.
+ *
+ */
+void BOARD_BootClockRUN(void);
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus*/
+
+#endif /* _CLOCK_CONFIG_H_ */

--- a/ports/mimxrt10xx/boards/teensy41/flash_config.c
+++ b/ports/mimxrt10xx/boards/teensy41/flash_config.c
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2017 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "flexspi_nor_flash.h"
+#include "fsl_flexspi_nor_boot.h"
+#include "boards.h"
+
+
+__attribute__((section(".boot_hdr.ivt")))
+/*************************************
+ *  IVT Data
+ *************************************/
+const ivt image_vector_table = {
+  IVT_HEADER,                         /* IVT Header */
+  IMAGE_ENTRY_ADDRESS,                /* Image Entry Function */
+  IVT_RSVD,                           /* Reserved = 0 */
+  (uint32_t)DCD_ADDRESS,              /* Address where DCD information is stored */
+  (uint32_t)BOOT_DATA_ADDRESS,        /* Address where BOOT Data Structure is stored */
+  (uint32_t)&image_vector_table,      /* Pointer to IVT Self (absolute address) */
+  (uint32_t)CSF_ADDRESS,              /* Address where CSF file is stored */
+  IVT_RSVD                            /* Reserved = 0 */
+};
+
+__attribute__((section(".boot_hdr.boot_data")))
+/*************************************
+ *  Boot Data
+ *************************************/
+const BOOT_DATA_T g_boot_data = {
+  BOARD_BOOT_START,           /* boot start location */
+  BOARD_BOOT_LENGTH,          /* bootloader size 48K */
+  PLUGIN_FLAG,                /* Plugin flag */
+  0xFFFFFFFF                  /* empty - extra data word */
+};
+
+// Config for on-chip W25Q64JVXGIM Q64JVXGIM with QSPI routed.
+__attribute__((section(".boot_hdr.conf")))
+const flexspi_nor_config_t qspiflash_config = {
+    .pageSize           = 256u,
+    .sectorSize         = 4u * 1024u,
+    .ipcmdSerialClkFreq = kFlexSpiSerialClk_30MHz,
+    .blockSize          = 0x00010000,
+    .isUniformBlockSize = false,
+    .memConfig =
+    {
+        .tag              = FLEXSPI_CFG_BLK_TAG,
+        .version          = 0x56010000,
+        .readSampleClkSrc = kFlexSPIReadSampleClk_LoopbackFromDqsPad,
+        .csHoldTime       = 3u,
+        .csSetupTime      = 3u,
+
+        .busyOffset = 0u, // Status bit 0 indicates busy.
+        .busyBitPolarity = 0u, // Busy when the bit is 1.
+
+        .deviceModeCfgEnable = 0u,
+        .deviceModeArg = 0x0000,
+        .configCmdEnable = 0u,
+        .configModeType[0] = kDeviceConfigCmdType_Generic,
+        .deviceType = kFlexSpiDeviceType_SerialNOR,
+        .sflashPadType = kSerialFlash_4Pads,
+        .serialClkFreq = kFlexSpiSerialClk_133MHz,
+        .sflashA1Size  = BOARD_FLASH_SIZE,
+        .lookupTable =
+        {
+            // FLEXSPI_LUT_SEQ(cmd0, pad0, op0, cmd1, pad1, op1)
+            // The high 16 bits is command 1 and the low are command 0.
+            // Within a command, the top 6 bits are the opcode, the next two are the number
+            // of pads and then last byte is the operand. The operand's meaning changes
+            // per opcode.
+
+            // Indices with ROM should always have the same function because the ROM
+            // bootloader uses it.
+
+            // 0: ROM: Read LUTs
+            // Quad version
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR,   FLEXSPI_1PAD, 0xEB /* the command to send */,
+                                     RADDR_SDR, FLEXSPI_4PAD, 24 /* bits to transmit */),
+                     FLEXSPI_LUT_SEQ(DUMMY_SDR, FLEXSPI_4PAD, 6 /* 6 dummy cycles, 2 for M7-0 and 4 dummy */,
+                                     READ_SDR,  FLEXSPI_4PAD, 0x04),
+            // Single fast read version, good for debugging.
+            // FLEXSPI_LUT_SEQ(CMD_SDR,   FLEXSPI_1PAD, 0x0B /* the command to send */,
+            //                 RADDR_SDR, FLEXSPI_1PAD, 24  /* bits to transmit */),
+            // FLEXSPI_LUT_SEQ(DUMMY_SDR, FLEXSPI_1PAD, 8 /* 8 dummy clocks */,
+            //                 READ_SDR,  FLEXSPI_1PAD, 0x04),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 1: ROM: Read status
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR,  FLEXSPI_1PAD, 0x05  /* the command to send */,
+                                     READ_SDR, FLEXSPI_1PAD, 0x04),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 2: Empty
+            0x00000000, 0x00000000, 0x00000000, 0x00000000,
+
+            // 3: ROM: Write Enable
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x06  /* the command to send */,
+                                     STOP,    FLEXSPI_1PAD, 0x00),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 4: Config: Write Status
+            0x00000000, 0x00000000, 0x00000000, 0x00000000,
+
+            // 5: ROM: Erase Sector
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR,   FLEXSPI_1PAD, 0x20  /* the command to send */,
+                                     RADDR_SDR, FLEXSPI_1PAD, 24 /* bits to transmit */),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 6: Empty
+            EMPTY_SEQUENCE,
+
+            // 7: Empty
+            EMPTY_SEQUENCE,
+
+            // 8: Block Erase
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR,   FLEXSPI_1PAD, 0xD8  /* the command to send */,
+                                     RADDR_SDR, FLEXSPI_1PAD, 24 /* bits to transmit */),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 9: ROM: Page program
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR,   FLEXSPI_1PAD, 0x02  /* the command to send */,
+                                     RADDR_SDR, FLEXSPI_1PAD, 24 /* bits to transmit */),
+
+                     FLEXSPI_LUT_SEQ(WRITE_SDR, FLEXSPI_1PAD, 0x04  /* data out */,
+                                     STOP,      FLEXSPI_1PAD, 0),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 10: Empty
+            EMPTY_SEQUENCE,
+
+            // 11: ROM: Chip erase
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x60  /* the command to send */,
+                                     STOP,    FLEXSPI_1PAD, 0),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 12: Empty
+            EMPTY_SEQUENCE,
+
+            // 13: ROM: Read SFDP
+            EMPTY_SEQUENCE,
+
+            // 14: ROM: Restore no cmd
+            EMPTY_SEQUENCE,
+
+            // 15: ROM: Dummy
+            EMPTY_SEQUENCE
+        },
+    },
+};

--- a/ports/mimxrt10xx/port.mk
+++ b/ports/mimxrt10xx/port.mk
@@ -15,7 +15,11 @@ CFLAGS += \
   -DXIP_EXTERNAL_FLASH=1 \
   -DXIP_BOOT_HEADER_ENABLE=1 \
   -DCFG_TUSB_MCU=OPT_MCU_MIMXRT10XX
-  
+
+# Choose which port to use
+TUD_OPT_RHPORT = 0
+CFLAGS+=-DTUD_OPT_RHPORT=$(TUD_OPT_RHPORT)
+
 # mcu driver cause following warnings
 CFLAGS += -Wno-error=unused-parameter
 

--- a/ports/mimxrt10xx/port.mk
+++ b/ports/mimxrt10xx/port.mk
@@ -17,8 +17,8 @@ CFLAGS += \
   -DCFG_TUSB_MCU=OPT_MCU_MIMXRT10XX
 
 # Choose which port to use
-TUD_OPT_RHPORT = 0
-CFLAGS+=-DTUD_OPT_RHPORT=$(TUD_OPT_RHPORT)
+BOARD_TUD_RHPORT = 0
+CFLAGS+=-DBOARD_TUD_RHPORT=$(BOARD_TUD_RHPORT)
 
 # mcu driver cause following warnings
 CFLAGS += -Wno-error=unused-parameter

--- a/ports/mimxrt10xx/port.mk
+++ b/ports/mimxrt10xx/port.mk
@@ -4,6 +4,9 @@ CROSS_COMPILE = arm-none-eabi-
 SDK_DIR = lib/nxp/mcux-sdk
 MCU_DIR = $(SDK_DIR)/devices/$(MCU)
 
+# Choose which USB port to use (default to USB0)
+BOARD_TUD_RHPORT ?= 0
+
 # Port Compiler Flags
 CFLAGS += \
   -mthumb \
@@ -14,11 +17,8 @@ CFLAGS += \
   -D__ARMVFP__=0 -D__ARMFPV5__=0 \
   -DXIP_EXTERNAL_FLASH=1 \
   -DXIP_BOOT_HEADER_ENABLE=1 \
-  -DCFG_TUSB_MCU=OPT_MCU_MIMXRT10XX
-
-# Choose which port to use
-BOARD_TUD_RHPORT = 0
-CFLAGS+=-DBOARD_TUD_RHPORT=$(BOARD_TUD_RHPORT)
+  -DCFG_TUSB_MCU=OPT_MCU_MIMXRT10XX \
+  -DBOARD_TUD_RHPORT=$(BOARD_TUD_RHPORT)
 
 # mcu driver cause following warnings
 CFLAGS += -Wno-error=unused-parameter

--- a/ports/mimxrt10xx/tusb_config.h
+++ b/ports/mimxrt10xx/tusb_config.h
@@ -38,10 +38,10 @@
 #error CFG_TUSB_MCU must be defined in board.mk
 #endif
 
-#if TUD_OPT_RHPORT == 0
+#if BOARD_TUD_RHPORT == 0
 #    define CFG_TUSB_RHPORT0_MODE      (OPT_MODE_DEVICE | OPT_MODE_HIGH_SPEED)
 #    define CFG_TUSB_RHPORT1_MODE      0
-#elif TUD_OPT_RHPORT == 1
+#elif BOARD_TUD_RHPORT == 1
 #    define CFG_TUSB_RHPORT0_MODE      0
 #    define CFG_TUSB_RHPORT1_MODE      (OPT_MODE_DEVICE | OPT_MODE_HIGH_SPEED)
 #else

--- a/ports/mimxrt10xx/tusb_config.h
+++ b/ports/mimxrt10xx/tusb_config.h
@@ -38,8 +38,16 @@
 #error CFG_TUSB_MCU must be defined in board.mk
 #endif
 
-#define CFG_TUSB_RHPORT0_MODE      (OPT_MODE_DEVICE | OPT_MODE_HIGH_SPEED)
-#define CFG_TUSB_RHPORT1_MODE      0
+#if TUD_OPT_RHPORT == 0
+#    define CFG_TUSB_RHPORT0_MODE      (OPT_MODE_DEVICE | OPT_MODE_HIGH_SPEED)
+#    define CFG_TUSB_RHPORT1_MODE      0
+#elif TUD_OPT_RHPORT == 1
+#    define CFG_TUSB_RHPORT0_MODE      0
+#    define CFG_TUSB_RHPORT1_MODE      (OPT_MODE_DEVICE | OPT_MODE_HIGH_SPEED)
+#else
+#    error "RHPORT isn't right     "
+#endif
+
 #define CFG_TUSB_OS                OPT_OS_NONE
 
 // can be defined by compiler in DEBUG build

--- a/ports/mimxrt10xx/tusb_config.h
+++ b/ports/mimxrt10xx/tusb_config.h
@@ -39,13 +39,13 @@
 #endif
 
 #if BOARD_TUD_RHPORT == 0
-#    define CFG_TUSB_RHPORT0_MODE      (OPT_MODE_DEVICE | OPT_MODE_HIGH_SPEED)
-#    define CFG_TUSB_RHPORT1_MODE      0
+  #define CFG_TUSB_RHPORT0_MODE      (OPT_MODE_DEVICE | OPT_MODE_HIGH_SPEED)
+  #define CFG_TUSB_RHPORT1_MODE      0
 #elif BOARD_TUD_RHPORT == 1
-#    define CFG_TUSB_RHPORT0_MODE      0
-#    define CFG_TUSB_RHPORT1_MODE      (OPT_MODE_DEVICE | OPT_MODE_HIGH_SPEED)
+  #define CFG_TUSB_RHPORT0_MODE      0
+  #define CFG_TUSB_RHPORT1_MODE      (OPT_MODE_DEVICE | OPT_MODE_HIGH_SPEED)
 #else
-#    error "RHPORT isn't right     "
+  #error "BOARD_TUD_RHPORT is not correct"
 #endif
 
 #define CFG_TUSB_OS                OPT_OS_NONE

--- a/ports/rules.mk
+++ b/ports/rules.mk
@@ -47,9 +47,14 @@ $(BUILD)/$(OUTNAME).bin: $(BUILD)/$(OUTNAME).elf
 	@echo CREATE $@
 	@$(OBJCOPY) -O binary $^ $@
 
+# skip hex rul if building bootloader for imxrt since it needs spceial rule
+ifneq ($(PORT)$(BUILD_APPLICATION),mimxrt10xx)
+
 $(BUILD)/$(OUTNAME).hex: $(BUILD)/$(OUTNAME).elf
 	@echo CREATE $@
 	@$(OBJCOPY) -O ihex $^ $@
+
+endif
 
 size: $(BUILD)/$(OUTNAME).elf
 	-@echo ''


### PR DESCRIPTION
**NOTE:  I don't know the appropriate VID/PID -- It's currently using the 1060_evk settings and not the teensy settings.  Not sure which to use**

## Checklist

- [x] Please provide specific title of the PR describing the change
- [x] Please provide related links (*eg. Issue which will be closed by this Pull Request*).
- [x] If you are adding an new boards, please make sure
  - [x] Provide link to your allocated VID/PID if applicable.  **I don't know what do do here.  Currently, I left it at the values for the 1060_evk**
  - [x] Add your board to [action ci](/.github/workflows) in correct workflow and alphabet order for release binary
  - [x] `UF2_BOARD_ID` in your board.h follow correct format from [uf2 specs](https://github.com/microsoft/uf2#files-exposed-by-bootloaders)

-----------

## Description of Change
This commit adds support for the Teensy 4.0 and 4.1 boards.

It modifies the ports/mimxrt10xx/tusb_config.h and boards.c so that either USB port 0 or usb port 1 can be used.  This is useful for any IMXRT1062 based board.  Though less useful for the teensy 4.0 because it doens't have that port pinned out.

The discussion of this PR is here: https://github.com/adafruit/tinyuf2/discussions/285
