### PR TITLE
fix: Increases the drive strength of 32kHz external crystal

### DIFF
--- a/ports/stm32l4/boards/swan_r5/board.c
+++ b/ports/stm32l4/boards/swan_r5/board.c
@@ -28,8 +28,10 @@ void clock_init(void)
 
 
   /* Enable Power Control clock */
-   __HAL_RCC_LSEDRIVE_CONFIG(RCC_LSEDRIVE_LOW);
-  __HAL_RCC_PWR_CLK_ENABLE();
+   // Sets the drive strength of 32kHz external crystal, in line with calculations specified in ST AN2867 sections 3.3, 3.4, and STM32L4 datasheet DS12023 Table 58. LSE oscillator characteristics.
+   // The drive strength RCC_LSEDRIVE_LOW is marginal for the 32kHz crystal oscillator stability, and RCC_LSEDRIVE_MEDIUMLOW meets the calculated drive strength with a small margin for parasitic capacitance.
+   __HAL_RCC_LSEDRIVE_CONFIG(RCC_LSEDRIVE_MEDIUMLOW);
+   __HAL_RCC_PWR_CLK_ENABLE();
 
    if (HAL_PWREx_ControlVoltageScaling(PWR_REGULATOR_VOLTAGE_SCALE1_BOOST) != HAL_OK) {
       Error_Handler();


### PR DESCRIPTION
## Checklist

*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

- [x] Please provide specific title of the PR describing the change
- [ ] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
- [ ] If you are adding an new boards, please make sure
  - [ ] Provide link to your allocated VID/PID if applicable
  - [ ] Add your board to [action ci](/.github/workflows) in correct workflow and alphabet order for release binary
  - [ ] `UF2_BOARD_ID` in your board.h follow correct format from [uf2 specs](https://github.com/microsoft/uf2#files-exposed-by-bootloaders)

*This checklist items that are not applicable to your PR can be deleted.*

-----------

## Description of Change

fix: Increases the drive strength of 32kHz external crystal for the Swan R5 board in line with calculations specified in ST AN2867 sections 3.3, 3.4, and STM32L4 datasheet DS12023 Table 58. LSE oscillator characteristics.

The drive strength RCC_LSEDRIVE_LOW is marginal for the 32kHz crystal oscillator stability, and RCC_LSEDRIVE_MEDIUMLOW meets the calculated drive strength with a small margin for parasitic capacitance.
