### PR TITLE
SUKU use 'app' type field instead of numeric 0

### DIFF
--- a/ports/espressif/partitions-8MB.csv
+++ b/ports/espressif/partitions-8MB.csv
@@ -4,7 +4,7 @@
 # partition table,,         0x8000, 4K
 nvs,      data, nvs,      0x9000,  20K,
 otadata,  data, ota,      0xe000,  8K,
-ota_0,    0,    ota_0,   0x10000,  2048K,
-ota_1,    0,    ota_1,  0x210000,  2048K,
+ota_0,    app,    ota_0,   0x10000,  2048K,
+ota_1,    app,    ota_1,  0x210000,  2048K,
 uf2,      app,  factory,0x410000,  256K,
 ffat,     data, fat,    0x450000,  3776K,


### PR DESCRIPTION


## Checklist

*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

- [ ] Please provide specific title of the PR describing the change
- [ ] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
exposed-by-bootloaders)

-----------

## Description of Change

use 'app' instead of 0, change should not effect functionality, however makes partition table more consistent with the espressif docs!

https://docs.espressif.com/projects/esp-idf/en/v4.1.4/api-guides/partition-tables.html#type-field

Please describe your proposed Pull Request and it's impact.
