### PR TITLE
SUKU use 'app' type field instead of numeric 0 (16MB partition table)

### DIFF
--- a/ports/espressif/partitions-16MB.csv
+++ b/ports/espressif/partitions-16MB.csv
@@ -4,7 +4,7 @@
 # partition table,,         0x8000, 4K
 nvs,      data, nvs,      0x9000,  20K,
 otadata,  data, ota,      0xe000,  8K,
-ota_0,    0,    ota_0,   0x10000,  2048K,
-ota_1,    0,    ota_1,  0x210000,  2048K,
+ota_0,    app,  ota_0,   0x10000,  2048K,
+ota_1,    app,  ota_1,  0x210000,  2048K,
 uf2,      app,  factory,0x410000,  256K,
 ffat,     data, fat,    0x450000,  11968K,


### PR DESCRIPTION
same as #308 but for 16MB partition table