### PR TITLE
add board magiclick_s3_n4r2  &  display gc9107

### DIFF
--- a/.github/workflows/build_esp32.yml
+++ b/.github/workflows/build_esp32.yml
@@ -92,6 +92,7 @@ jobs:
         - 'm5stack_atoms3'
         - 'm5stack_atoms3_lite'
         - 'm5stack_atoms3u'
+        - 'magiclick_s3_n4r2'
         - 'seeed_xiao_esp32s3'
         - 'smartbeedesigns_bee_motion_s3'
         - 'smartbeedesigns_bee_s3'

--- a/ports/espressif/boards/magiclick_s3_n4r2/board.cmake
+++ b/ports/espressif/boards/magiclick_s3_n4r2/board.cmake
@@ -1,0 +1,2 @@
+# Apply board specific content here
+set(IDF_TARGET "esp32s3")

--- a/ports/espressif/boards/magiclick_s3_n4r2/board.h
+++ b/ports/espressif/boards/magiclick_s3_n4r2/board.h
@@ -1,0 +1,110 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MAGICLICK_S3_N4R2_H_
+#define MAGICLICK_S3_N4R2_H_
+
+//--------------------------------------------------------------------+
+// Button
+//--------------------------------------------------------------------+
+
+// Enter UF2 mode if GPIO is pressed while 2nd stage bootloader indicator
+// is on e.g RGB = Purple. If it is GPIO0, user should not hold this while
+// reset since that will instead run the 1st stage ROM bootloader
+#define PIN_BUTTON_UF2        0
+
+// GPIO that implement 1-bit memory with RC components which hold the
+// pin value long enough for double reset detection.
+#define PIN_DOUBLE_RESET_RC   6
+
+//--------------------------------------------------------------------+
+// LED
+//--------------------------------------------------------------------+
+
+// GPIO connected to Neopixel data
+#define NEOPIXEL_PIN          17
+
+// #define NEOPIXEL_POWER_PIN    -1
+#define NEOPIXEL_POWER_STATE  1
+
+// Brightness percentage from 1 to 255
+#define NEOPIXEL_BRIGHTNESS   0x10
+
+// Number of neopixels
+#define NEOPIXEL_NUMBER       2
+
+// LED for indicator and writing flash
+// If not defined neopixel will be use for flash writing instead
+// #define LED_PIN               -1
+#define LED_STATE_ON          1
+
+//--------------------------------------------------------------------+
+// TFT
+//--------------------------------------------------------------------+
+
+#define CONFIG_LCD_TYPE_GC9107
+
+#define DISPLAY_PIN_MISO      -1 // required if use CONFIG_LCD_TYPE_AUTO
+#define DISPLAY_PIN_MOSI      4
+#define DISPLAY_PIN_SCK       5
+
+#define DISPLAY_PIN_CS         9
+#define DISPLAY_PIN_DC        38
+#define DISPLAY_PIN_RST       10
+
+#define DISPLAY_PIN_BL        37
+#define DISPLAY_BL_ON          1  // GPIO state to enable back light
+
+// #define DISPLAY_PIN_POWER     -1
+#define DISPLAY_POWER_ON       1  // GPIO state to enable TFT
+
+#define DISPLAY_WIDTH         128
+#define DISPLAY_HEIGHT        128
+
+#define DISPLAY_COL_OFFSET    1
+#define DISPLAY_ROW_OFFSET    2
+
+// Memory Data Access Control & // Vertical Scroll Start Address
+#define DISPLAY_MADCTL        (TFT_MADCTL_MX | TFT_MADCTL_MY | TFT_MADCTL_MV  |TFT_MADCTL_BGR)
+#define DISPLAY_VSCSAD        0
+
+#define DISPLAY_TITLE         "MagiClick S3 "
+
+//--------------------------------------------------------------------+
+// USB UF2
+//--------------------------------------------------------------------+
+
+#define USB_VID                  0x303A
+#define USB_PID                  0x81AC
+
+#define USB_MANUFACTURER         "MakerM0"
+#define USB_PRODUCT              "MagiClick S3"
+
+#define UF2_PRODUCT_NAME         USB_MANUFACTURER " " USB_PRODUCT
+#define UF2_BOARD_ID             "MagiClick-S3-revA"
+#define UF2_VOLUME_LABEL         "MAGICS3BOOT"
+#define UF2_INDEX_URL            "https://github.com/MakerM0/MagiClick-esp32s3"
+
+
+#endif

