### PR TITLE
correct usb pid for qt s3 n4r2

### DIFF
--- a/ports/espressif/boards/adafruit_qtpy_esp32s3_n4r2/board.h
+++ b/ports/espressif/boards/adafruit_qtpy_esp32s3_n4r2/board.h
@@ -65,10 +65,10 @@
 //--------------------------------------------------------------------+
 
 #define USB_VID                  0x239A
-#define USB_PID                  0x0119 // TODO may need update
+#define USB_PID                  0x0143
 
 #define USB_MANUFACTURER         "Adafruit"
-#define USB_PRODUCT              "QT Py ESP32-S3"
+#define USB_PRODUCT              "QT Py ESP32-S3 (4M Flash, 2M PSRAM)"
 
 #define UF2_PRODUCT_NAME         USB_MANUFACTURER " " USB_PRODUCT
 #define UF2_BOARD_ID             "ESP32S3-QTPy-N4R2-A"

--- a/src/usb_descriptors.c
+++ b/src/usb_descriptors.c
@@ -171,7 +171,7 @@ char const* string_desc_arr [] =
   "HF2 WebUSB"
 };
 
-static uint16_t _desc_str[32+1];
+static uint16_t _desc_str[48+1];
 
 // Invoked when received GET STRING DESCRIPTOR request
 // Application return pointer to descriptor, whose contents must exist long enough for transfer to complete
@@ -215,14 +215,15 @@ uint16_t const* tud_descriptor_string_cb(uint8_t index, uint16_t langid)
       // Convert ASCII string into UTF-16
       if ( !(index < sizeof(string_desc_arr)/sizeof(string_desc_arr[0])) ) return NULL;
 
+      uint16_t const max_count = (sizeof(_desc_str)/sizeof(_desc_str[0])) - 1;
+
       const char* str = string_desc_arr[index];
+      chr_count = strlen(str);
 
       // Cap at max char
-      chr_count = strlen(str);
-      if ( chr_count > 31 ) chr_count = 31;
+      if ( chr_count > max_count ) chr_count = max_count;
 
-      for(uint8_t i=0; i<chr_count; i++)
-      {
+      for(uint8_t i=0; i<chr_count; i++) {
         _desc_str[1+i] = str[i];
       }
     }


### PR DESCRIPTION
- increase max desc string count to 48 chars
- also update usb product for better matches

```
Bus 001 Device 082: ID 239a:0143 Adafruit QT Py ESP32-S3 (4M Flash, 2M PSRAM)
```
