### PR TITLE
Update  bpi_leaf_s3

### DIFF
--- a/ports/espressif/boards/bpi_leaf_s3/board.h
+++ b/ports/espressif/boards/bpi_leaf_s3/board.h
@@ -36,7 +36,7 @@
 
 // GPIO that implement 1-bit memory with RC components which hold the
 // pin value long enough for double reset detection.
-// #define PIN_DOUBLE_RESET_RC
+#define PIN_DOUBLE_RESET_RC   34
 
 //--------------------------------------------------------------------+
 // LED


### PR DESCRIPTION
New BPI-Leaf-S3 v1.1 version support double-clicking the reset button to enter the UF2 bootloader.