--- a/ports/espressif/boards/magiclick_s3_n4r2/board.h
+++ b/ports/espressif/boards/magiclick_s3_n4r2/board.h
@@ -102,7 +102,7 @@
 #define USB_PRODUCT              "MagiClick S3"
 
 #define UF2_PRODUCT_NAME         USB_MANUFACTURER " " USB_PRODUCT
-#define UF2_BOARD_ID             "MagiClick-S3-revA"
+#define UF2_BOARD_ID             "ESP32S3-MagiClick-revA"
 #define UF2_VOLUME_LABEL         "MAGICS3BOOT"
 #define UF2_INDEX_URL            "https://github.com/MakerM0/MagiClick-esp32s3"
 

--- a/ports/espressif/boards/magiclick_s3_n4r2/sdkconfig
+++ b/ports/espressif/boards/magiclick_s3_n4r2/sdkconfig
@@ -1,0 +1,7 @@
+# Board Specific Config
+
+# Partition Table
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-4MB.csv"
+
+# Serial flasher config
+CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y

--- a/ports/espressif/components/lcd/include/lcd.h
+++ b/ports/espressif/components/lcd/include/lcd.h
@@ -39,6 +39,7 @@ typedef struct {
 typedef enum {
     LCD_TYPE_ILI = 1,
     LCD_TYPE_ST,
+    LCD_TYPE_GC,
     LCD_TYPE_MAX,
 } type_lcd_t;
 

--- a/ports/espressif/components/lcd/lcd.c
+++ b/ports/espressif/components/lcd/lcd.c
@@ -344,7 +344,7 @@ esp_err_t lcd_init(spi_device_handle_t spi)
     if (lcd_type == LCD_TYPE_ST) {
         ESP_LOGI(TAG, "ST7789V initialization.");
         lcd_init_cmds = st_init_cmds;
-    else if(lcd_type == LCD_TYPE_GC){
+    } else if(lcd_type == LCD_TYPE_GC) {
         ESP_LOGI(TAG, "GC9107 initialization.");
         lcd_init_cmds = gc_init_cmds;    
     } else {

--- a/ports/espressif/components/lcd/lcd.c
+++ b/ports/espressif/components/lcd/lcd.c
@@ -154,6 +154,46 @@ DRAM_ATTR static const lcd_init_cmd_t ili_init_cmds[] = {
     {0, {0}, 0xff},
 };
 
+//GC9107
+DRAM_ATTR static const lcd_init_cmd_t gc_init_cmds[] = {
+
+    //  {0xfe, {0}, 0x80},
+    //   {0xef, {0}, 0x80},
+    /* Interface Pixel Format, 16bits/pixel for RGB/MCU interface */
+    {0xB0,   {0xC0},1},
+    {0xB2,   {0x2F},1},
+    {0xB3,   {0x03},1},
+    {0xB6,   {0x19},1},
+    {0xB7,   {0x01},1},  
+    {0xAC,   {0xCB},1},
+    {0xAB,   {0x0e},1},     
+    {0xB4,   {0x04},1},  
+    {0xA8,   {0x19},1},
+    {0x3A,   {0x05},1},
+    // Memory Data Access Control
+    {0x36, {DISPLAY_MADCTL}, 1},
+    // Vertical Scroll Start Address of RAM
+    // {0x37, {DISPLAY_VSCSAD >> 8, DISPLAY_VSCSAD & 0x00FF}, 2},
+
+    {0xb8,   {0x08},1},
+    {0xE8,   {0x24},1},
+    {0xE9,   {0x48},1},
+    {0xea,   {0x22},1},               
+    {0xC6,   {0x30},1},
+    {0xC7,   {0x18},1},
+    /* Positive Voltage Gamma Control */
+    {0xF0, {0x1F, 0x28, 0x04, 0x3E, 0x2A, 0x2E, 0x20, 0x00, 0x0C, 0x06, 0x00, 0x1C, 0x1F, 0x0F}, 14},
+    /* Negative Voltage Gamma Control */
+    {0xF1, {0x00, 0x2D, 0x2F, 0x3C, 0x6F, 0x1C, 0x0B, 0x00, 0x00, 0x00, 0x07, 0x0D, 0x11, 0x0F}, 14},
+    // Inversion ON
+    {0x21, {0}, 0x00},
+    /* Sleep Out */
+    {0x11, {0}, 0x80},
+    /* Display On */
+    {0x29, {0}, 0x80},
+    {0, {0}, 0xff}
+};
+
 static void lcd_cmd(spi_device_handle_t spi, const uint8_t cmd)
 {
     esp_err_t ret;
@@ -295,11 +335,18 @@ esp_err_t lcd_init(spi_device_handle_t spi)
     ESP_LOGI(TAG, "kconfig: force CONFIG_LCD_TYPE_ILI9341.");
     lcd_type = LCD_TYPE_ILI;
 
+#elif defined( CONFIG_LCD_TYPE_GC9107 )
+    ESP_LOGI(TAG, "kconfig: force CONFIG_LCD_TYPE_GC9107.");
+    lcd_type = LCD_TYPE_GC;
+
 #endif
 
     if (lcd_type == LCD_TYPE_ST) {
         ESP_LOGI(TAG, "ST7789V initialization.");
         lcd_init_cmds = st_init_cmds;
+    else if(lcd_type == LCD_TYPE_GC){
+        ESP_LOGI(TAG, "GC9107 initialization.");
+        lcd_init_cmds = gc_init_cmds;    
     } else {
         ESP_LOGI(TAG, "ILI9341 initialization.");
         lcd_init_cmds = ili_init_cmds;
@@ -377,14 +424,24 @@ void lcd_draw_lines(spi_device_handle_t spi, int ypos, uint16_t *linedata)
     trans[0].tx_data[0] = 0x2A;         /*!< Column Address Set */
     trans[1].tx_data[0] = (DISPLAY_COL_OFFSET) >> 8;            /*!< Start Col High */
     trans[1].tx_data[1] = (DISPLAY_COL_OFFSET) & 0xff;            /*!< Start Col Low */
+    #if defined( CONFIG_LCD_TYPE_GC9107 )
+    trans[1].tx_data[2] = (DISPLAY_HEIGHT+DISPLAY_COL_OFFSET-1) >> 8;   /*!< End Col High */
+    trans[1].tx_data[3] = (DISPLAY_HEIGHT+DISPLAY_COL_OFFSET-1) & 0xff; /*!< End Col Low */
+    #else
     trans[1].tx_data[2] = (320) >> 8;   /*!< End Col High */
     trans[1].tx_data[3] = (320) & 0xff; /*!< End Col Low */
+    #endif
 
     trans[2].tx_data[0] = 0x2B;         /*!< Page address set */
     trans[3].tx_data[0] = ypos >> 8;    /*!< Start page high */
     trans[3].tx_data[1] = ypos & 0xff;  /*!< start page low */
+    #if defined( CONFIG_LCD_TYPE_GC9107 )
+    trans[3].tx_data[2] = (ypos + PARALLEL_LINES-1) >> 8; /*!< end page high */
+    trans[3].tx_data[3] = (ypos + PARALLEL_LINES-1) & 0xff; /*!< end page low */
+    #else
     trans[3].tx_data[2] = (ypos + PARALLEL_LINES) >> 8; /*!< end page high */
     trans[3].tx_data[3] = (ypos + PARALLEL_LINES) & 0xff; /*!< end page low */
+    #endif
 
     trans[4].tx_data[0] = 0x2C;         /*!< memory write */
     trans[5].tx_buffer = linedata;      /*!< finally send the line data */


### PR DESCRIPTION
## Checklist

- [x] Please provide specific title of the PR describing the change
- [x] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
- [x] If you are adding an new boards, please make sure
  - [x] Provide link to your allocated VID/PID if applicable
  - [x] Add your board to [action ci](/.github/workflows) in correct workflow and alphabet order for release binary
  - [x] `UF2_BOARD_ID` in your board.h follow correct format from [uf2 specs](https://github.com/microsoft/uf2#files-exposed-by-bootloaders)



-----------

## Description of Change
add display gc9107
add board magiclick_s3_n4r2


[Board Repo](https://github.com/MakerM0/MagiClick-esp32s3)

[VID&PID](https://github.com/espressif/usb-pids/blob/60f612f5e2e177104382a009e7b787fc463c18d1/allocated-pids.txt#L436)
 

![屏幕截图 27-09-2023 13 41 36](https://github.com/adafruit/tinyuf2/assets/117961102/c96b4df3-0c4c-4ced-9f50-6db2da934fcf)

