### PR TITLE
SUKU use 'app' type field instead of numeric 0 (4MB partition table)

### DIFF
--- a/ports/espressif/partitions-4MB.csv
+++ b/ports/espressif/partitions-4MB.csv
@@ -5,7 +5,7 @@
 
 nvs,      data, nvs,      0x9000,  20K,
 otadata,  data, ota,      0xe000,  8K,
-ota_0,    0,    ota_0,   0x10000,  1408K,
-ota_1,    0,    ota_1,  0x170000,  1408K,
+ota_0,    app,  ota_0,   0x10000,  1408K,
+ota_1,    app,  ota_1,  0x170000,  1408K,
 uf2,      app,  factory,0x2d0000,  256K,
 ffat,     data, fat,    0x310000,  960K,


### PR DESCRIPTION
same as #308 but for 4MB partition table