### PR TITLE
Allow board.h to configure BOARD_FLASH_APP_START

### DIFF
--- a/ports/mimxrt10xx/boards.h
+++ b/ports/mimxrt10xx/boards.h
@@ -48,7 +48,9 @@ extern uint32_t _board_boot_length[];
 #define BOARD_BOOT_LENGTH       ((uint32_t) _board_boot_length)
 
 // Flash Start Address of Application, typically 0x6000C000
+#ifndef BOARD_FLASH_APP_START
 #define BOARD_FLASH_APP_START   (FlexSPI_AMBA_BASE + 0xC000)
+#endif
 
 // Double Reset tap to enter DFU
 #define TINYUF2_DFU_DOUBLE_TAP  1


### PR DESCRIPTION
## Checklist

- [x] Please provide specific title of the PR describing the change
- [x] Please provide related links (*eg. Issue which will be closed by this Pull Request*)

## Description of Change

For the i.MX RT boards, the current BOARD_FLASH_APP_START is fixed at flash_base + 0xC000.  However it is sometimes useful to put the application in a different memory location.  This patch allows the board.h to configure the app start address.
