### PR TITLE
Allow per-board custom init, teardown, and validate hooks

### DIFF
--- a/src/board_api.h
+++ b/src/board_api.h
@@ -81,9 +81,16 @@
 // This API does not init usb which is only init if DFU is entered
 void board_init(void);
 
+// board_init2 is the same as board_init, but allows custom boards
+// to have a chance at board_init without modifying the boards.c file.
+void board_init2(void) __attribute__ ((weak));
+
 // opposite to board_init(), reset all board peripherals. Is called before jumping to application
 // TODO force this API in the future
 void board_teardown(void) __attribute__ ((weak));
+
+// board_teardown2() is called immeidately after board_init()
+void board_teardown2(void) __attribute__ ((weak));
 
 // Reset board, not return
 void board_reset(void);
@@ -111,6 +118,9 @@ extern void board_timer_handler(void);
 
 // Check if application is valid
 bool board_app_valid(void);
+
+// Additional check if application is valid for custom board.
+bool board_app_valid2(void) __attribute__ ((weak));
 
 // Jump to Application
 void board_app_jump(void);

--- a/src/main.c
+++ b/src/main.c
@@ -63,6 +63,7 @@ static bool check_dfu_mode(void);
 int main(void)
 {
   board_init();
+  if (board_init2) board_init2();
   TU_LOG1("TinyUF2\r\n");
 
 #if TINYUF2_PROTECT_BOOTLOADER
@@ -74,6 +75,7 @@ int main(void)
   {
     TU_LOG1("Jump to application\r\n");
     if (board_teardown) board_teardown();
+    if (board_teardown2) board_teardown2();
     board_app_jump();
     while(1) {}
   }
@@ -122,6 +124,7 @@ static bool check_dfu_mode(void)
 
   // Check if app is valid
   if ( !board_app_valid() ) return true;
+  if ( board_app_valid2 && !board_app_valid2() ) return true;
 
 #if TINYUF2_DFU_DOUBLE_TAP
 //  TU_LOG1_HEX(DBL_TAP_REG);


### PR DESCRIPTION
## Checklist
- [x] Please provide specific title of the PR describing the change
- [x] Please provide related links (*eg. Issue which will be closed by this Pull Request*)

-----------

## Description of Change
Some custom i.MX boards require per board setup.  Currently, I don't see a mechanism for a specific board to have a setup call.

As a specific example, For example, on the i.MX RT 1011, if you happen to have the boot LED on `GPIO_AD_02`, you might need to custom configure `GPR26` in order for it to work with the GPIO configuration you want to use.   

Additionally, there are lots of other potential reasons you might want to do some setup in `boards/<board_name>`.

This patch adds `#ifdef BOARD_INIT_POST_HOOK `, and if it's defined, then `board_init_post_hook()` will be called at the end of `board_init()`.
