### PR TITLE
Implement stm32f3 bootloader protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Not all features are implemented for all MCUs, following is supported MCUs and i
 | K32L2       |  ✔   |      ✔       |             |                  |          |      |
 | LPC55       |  ✔   |      ✔       |             |                  |    ✔     |      |
 | iMXRT       |  ✔   |      ✔       |      ✔      |                  |    ✔     |      |
-| STM32F3     |  ✔   |      ✔       |      ✔      |                  |    ✔     |      |
+| STM32F3     |  ✔   |      ✔       |      ✔      |        ✔         |    ✔     |      |
 | STM32F4     |  ✔   |      ✔       |      ✔      |        ✔         |    ✔     |      |
 
 ## Build and Flash

--- a/cmake/family_support.cmake
+++ b/cmake/family_support.cmake
@@ -1,8 +1,5 @@
 include_guard()
 
-# set output name to .elf
-set(CMAKE_EXECUTABLE_SUFFIX .elf)
-
 include(CMakePrintHelpers)
 find_package(Python COMPONENTS Interpreter)
 

--- a/cmake/toolchain/arm_gcc.cmake
+++ b/cmake/toolchain/arm_gcc.cmake
@@ -9,7 +9,6 @@ set(CMAKE_OBJCOPY "arm-none-eabi-objcopy" CACHE FILEPATH "")
 set(CMAKE_OBJDUMP "arm-none-eabi-objdump" CACHE FILEPATH "")
 
 set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS FALSE)
-set(CMAKE_EXECUTABLE_SUFFIX .elf)
 
 # Look for includes and libraries only in the target system prefix.
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

--- a/cmake/toolchain/arm_gcc.cmake
+++ b/cmake/toolchain/arm_gcc.cmake
@@ -4,9 +4,12 @@ set(CMAKE_ASM_COMPILER "arm-none-eabi-gcc")
 set(CMAKE_C_COMPILER "arm-none-eabi-gcc")
 set(CMAKE_CXX_COMPILER "arm-none-eabi-g++")
 
-set(TOOLCHAIN_SIZE "arm-none-eabi-size" CACHE INTERNAL "")
-set(GCC_ELF2BIN "arm-none-eabi-objcopy")
-set_property(GLOBAL PROPERTY ELF2BIN ${GCC_ELF2BIN})
+set(CMAKE_SIZE "arm-none-eabi-size" CACHE FILEPATH "")
+set(CMAKE_OBJCOPY "arm-none-eabi-objcopy" CACHE FILEPATH "")
+set(CMAKE_OBJDUMP "arm-none-eabi-objdump" CACHE FILEPATH "")
+
+set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS FALSE)
+set(CMAKE_EXECUTABLE_SUFFIX .elf)
 
 # Look for includes and libraries only in the target system prefix.
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

--- a/ports/stm32f3/CMakeLists.txt
+++ b/ports/stm32f3/CMakeLists.txt
@@ -7,6 +7,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/../../cmake/family_support.cmake)
 set(ST_HAL_DRIVER ${TOP}/lib/st/stm32f3xx_hal_driver)
 set(ST_CMSIS ${TOP}/lib/st/cmsis_device_f3)
 set(CMSIS_5 ${TOP}/lib/CMSIS_5)
+set(PORT_DIR ${CMAKE_CURRENT_LIST_DIR})
 
 include(${CMAKE_CURRENT_LIST_DIR}/boards/${BOARD}/board.cmake)
 
@@ -18,14 +19,14 @@ set(CMAKE_TOOLCHAIN_FILE ${TOP}/cmake/toolchain/arm_${TOOLCHAIN}.cmake)
 
 set(UF2_FAMILY_ID 0x6b846188)
 
-#------------------------------------
-# Project
-#------------------------------------
 project(tinyuf2 C ASM)
 
-# Bootloader
+#------------------------------------
+# TinyUF2
+#------------------------------------
+
 add_executable(tinyuf2)
-family_support_configure(tinyuf2)
+family_configure(tinyuf2)
 
 target_sources(tinyuf2 PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/board_flash.c
@@ -49,7 +50,11 @@ add_tinyuf2(tinyuf2)
 
 target_link_libraries(tinyuf2 board_${BOARD})
 
+family_add_bin_hex(tinyuf2)
 family_flash_jlink(tinyuf2)
+
+# Self Update
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/apps/self_update)
 
 #------------------------------------
 # BOARD_TARGET

