### PR TITLE
M5stack atoms3

### DIFF
--- a/.github/workflows/build_esp32.yml
+++ b/.github/workflows/build_esp32.yml
@@ -82,6 +82,7 @@ jobs:
         - 'espressif_esp32s3_eye'
         - 'lilygo_ttgo_tbeam_s3'
         - 'lolin_s3'
+        - 'm5stack_atoms3'
         - 'm5stack_atoms3_lite'
         - 'smartbeedesigns_bee_motion_s3'
         - 'smartbeedesigns_bee_s3'

--- a/ports/espressif/boards/m5stack_atoms3/board.cmake
+++ b/ports/espressif/boards/m5stack_atoms3/board.cmake
@@ -1,0 +1,2 @@
+# Apply board specific content here
+set(IDF_TARGET "esp32s3")

--- a/ports/espressif/boards/m5stack_atoms3/board.h
+++ b/ports/espressif/boards/m5stack_atoms3/board.h
@@ -49,7 +49,7 @@
 #define USB_PRODUCT              "AtomS3"
 
 #define UF2_PRODUCT_NAME         USB_MANUFACTURER " " USB_PRODUCT
-#define UF2_BOARD_ID             "ESP32S3-AtomS3-02"
+#define UF2_BOARD_ID             "ESP32S3-AtomS3-01"
 #define UF2_VOLUME_LABEL         "ATOMS3BOOT"
 #define UF2_INDEX_URL            "https://shop.m5stack.com/products/atoms3-dev-kit-w-0-85-inch-screen"
 

--- a/ports/espressif/boards/m5stack_atoms3/board.h
+++ b/ports/espressif/boards/m5stack_atoms3/board.h
@@ -1,0 +1,56 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 CDarius
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef M5STACK_ATOMS3_H_
+#define M5STACK_ATOMS3_H_
+
+//--------------------------------------------------------------------+
+// Button
+//--------------------------------------------------------------------+
+
+// Enter UF2 mode if GPIO is pressed while 2nd stage bootloader indicator
+// is on e.g RGB = Purple. If it is GPIO0, user should not hold this while
+// reset since that will instead run the 1st stage ROM bootloader
+#define PIN_BUTTON_UF2        41
+
+// GPIO that implement 1-bit memory with RC components which hold the
+// pin value long enough for double reset detection.
+//#define PIN_DOUBLE_RESET_RC   41
+
+//--------------------------------------------------------------------+
+// USB UF2
+//--------------------------------------------------------------------+
+
+#define USB_VID                  0x303A
+#define USB_PID                  0x8121
+
+#define USB_MANUFACTURER         "M5Stack"
+#define USB_PRODUCT              "AtomS3"
+
+#define UF2_PRODUCT_NAME         USB_MANUFACTURER " " USB_PRODUCT
+#define UF2_BOARD_ID             "ESP32S3-AtomS3-02"
+#define UF2_VOLUME_LABEL         "ATOMS3BOOT"
+#define UF2_INDEX_URL            "https://shop.m5stack.com/products/atoms3-dev-kit-w-0-85-inch-screen"
+
+#endif

--- a/ports/espressif/boards/m5stack_atoms3/sdkconfig
+++ b/ports/espressif/boards/m5stack_atoms3/sdkconfig
@@ -1,0 +1,7 @@
+# Board Specific Config
+
+# Partition Table
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-8MB.csv"
+
+# Serial flasher config
+CONFIG_ESPTOOLPY_FLASHSIZE_8MB=y

--- a/ports/espressif/boards/m5stack_atoms3_lite/board.h
+++ b/ports/espressif/boards/m5stack_atoms3_lite/board.h
@@ -62,7 +62,7 @@
 #define USB_PRODUCT              "AtomS3 Lite"
 
 #define UF2_PRODUCT_NAME         USB_MANUFACTURER " " USB_PRODUCT
-#define UF2_BOARD_ID             "ESP32S3-AtomS3-01"
+#define UF2_BOARD_ID             "ESP32S3-AtomS3Lite-01"
 #define UF2_VOLUME_LABEL         "ATOMS3BOOT"
 #define UF2_INDEX_URL            "https://shop.m5stack.com/products/atoms3-lite-esp32s3-dev-kit" 
 


### PR DESCRIPTION
## Description of Change

Add [M5Stack AtomS3 ](https://shop.m5stack.com/products/atoms3-dev-kit-w-0-85-inch-screen) board
VID & PID comes from EspressIf pids repository
Also fixed UF2_BOARD_ID for AtomS3 Lite board. Now IDs are:

- AtomS3 Lite -> ESP32S3-AtomS3Lite-01
- AtomS3 -> ESP32S3-AtomS3-01