### PR TITLE
Minor alignment of STM32L4 port

### DIFF
--- a/ports/stm32l4/Makefile
+++ b/ports/stm32l4/Makefile
@@ -1,58 +1,12 @@
-UF2_FAMILY_ID = 0x00ff6919
-CROSS_COMPILE = arm-none-eabi-
-
-ST_HAL_DRIVER = lib/st/stm32l4xx_hal_driver
-ST_CMSIS = lib/st/cmsis_device_l4
-CMSIS_5 = lib/CMSIS_5
-
 # List of git submodules that is included as part of the UF2 version
 GIT_SUBMODULES = st/cmsis_device_l4 st/stm32l4xx_hal_driver tinyusb
 
 include ../make.mk
-
-# Port Compiler Flags
-CFLAGS += \
-  -flto \
-  -mthumb \
-  -mabi=aapcs \
-  -mcpu=cortex-m4 \
-  -mfloat-abi=hard \
-  -mfpu=fpv4-sp-d16 \
-  -nostdlib -nostartfiles \
-  -DCFG_TUSB_MCU=OPT_MCU_STM32L4
-
-# suppress warning caused by vendor mcu driver
-CFLAGS += -Wno-error=cast-align -Wno-error=unused-parameter
-
-LD_FILES ?= $(PORT_DIR)/linker/stm32l4.ld
-
-# Port source
-PORT_SRC_C += \
-	$(addprefix $(CURRENT_PATH)/, $(wildcard *.c)) \
-	$(ST_CMSIS)/Source/Templates/system_stm32l4xx.c \
-	$(ST_HAL_DRIVER)/Src/stm32l4xx_hal.c \
-	$(ST_HAL_DRIVER)/Src/stm32l4xx_hal_cortex.c \
-	$(ST_HAL_DRIVER)/Src/stm32l4xx_hal_rcc.c \
-	$(ST_HAL_DRIVER)/Src/stm32l4xx_hal_gpio.c \
-	$(ST_HAL_DRIVER)/Src/stm32l4xx_hal_flash.c \
-	$(ST_HAL_DRIVER)/Src/stm32l4xx_hal_flash_ex.c \
-	$(ST_HAL_DRIVER)/Src/stm32l4xx_hal_pwr_ex.c \
-	$(ST_HAL_DRIVER)/Src/stm32l4xx_hal_rcc.c \
-	$(ST_HAL_DRIVER)/Src/stm32l4xx_hal_rcc_ex.c \
-	$(ST_HAL_DRIVER)/Src/stm32l4xx_hal_uart.c
-
-SRC_C += \
-	$(PORT_SRC_C) \
-	lib/tinyusb/src/portable/synopsys/dwc2/dcd_dwc2.c \
-	
-# Port include
-INC += \
-	$(TOP)/$(CMSIS_5)/CMSIS/Core/Include \
-	$(TOP)/$(ST_CMSIS)/Include \
-	$(TOP)/$(ST_HAL_DRIVER)/Inc
-
+include port.mk
 include ../rules.mk
 
-#-------------- Self-update  --------------
+#------------------------------------------
+# Self-update
+#------------------------------------------
 self-update:
 	@echo "not implemented yet"

--- a/ports/stm32l4/README.md
+++ b/ports/stm32l4/README.md
@@ -1,8 +1,17 @@
 # TinyUF2 for STM32L4
 
-TinyUF2 reserved 64KB for compatible with eixisting application e.g ciruitpython, even though TinyUF2 actual binary size is much smaller (less than 32KB). Therefore application should start at `0x08010000`.
+TinyUF2 reserved 64KB for compatible with existing application e.g CiruitPython, even though TinyUF2 actual binary size is much smaller (less than 32KB). Therefore application should start at `0x08010000`.
 
 To create a UF2 image from a .bin file, either use family option `STM32L4` or its magic number as follows:
+
+From hex
+
+```
+uf2conv.py -c -f 0x00ff6919 firmware.hex
+uf2conv.py -c -f STM32L4 firmware.hex
+```
+
+From bin
 
 ```
 uf2conv.py -c -b 0x08010000 -f STM32L4 firmware.bin

--- a/ports/stm32l4/boards.h
+++ b/ports/stm32l4/boards.h
@@ -39,6 +39,8 @@
 #define BOARD_FLASH_APP_START   0x08010000
 #endif
 
+#define BOARD_PAGE_SIZE 0x1000
+
 // Double Reset tap to enter DFU
 #define TINYUF2_DFU_DOUBLE_TAP  1
 

--- a/ports/stm32l4/port.mk
+++ b/ports/stm32l4/port.mk
@@ -1,0 +1,49 @@
+UF2_FAMILY_ID = 0x00ff6919
+CROSS_COMPILE = arm-none-eabi-
+
+ST_HAL_DRIVER = lib/st/stm32l4xx_hal_driver
+ST_CMSIS = lib/st/cmsis_device_l4
+CMSIS_5 = lib/CMSIS_5
+
+# Port Compiler Flags
+CFLAGS += \
+  -flto \
+  -mthumb \
+  -mabi=aapcs \
+  -mcpu=cortex-m4 \
+  -mfloat-abi=hard \
+  -mfpu=fpv4-sp-d16 \
+  -nostdlib -nostartfiles \
+  -DCFG_TUSB_MCU=OPT_MCU_STM32L4
+
+# suppress warning caused by vendor mcu driver
+CFLAGS += -Wno-error=cast-align -Wno-error=unused-parameter
+
+# default linker file
+LD_FILES ?= $(PORT_DIR)/linker/stm32l4.ld
+
+# Port source
+SRC_C += \
+	ports/stm32l4/boards.c \
+	ports/stm32l4/board_flash.c \
+	$(ST_CMSIS)/Source/Templates/system_stm32l4xx.c \
+	$(ST_HAL_DRIVER)/Src/stm32l4xx_hal.c \
+	$(ST_HAL_DRIVER)/Src/stm32l4xx_hal_cortex.c \
+	$(ST_HAL_DRIVER)/Src/stm32l4xx_hal_rcc.c \
+	$(ST_HAL_DRIVER)/Src/stm32l4xx_hal_gpio.c \
+	$(ST_HAL_DRIVER)/Src/stm32l4xx_hal_flash.c \
+	$(ST_HAL_DRIVER)/Src/stm32l4xx_hal_flash_ex.c \
+	$(ST_HAL_DRIVER)/Src/stm32l4xx_hal_pwr_ex.c \
+	$(ST_HAL_DRIVER)/Src/stm32l4xx_hal_rcc.c \
+	$(ST_HAL_DRIVER)/Src/stm32l4xx_hal_rcc_ex.c \
+	$(ST_HAL_DRIVER)/Src/stm32l4xx_hal_uart.c
+
+ifndef BUILD_NO_TINYUSB
+SRC_C += lib/tinyusb/src/portable/synopsys/dwc2/dcd_dwc2.c
+endif
+
+# Port include
+INC += \
+	$(TOP)/$(CMSIS_5)/CMSIS/Core/Include \
+	$(TOP)/$(ST_CMSIS)/Include \
+	$(TOP)/$(ST_HAL_DRIVER)/Inc


### PR DESCRIPTION
## Description of Change

STM32L4 support has been mentioned a few times on the QMK Discord. Eventually targeting single-bank MCU like the STM32L432, there are a few assumptions on flash layout to unpick. 

Before submitting those changes, I figured it was worth a pass to tidy a few areas up so that its more consistent with the F3 and F4 port.