### PR TITLE
Add M5Stack AtomS3 board

### DIFF
--- a/.github/workflows/build_esp32.yml
+++ b/.github/workflows/build_esp32.yml
@@ -78,6 +78,7 @@ jobs:
         - 'espressif_esp32s3_eye'
         - 'lilygo_ttgo_tbeam_s3'
         - 'lolin_s3'
+        - 'm5stack_atoms3_lite'
         - 'smartbeedesigns_bee_motion_s3'
         - 'smartbeedesigns_bee_s3'
         - 'unexpectedmaker_feathers3'

--- a/ports/espressif/boards/m5stack_atoms3_lite/board.cmake
+++ b/ports/espressif/boards/m5stack_atoms3_lite/board.cmake
@@ -1,0 +1,2 @@
+# Apply board specific content here
+set(IDF_TARGET "esp32s3")

--- a/ports/espressif/boards/m5stack_atoms3_lite/board.h
+++ b/ports/espressif/boards/m5stack_atoms3_lite/board.h
@@ -1,0 +1,69 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 CDarius
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef M5STACK_ATOMS3_LITE_H_
+#define M5STACK_ATOMS3_LITE_H_
+
+//--------------------------------------------------------------------+
+// Button
+//--------------------------------------------------------------------+
+
+// Enter UF2 mode if GPIO is pressed while 2nd stage bootloader indicator
+// is on e.g RGB = Purple. If it is GPIO0, user should not hold this while
+// reset since that will instead run the 1st stage ROM bootloader
+#define PIN_BUTTON_UF2        41
+
+// GPIO that implement 1-bit memory with RC components which hold the
+// pin value long enough for double reset detection.
+//#define PIN_DOUBLE_RESET_RC   41
+
+//--------------------------------------------------------------------+
+// LED
+//--------------------------------------------------------------------+
+
+// GPIO connected to Neopixel data
+#define NEOPIXEL_PIN          35
+
+// Brightness percentage from 1 to 255
+#define NEOPIXEL_BRIGHTNESS   0x10
+
+// Number of neopixels
+#define NEOPIXEL_NUMBER       1
+
+//--------------------------------------------------------------------+
+// USB UF2
+//--------------------------------------------------------------------+
+
+#define USB_VID                  0x303A
+#define USB_PID                  0x8160
+
+#define USB_MANUFACTURER         "M5Stack"
+#define USB_PRODUCT              "AtomS3 Lite"
+
+#define UF2_PRODUCT_NAME         USB_MANUFACTURER " " USB_PRODUCT
+#define UF2_BOARD_ID             "ESP32S3-AtomS3-01"
+#define UF2_VOLUME_LABEL         "ATOMS3BOOT"
+#define UF2_INDEX_URL            "https://shop.m5stack.com/products/atoms3-lite-esp32s3-dev-kit" 
+
+#endif

--- a/ports/espressif/boards/m5stack_atoms3_lite/sdkconfig
+++ b/ports/espressif/boards/m5stack_atoms3_lite/sdkconfig
@@ -1,0 +1,7 @@
+# Board Specific Config
+
+# Partition Table
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-8MB.csv"
+
+# Serial flasher config
+CONFIG_ESPTOOLPY_FLASHSIZE_8MB=y


### PR DESCRIPTION
## Description of Change
Add [M5Stack AtomS3 Lite](https://shop.m5stack.com/products/atoms3-lite-esp32s3-dev-kit) board
VID & PID comes from EspressIf pids repository: [commit](https://github.com/espressif/usb-pids/commit/b5aee454d64b1266796a8ebf40eb36c8f796ff45)
