### PR TITLE
SUKU run the GPIO detection at least once even if UF2_DETECTION_DELAY…

### DIFF
--- a/ports/espressif/components/bootloader/subproject/main/bootloader_start.c
+++ b/ports/espressif/components/bootloader/subproject/main/bootloader_start.c
@@ -233,9 +233,10 @@ static int selected_boot_partition(const bootloader_state_t *bs)
             esp_rom_gpio_pad_select_gpio(PIN_BUTTON_UF2);
             PIN_INPUT_ENABLE(GPIO_PIN_MUX_REG[PIN_BUTTON_UF2]);
             esp_rom_gpio_pad_pullup_only(PIN_BUTTON_UF2);
-
+            
+            // run the GPIO detection at least once even if UF2_DETECTION_DELAY_MS is set to zero
             uint32_t tm_start = esp_log_early_timestamp();
-            while (UF2_DETECTION_DELAY_MS > (esp_log_early_timestamp() - tm_start) )
+            do
             {
               if ( gpio_ll_get_level(&GPIO, PIN_BUTTON_UF2) == 0 )
               {
@@ -246,6 +247,7 @@ static int selected_boot_partition(const bootloader_state_t *bs)
                 break;
               }
             }
+            while (UF2_DETECTION_DELAY_MS > (esp_log_early_timestamp() - tm_start) );
           }
 
 #if PIN_DOUBLE_RESET_RC


### PR DESCRIPTION
## Description of Change
- UF2_DETECTION_DELAY_MS is useful to allow ESP32 boards that only have a button on BOOT0 pin to use both ROM bootloader and UF2 bootloader.
- If however the board uses separate gpio for UF2 detect button, then this just slows down the boot procedure. I this case I wanted to set UF2_DETECTION_DELAY_MS to zero so that uf2 bootloader is only activated if the button was pressed before power on!
- In the gpio detection logic the while statement never evaluated true because more than 0 ms has already passed, making it impossible to enter bootloader mode!
- Do ... while syntax allows the detection logic to run at least once regardless of the UF2_DETECTION_DELAY_MS value!