### PR TITLE
minor update of ESP32-S3 BSP for LilyGO T-TWR Plus v2.x

### DIFF
--- a/ports/espressif/boards/lilygo_ttgo_t_twr_plus/board.cpp
+++ b/ports/espressif/boards/lilygo_ttgo_t_twr_plus/board.cpp
@@ -141,8 +141,10 @@ extern "C" bool board_init_extension()
     PMU.setDC1Voltage(3300); // WROOM, OLED
     PMU.enableDC1();
 
-    PMU.setDC3Voltage(3400); // SA868, NeoPixel
+    PMU.setDC3Voltage(3400);   // V2.0 - SA868, NeoPixel
     PMU.enableDC3();
+    PMU.setALDO3Voltage(3300); // V2.1 - SA868, NeoPixel
+    PMU.enableALDO3();
 
     /* no power for GNSS and/or Mic at this moment */
 


### PR DESCRIPTION
## Checklist

*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

- [x] Please provide specific title of the PR describing the change

-----------

## Description of Change

Upcoming revision V2.1 of the LilyGO T-TWR board uses a little bit different NeoPixel power enable signal.
This PR makes the TinyUF2 bootloader to be compatible both with version 2.0 and version 2.1 of the product.