### PR TITLE
Add M5Stack AtomS3U

### DIFF
--- a/.github/workflows/build_esp32.yml
+++ b/.github/workflows/build_esp32.yml
@@ -90,6 +90,7 @@ jobs:
         - 'lolin_s3'
         - 'm5stack_atoms3'
         - 'm5stack_atoms3_lite'
+        - 'm5stack_atoms3u'
         - 'seeed_xiao_esp32s3'
         - 'smartbeedesigns_bee_motion_s3'
         - 'smartbeedesigns_bee_s3'

--- a/ports/espressif/boards/m5stack_atoms3u/board.cmake
+++ b/ports/espressif/boards/m5stack_atoms3u/board.cmake
@@ -1,0 +1,2 @@
+# Apply board specific content here
+set(IDF_TARGET "esp32s3")

--- a/ports/espressif/boards/m5stack_atoms3u/board.h
+++ b/ports/espressif/boards/m5stack_atoms3u/board.h
@@ -1,0 +1,69 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 Elviss Kustans
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef M5STACK_ATOMS3U_H_
+#define M5STACK_ATOMS3U_H_
+
+//--------------------------------------------------------------------+
+// Button
+//--------------------------------------------------------------------+
+
+// Enter UF2 mode if GPIO is pressed while 2nd stage bootloader indicator
+// is on e.g RGB = Purple. If it is GPIO0, user should not hold this while
+// reset since that will instead run the 1st stage ROM bootloader
+#define PIN_BUTTON_UF2        41
+
+// GPIO that implement 1-bit memory with RC components which hold the
+// pin value long enough for double reset detection.
+//#define PIN_DOUBLE_RESET_RC   41
+
+//--------------------------------------------------------------------+
+// LED
+//--------------------------------------------------------------------+
+
+// GPIO connected to Neopixel data
+#define NEOPIXEL_PIN          35
+
+// Brightness percentage from 1 to 255
+#define NEOPIXEL_BRIGHTNESS   0x10
+
+// Number of neopixels
+#define NEOPIXEL_NUMBER       1
+
+//--------------------------------------------------------------------+
+// USB UF2
+//--------------------------------------------------------------------+
+
+#define USB_VID                  0x303A
+#define USB_PID                  0x8188
+
+#define USB_MANUFACTURER         "M5Stack"
+#define USB_PRODUCT              "AtomS3U"
+
+#define UF2_PRODUCT_NAME         USB_MANUFACTURER " " USB_PRODUCT
+#define UF2_BOARD_ID             "ESP32S3-AtomS3U-01"
+#define UF2_VOLUME_LABEL         "ATOMS3UBOOT"
+#define UF2_INDEX_URL            "https://docs.m5stack.com/en/core/AtomS3U" 
+
+#endif

--- a/ports/espressif/boards/m5stack_atoms3u/sdkconfig
+++ b/ports/espressif/boards/m5stack_atoms3u/sdkconfig
@@ -1,0 +1,7 @@
+# Board Specific Config
+
+# Partition Table
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-8MB.csv"
+
+# Serial flasher config
+CONFIG_ESPTOOLPY_FLASHSIZE_8MB=y


### PR DESCRIPTION
## Checklist

*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

- [x] Please provide specific title of the PR describing the change
- [x] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
- [x] If you are adding an new boards, please make sure
  - [x] Provide link to your allocated VID/PID if applicable
  - [x] Add your board to [action ci](/.github/workflows) in correct workflow and alphabet order for release binary
  - [x] `UF2_BOARD_ID` in your board.h follow correct format from [uf2 specs](https://github.com/microsoft/uf2#files-exposed-by-bootloaders)

*This checklist items that are not applicable to your PR can be deleted.*

-----------

## Description of Change

Add M5Stack AtomS3U board. It is similar to [AtomS3 Lite board](https://github.com/adafruit/tinyuf2/tree/master/ports/espressif/boards/m5stack_atoms3_lite) that is already added and share same controller and basic pinout (button and LED).

USB IDs taken from https://github.com/espressif/usb-pids/blob/60f612f5e2e177104382a009e7b787fc463c18d1/allocated-pids.txt#L400C3-L400C7

Datasheet: https://docs.m5stack.com/en/core/AtomS3U

I am not associated with M5Stack.
