### PR TITLE
esp23 fix README.md reboot_to_uf2

### DIFF
--- a/ports/espressif/README.md
+++ b/ports/espressif/README.md
@@ -76,8 +76,7 @@ There are a few ways to enter UF2 mode:
 
     // call esp_reset_reason() is required for idf.py to properly links esp_reset_reason_set_hint()
     (void) esp_reset_reason();
-    esp_reset_reason_set_hint(
-        static_cast<esp_reset_reason_t>(APP_REQUEST_UF2_RESET_HINT));
+    esp_reset_reason_set_hint((esp_reset_reason_t)APP_REQUEST_UF2_RESET_HINT);
     esp_restart();
   }
   ```

--- a/ports/espressif/README.md
+++ b/ports/espressif/README.md
@@ -76,7 +76,8 @@ There are a few ways to enter UF2 mode:
 
     // call esp_reset_reason() is required for idf.py to properly links esp_reset_reason_set_hint()
     (void) esp_reset_reason();
-    esp_reset_reason_set_hint(APP_REQUEST_UF2_RESET_HINT);
+    esp_reset_reason_set_hint(
+        static_cast<esp_reset_reason_t>(APP_REQUEST_UF2_RESET_HINT));
     esp_restart();
   }
   ```


### PR DESCRIPTION
## Description of Change

*fixes* the example in the *usage* section in the README.md for the expressif borads - 
as at least i needed a static cast to `esp_reset_reason_t` to compile cleanly..
