### PR TITLE
imxrt10xx: fix LED blinking

### DIFF
--- a/ports/mimxrt10xx/boards.c
+++ b/ports/mimxrt10xx/boards.c
@@ -262,8 +262,6 @@ void SysTick_Handler(void)
 
 void board_led_write(uint32_t value)
 {
-  (void) value;
-
 #ifdef LED_PINMUX
 #ifdef LED_PWM_PINMUX
   if (_dfu_mode)
@@ -274,6 +272,7 @@ void board_led_write(uint32_t value)
   }else
 #endif
   {
+    value = (value >= 128) ? 1 : 0;
     GPIO_PinWrite(LED_PORT, LED_PIN, value ? LED_STATE_ON : (1-LED_STATE_ON));
   }
 #endif


### PR DESCRIPTION
## Checklist

- [x] Please provide specific title of the PR describing the change
-----------

## Description of Change
The LED write routine is meant to take a value between 0 for off and 255 for full brightness. the current 10xx port treats 0 as off, and anything else as on when dealing with non-PWM leds.  This creates a case where the LED is on virtually all the time, except for a tiny blink off every 256 timer intervals. 
This fix turns the LED on for `(value >= 128)`  and off for (value < 128), and makes the LED blinking look correct.