--- a/ports/stm32f3/CMakeLists.txt
+++ b/ports/stm32f3/CMakeLists.txt
@@ -29,12 +29,14 @@ add_executable(tinyuf2)
 family_configure(tinyuf2)
 
 target_sources(tinyuf2 PUBLIC
-  ${CMAKE_CURRENT_SOURCE_DIR}/board_flash.c
-  ${CMAKE_CURRENT_SOURCE_DIR}/boards.c
+  board_flash.c
+  boards.c
+  boards.h
+  # tinyusb port
   ${TOP}/lib/tinyusb/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
   )
 target_include_directories(tinyuf2 PUBLIC
-  ${CMAKE_CURRENT_SOURCE_DIR}
+  .
   )
 target_compile_options(tinyuf2 PUBLIC
   )
@@ -73,8 +75,8 @@ add_library(board_${BOARD} STATIC
   ${ST_HAL_DRIVER}/Src/stm32f3xx_hal_uart.c
   )
 target_include_directories(board_${BOARD} PUBLIC
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${CMAKE_CURRENT_SOURCE_DIR}/boards/${BOARD}
+  .
+  boards/${BOARD}
   ${CMSIS_5}/CMSIS/Core/Include
   ${ST_CMSIS}/Include
   ${ST_HAL_DRIVER}/Inc

--- a/ports/stm32f3/apps/self_update/CMakeLists.txt
+++ b/ports/stm32f3/apps/self_update/CMakeLists.txt
@@ -1,0 +1,35 @@
+#------------------------------------
+# Self Update
+#------------------------------------
+# This file is meant to be include by add_subdirectory() in the root CMakeLists.txt
+
+# Generate bootloader_bin.c
+add_custom_command(OUTPUT bootloader_bin.c
+  COMMAND ${Python_EXECUTABLE} ${UF2CONV_PY} --carray -o bootloader_bin.c $<TARGET_FILE_DIR:tinyuf2>/tinyuf2.bin
+  DEPENDS tinyuf2
+  )
+
+# self_update target
+add_executable(self_update
+  ${TOP}/apps/self_update/self_update.c
+  ${PORT_DIR}/boards.c
+  ${PORT_DIR}/board_flash.c
+  ${CMAKE_CURRENT_BINARY_DIR}/bootloader_bin.c
+  )
+
+target_include_directories(self_update PUBLIC
+  ${TOP}/src
+  )
+target_compile_definitions(self_update PUBLIC
+  TINYUF2_SELF_UPDATE
+  BUILD_NO_TINYUSB
+  BUILD_APPLICATION
+  )
+target_link_options(self_update PUBLIC
+  "LINKER:--script=${PORT_DIR}/linker/stm32f3_app.ld"
+  )
+
+family_configure(self_update)
+target_link_libraries(self_update board_${BOARD})
+family_add_bin_hex(self_update)
+family_add_uf2(self_update ${UF2_FAMILY_ID})

--- a/ports/stm32f3/board_flash.c
+++ b/ports/stm32f3/board_flash.c
@@ -182,10 +182,6 @@ void board_flash_erase_app(void)
 
 bool board_flash_protect_bootloader(bool protect)
 {
-  // Ignore if HAL_FLASHEx_OBProgram triggered reset
-  bool board_reset_was_option_bytes(void);
-  if(board_reset_was_option_bytes()) return true;
-
   bool ret = true;
 
   HAL_FLASH_Unlock();

--- a/ports/stm32f3/board_flash.c
+++ b/ports/stm32f3/board_flash.c
@@ -185,7 +185,7 @@ bool board_flash_protect_bootloader(bool protect)
   // F3 reset everytime Option Bytes is programmed
   // skip protecting bootloader if we just reset by option byte changes
   // since we want to disable protect mode for e.g self-updating
-  if (protect && board_reset_by_option_bytes() ) {
+  if ( board_reset_by_option_bytes() ) {
     return true;
   }
 

--- a/ports/stm32f3/board_flash.c
+++ b/ports/stm32f3/board_flash.c
@@ -34,7 +34,7 @@
 
 #define FLASH_BASE_ADDR         0x08000000UL
 
-// TinyUF2 by default resides in the first 8 flash pages on STM32F43s, therefore these are write protected
+// TinyUF2 by default resides in the first 8 flash pages on STM32F3s, therefore these are write protected
 #if BOARD_FLASH_APP_START == 0x08004000
 #define BOOTLOADER_PAGE_MASK (OB_WRP_PAGES0TO1 | OB_WRP_PAGES2TO3 | OB_WRP_PAGES4TO5 | OB_WRP_PAGES6TO7)
 #endif

--- a/ports/stm32f3/board_flash.c
+++ b/ports/stm32f3/board_flash.c
@@ -182,6 +182,13 @@ void board_flash_erase_app(void)
 
 bool board_flash_protect_bootloader(bool protect)
 {
+  // F3 reset everytime Option Bytes is programmed
+  // skip protecting bootloader if we just reset by option byte changes
+  // since we want to disable protect mode for e.g self-updating
+  if (protect && board_reset_by_option_bytes() ) {
+    return true;
+  }
+
   bool ret = true;
 
   HAL_FLASH_Unlock();
@@ -196,7 +203,7 @@ bool board_flash_protect_bootloader(bool protect)
   TUF2_LOG1("Protection: current = %u, request = %u\r\n", already_protected, protect);
 
   // request and current state mismatched --> require ob program
-  if ( (protect && !already_protected) || (!protect && already_protected) )
+  if (protect != already_protected)
   {
     FLASH_OBProgramInitTypeDef ob_update = {0};
     ob_update.OptionType = OPTIONBYTE_WRP;

--- a/ports/stm32f3/boards.c
+++ b/ports/stm32f3/boards.c
@@ -37,8 +37,18 @@
 
 static UART_HandleTypeDef UartHandle;
 
+static bool reset_was_option_bytes = false;
+
+bool board_reset_was_option_bytes(void)
+{
+  return reset_was_option_bytes;
+}
+
 void board_init(void)
 {
+  // Check asap to ensure correct reason
+  reset_was_option_bytes = !!(__HAL_RCC_GET_FLAG(RCC_FLAG_OBLRST));
+
   clock_init();
   SystemCoreClockUpdate();
 

--- a/ports/stm32f3/boards.c
+++ b/ports/stm32f3/boards.c
@@ -39,9 +39,9 @@ static UART_HandleTypeDef UartHandle;
 
 static bool reset_was_option_bytes = false;
 
-bool board_reset_was_option_bytes(void)
+bool board_should_protect_bootloader(void)
 {
-  return reset_was_option_bytes;
+  return !reset_was_option_bytes;
 }
 
 void board_init(void)

--- a/ports/stm32f3/boards.c
+++ b/ports/stm32f3/boards.c
@@ -37,17 +37,17 @@
 
 static UART_HandleTypeDef UartHandle;
 
-static bool reset_was_option_bytes = false;
+static bool reset_by_option_bytes = false;
 
-bool board_should_protect_bootloader(void)
+bool board_reset_by_option_bytes(void)
 {
-  return !reset_was_option_bytes;
+  return reset_by_option_bytes;
 }
 
 void board_init(void)
 {
   // Check asap to ensure correct reason
-  reset_was_option_bytes = !!(__HAL_RCC_GET_FLAG(RCC_FLAG_OBLRST));
+  reset_by_option_bytes = !!(__HAL_RCC_GET_FLAG(RCC_FLAG_OBLRST));
 
   clock_init();
   SystemCoreClockUpdate();

--- a/ports/stm32f3/boards.h
+++ b/ports/stm32f3/boards.h
@@ -47,6 +47,11 @@
 // Double Reset tap to enter DFU
 #define TINYUF2_DFU_DOUBLE_TAP      1
 
+// Enable write protection
+#ifndef TINYUF2_PROTECT_BOOTLOADER
+#define TINYUF2_PROTECT_BOOTLOADER    1
+#endif
+
 // Brightness percentage from 1 to 255
 #ifndef NEOPIXEL_BRIGHTNESS
 #define NEOPIXEL_BRIGHTNESS   0x10

--- a/ports/stm32f3/boards.h
+++ b/ports/stm32f3/boards.h
@@ -61,6 +61,14 @@
 #define TINYUF2_LED 1
 #endif
 
+//--------------------------------------------------------------------+
+// Port specific APIs
+// Only used with port source
+//--------------------------------------------------------------------+
+
+// check if we just reset by option bytes load i.e protection changes
+bool board_reset_by_option_bytes(void);
+
 #ifdef __cplusplus
  }
 #endif

--- a/ports/stm32f3/boards/stm32f303disco/board.h
+++ b/ports/stm32f3/boards/stm32f303disco/board.h
@@ -80,6 +80,7 @@
 
 #define UART_DEV              USART1
 #define UART_CLOCK_ENABLE     __HAL_RCC_USART1_CLK_ENABLE
+#define UART_CLOCK_DISABLE    __HAL_RCC_USART1_CLK_DISABLE
 #define UART_GPIO_PORT        GPIOC
 #define UART_GPIO_AF          GPIO_AF7_USART1
 #define UART_TX_PIN           GPIO_PIN_4

--- a/ports/stm32f3/boards/stm32f303disco/board.h
+++ b/ports/stm32f3/boards/stm32f303disco/board.h
@@ -70,7 +70,7 @@
 #define USB_PRODUCT       "STM32F303 Discovery"
 
 #define UF2_PRODUCT_NAME  USB_MANUFACTURER " " USB_PRODUCT
-#define UF2_BOARD_ID      "STM32F303 discovery"
+#define UF2_BOARD_ID      "STM32F303-Discovery-MB1035D"
 #define UF2_VOLUME_LABEL  "F303BOOT"
 #define UF2_INDEX_URL     "https://www.st.com/en/evaluation-tools/stm32f3discovery.html"
 

--- a/ports/stm32f3/linker/stm32f3_boot.ld
+++ b/ports/stm32f3/linker/stm32f3_boot.ld
@@ -42,9 +42,9 @@ _Min_Stack_Size = 0x800;; /* required amount of stack */
 /* Specify the memory areas */
 MEMORY
 {
-FLASH (rx)      : ORIGIN = 0x8000000, LENGTH = 16K
-RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 40K - 4    /* reserve 4 bytes for double tap   */
-CCMRAM (rw)      : ORIGIN = 0x10000000, LENGTH = 8K
+  FLASH (rx)  : ORIGIN = 0x8000000, LENGTH = 16K
+  RAM (xrw)   : ORIGIN = 0x20000000, LENGTH = 40K - 4    /* reserve 4 bytes for double tap   */
+  CCMRAM (rw) : ORIGIN = 0x10000000, LENGTH = 8K
 }
 
 /* Define output sections */

--- a/ports/stm32f3/tusb_config.h
+++ b/ports/stm32f3/tusb_config.h
@@ -81,7 +81,7 @@
 //------------- CLASS -------------//
 #define CFG_TUD_CDC               0
 #define CFG_TUD_MSC               1
-#define CFG_TUD_HID               1
+#define CFG_TUD_HID               0
 #define CFG_TUD_MIDI              0
 #define CFG_TUD_VENDOR            0
 

--- a/ports/stm32f4/board_flash.c
+++ b/ports/stm32f4/board_flash.c
@@ -221,7 +221,7 @@ bool board_flash_protect_bootloader(bool protect)
   TUF2_LOG1("Protection: current = %u, request = %u\r\n", already_protected, protect);
 
   // request and current state mismatched --> require ob program
-  if ( (protect && !already_protected) || (!protect && already_protected) )
+  if (protect != already_protected)
   {
     FLASH_OBProgramInitTypeDef ob_update = {0};
     ob_update.OptionType = OPTIONBYTE_WRP;

--- a/src/board_api.h
+++ b/src/board_api.h
@@ -59,6 +59,11 @@
 #define TINYUF2_PROTECT_BOOTLOADER  0
 #endif
 
+// Bootloader often has limited ROM than RAM and prefer to use RAM for data
+#ifndef TINYUF2_CONST
+#define TINYUF2_CONST
+#endif
+
 // Use favicon.ico + autorun.inf (only works with windows)
 // define TINYUF2_FAVICON_HEADER to enable this feature
 

--- a/src/main.c
+++ b/src/main.c
@@ -33,7 +33,7 @@
 #include "tusb.h"
 
 //--------------------------------------------------------------------+
-// MACRO CONSTANT TYPEDEF PROTYPES
+// MACRO CONSTANT TYPEDEF PROTOTYPES
 //--------------------------------------------------------------------+
 //#define USE_DFU_BUTTON    1
 
@@ -60,13 +60,6 @@ static volatile uint32_t _timer_count = 0;
 //--------------------------------------------------------------------+
 static bool check_dfu_mode(void);
 
-#if TINYUF2_PROTECT_BOOTLOADER
-__attribute__((weak)) bool board_should_protect_bootloader(void)
-{
-  return true;
-}
-#endif
-
 int main(void)
 {
   board_init();
@@ -74,10 +67,7 @@ int main(void)
   TU_LOG1("TinyUF2\r\n");
 
 #if TINYUF2_PROTECT_BOOTLOADER
-  if (board_should_protect_bootloader())
-  {
-    board_flash_protect_bootloader(true);
-  }
+  board_flash_protect_bootloader(true);
 #endif
 
   // if not DFU mode, jump to App

--- a/src/main.c
+++ b/src/main.c
@@ -60,6 +60,13 @@ static volatile uint32_t _timer_count = 0;
 //--------------------------------------------------------------------+
 static bool check_dfu_mode(void);
 
+#if TINYUF2_PROTECT_BOOTLOADER
+__attribute__((weak)) bool board_should_protect_bootloader(void)
+{
+  return true;
+}
+#endif
+
 int main(void)
 {
   board_init();
@@ -67,7 +74,10 @@ int main(void)
   TU_LOG1("TinyUF2\r\n");
 
 #if TINYUF2_PROTECT_BOOTLOADER
-  board_flash_protect_bootloader(true);
+  if (board_should_protect_bootloader())
+  {
+    board_flash_protect_bootloader(true);
+  }
 #endif
 
   // if not DFU mode, jump to App

--- a/src/tinyuf2.cmake
+++ b/src/tinyuf2.cmake
@@ -12,6 +12,7 @@ function (add_tinyuf2 TARGET)
     ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/msc.c
     ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/screen.c
     ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/usb_descriptors.c
+    ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/board_api.h
     )
 
   # tinyusb source

--- a/src/usb_descriptors.c
+++ b/src/usb_descriptors.c
@@ -41,7 +41,10 @@ enum
 enum
 {
   ITF_NUM_MSC,
+
+#if CFG_TUD_HID
   ITF_NUM_HID,
+#endif
 
 #if CFG_TUD_VENDOR
   ITF_NUM_VENDOR, // webUSB
@@ -53,7 +56,7 @@ enum
 //--------------------------------------------------------------------+
 // Device Descriptors
 //--------------------------------------------------------------------+
-tusb_desc_device_t const desc_device =
+tusb_desc_device_t TINYUF2_CONST desc_device =
 {
     .bLength            = sizeof(tusb_desc_device_t),
     .bDescriptorType    = TUSB_DESC_DEVICE,
@@ -84,7 +87,7 @@ uint8_t const * tud_descriptor_device_cb(void)
 //--------------------------------------------------------------------+
 // HID Report Descriptor
 //--------------------------------------------------------------------+
-
+#if CFG_TUD_HID
 uint8_t const desc_hid_report[] =
 {
   TUD_HID_REPORT_DESC_GENERIC_INOUT(CFG_TUD_HID_BUFSIZE)
@@ -98,13 +101,15 @@ uint8_t const * tud_hid_descriptor_report_cb(uint8_t itf)
   (void) itf;
   return desc_hid_report;
 }
+#endif
 
 
 //--------------------------------------------------------------------+
 // Configuration Descriptor
 //--------------------------------------------------------------------+
 
-#define CONFIG_TOTAL_LEN  (TUD_CONFIG_DESC_LEN + TUD_MSC_DESC_LEN + TUD_HID_INOUT_DESC_LEN + CFG_TUD_VENDOR*TUD_VENDOR_DESC_LEN)
+#define CONFIG_TOTAL_LEN  (TUD_CONFIG_DESC_LEN + TUD_MSC_DESC_LEN + \
+                            CFG_TUD_HID*TUD_HID_INOUT_DESC_LEN + CFG_TUD_VENDOR*TUD_VENDOR_DESC_LEN)
 
 #define EPNUM_MSC_OUT     0x01
 #define EPNUM_MSC_IN      0x81
@@ -123,8 +128,10 @@ uint8_t const desc_configuration[] =
   // Interface number, string index, EP Out & EP In address, EP size
   TUD_MSC_DESCRIPTOR(ITF_NUM_MSC, STRID_MSC, EPNUM_MSC_OUT, EPNUM_MSC_IN, TUD_OPT_HIGH_SPEED ? 512 : 64),
 
+#if CFG_TUD_HID
   // Interface number, string index, protocol, report descriptor len, EP In & Out address, size & polling interval
   TUD_HID_INOUT_DESCRIPTOR(ITF_NUM_HID, STRID_HID, HID_ITF_PROTOCOL_NONE, sizeof(desc_hid_report), EPNUM_HID_OUT, EPNUM_HID_IN, CFG_TUD_HID_BUFSIZE, 10),
+#endif
 
 #if CFG_TUD_VENDOR
   // Interface number, string index, EP Out & IN address, EP size


### PR DESCRIPTION
## Description of Change

Slight complication on the implementation compared to F4 as `HAL_FLASH_OB_Launch` resets the MCU. Without specific logic to handle this case the self-updater gets into a bit of a spin.

1. self-update calls `board_flash_protect_bootloader(false)`
2. MCU resets
3. bootloader main then runs `board_flash_protect_bootloader(true)`
4. MCU resets
5. goto 1

Catching the reset reason allows the bootloader to re-run the self-updater with the now unlocked write protection.