### PR TITLE
pull request for new esp32s3 dev board 

### DIFF
--- a/.github/workflows/build_esp32.yml
+++ b/.github/workflows/build_esp32.yml
@@ -73,6 +73,7 @@ jobs:
         - 'adafruit_qtpy_esp32s3'
         - 'bpi_leaf_s3'
         - 'bpi_picow_s3'
+        - 'circuitart_zero_s3'
         - 'cytron_maker_feather_aiot_s3'
         - 'deneyap_kart_1a_v2'
         - 'espressif_esp32s3_box'

--- a/ports/espressif/boards/circuitart_zero_s3/board.cmake
+++ b/ports/espressif/boards/circuitart_zero_s3/board.cmake
@@ -1,0 +1,2 @@
+# Apply board specific content here
+set(IDF_TARGET "esp32s3")

--- a/ports/espressif/boards/circuitart_zero_s3/board.h
+++ b/ports/espressif/boards/circuitart_zero_s3/board.h
@@ -1,0 +1,109 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef CIRCUITART_ZERO_S3_H_
+#define CIRCUITART_ZERO_S3_H_
+
+//--------------------------------------------------------------------+
+// Button
+//--------------------------------------------------------------------+
+
+// Enter UF2 mode if GPIO is pressed while 2nd stage bootloader indicator
+// is on e.g RGB = Purple. If it is GPIO0, user should not hold this while
+// reset since that will instead run the 1st stage ROM bootloader
+#define PIN_BUTTON_UF2        0
+
+// GPIO that implement 1-bit memory with RC components which hold the
+// pin value long enough for double reset detection.
+#define PIN_DOUBLE_RESET_RC   45
+
+//--------------------------------------------------------------------+
+// LED
+//--------------------------------------------------------------------+
+
+// GPIO connected to Neopixel data
+#define NEOPIXEL_PIN          3
+
+// Brightness percentage from 1 to 255
+#define NEOPIXEL_BRIGHTNESS   0x10
+
+// Number of neopixels
+#define NEOPIXEL_NUMBER       1
+
+// LED for indicator and writing flash
+// If not defined neopixel will be use for flash writing instead
+//#define LED_PIN               46
+//#define LED_STATE_ON          1
+
+//--------------------------------------------------------------------+
+// TFT
+//--------------------------------------------------------------------+
+
+#define CONFIG_LCD_TYPE_ST7789V
+
+#define DISPLAY_PIN_MISO      -1 // required if use CONFIG_LCD_TYPE_AUTO
+#define DISPLAY_PIN_MOSI      35
+#define DISPLAY_PIN_SCK       36
+
+#define DISPLAY_PIN_CS        39
+#define DISPLAY_PIN_DC        38
+#define DISPLAY_PIN_RST       4
+
+#define DISPLAY_PIN_BL        46
+#define DISPLAY_BL_ON          0  // GPIO state to enable back light
+
+//#define DISPLAY_PIN_POWER      -1
+//#define DISPLAY_POWER_ON       0  // GPIO state to enable TFT
+
+#define DISPLAY_WIDTH         320
+#define DISPLAY_HEIGHT        172
+
+#define DISPLAY_COL_OFFSET    53
+#define DISPLAY_ROW_OFFSET    40
+
+// Memory Data Access Control & // Vertical Scroll Start Address
+#define DISPLAY_MADCTL        (TFT_MADCTL_MX)
+#define DISPLAY_VSCSAD        0
+
+#define DISPLAY_TITLE         "Zero S3 TFT"
+
+//--------------------------------------------------------------------+
+// USB UF2
+//--------------------------------------------------------------------+
+
+#define USB_VID                  0x303A
+#define USB_PID                  0x80DC
+
+#define USB_MANUFACTURER         "CircuiArt"
+#define USB_PRODUCT              "ZeroS3"
+
+#define UF2_PRODUCT_NAME         USB_MANUFACTURER " " USB_PRODUCT
+#define UF2_BOARD_ID             "ESP32S3-Zero-R1"
+#define UF2_VOLUME_LABEL         "ZEROS3BOOT"
+#define UF2_INDEX_URL            "https://github.com/CircuitART"
+
+// Use favicon
+#define TINYUF2_FAVICON_HEADER   "favicon_adafruit_256.h"
+
+#endif

--- a/ports/espressif/boards/circuitart_zero_s3/board.h
+++ b/ports/espressif/boards/circuitart_zero_s3/board.h
@@ -53,8 +53,8 @@
 
 // LED for indicator and writing flash
 // If not defined neopixel will be use for flash writing instead
-//#define LED_PIN               46
-//#define LED_STATE_ON          1
+#define LED_PIN               46
+#define LED_STATE_ON          1
 
 //--------------------------------------------------------------------+
 // TFT
@@ -67,10 +67,10 @@
 #define DISPLAY_PIN_SCK       36
 
 #define DISPLAY_PIN_CS        39
-#define DISPLAY_PIN_DC        38
+#define DISPLAY_PIN_DC        5
 #define DISPLAY_PIN_RST       4
 
-#define DISPLAY_PIN_BL        46
+#define DISPLAY_PIN_BL        18
 #define DISPLAY_BL_ON          0  // GPIO state to enable back light
 
 //#define DISPLAY_PIN_POWER      -1
@@ -79,8 +79,8 @@
 #define DISPLAY_WIDTH         320
 #define DISPLAY_HEIGHT        172
 
-#define DISPLAY_COL_OFFSET    53
-#define DISPLAY_ROW_OFFSET    40
+#define DISPLAY_COL_OFFSET    34
+#define DISPLAY_ROW_OFFSET    0
 
 // Memory Data Access Control & // Vertical Scroll Start Address
 #define DISPLAY_MADCTL        (TFT_MADCTL_MX)
@@ -102,8 +102,5 @@
 #define UF2_BOARD_ID             "ESP32S3-Zero-R1"
 #define UF2_VOLUME_LABEL         "ZEROS3BOOT"
 #define UF2_INDEX_URL            "https://github.com/CircuitART"
-
-// Use favicon
-#define TINYUF2_FAVICON_HEADER   "favicon_adafruit_256.h"
 
 #endif

--- a/ports/espressif/boards/circuitart_zero_s3/sdkconfig
+++ b/ports/espressif/boards/circuitart_zero_s3/sdkconfig
@@ -1,0 +1,7 @@
+# Board Specific Config
+
+# Partition Table
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-16MB.csv"
+
+# Serial flasher config
+CONFIG_ESPTOOLPY_FLASHSIZE_16MB=y


### PR DESCRIPTION
link to VID/PID 
https://github.com/espressif/usb-pids

USB_VID = 0x303A - USB_PID = 0x80DC | CircuitArt FeatherS3 - UF2 Bootloader

board has been added to /.github/workflows 

UF2 board id info
#define UF2_BOARD_ID             "ESP32S3-Zero-R1"
#define UF2_VOLUME_LABEL         "ZEROS3BOOT"
#define UF2_INDEX_URL            "https://github.com/CircuitART"