### PR TITLE
Only show purple waiting color on led if UF2_DETECTION_DELAY_MS is not zero

### DIFF
--- a/ports/espressif/components/bootloader/subproject/main/bootloader_start.c
+++ b/ports/espressif/components/bootloader/subproject/main/bootloader_start.c
@@ -202,9 +202,9 @@ static int selected_boot_partition(const bootloader_state_t *bs) {
         // UF2: check if GPIO0 is pressed and/or 1-bit RC on specific GPIO detect double reset
         // during this time. If yes then to load uf2 "bootloader".
         if ( boot_index != FACTORY_INDEX ) {
-          board_led_on();
 
 #ifdef PIN_DOUBLE_RESET_RC
+          board_led_on();
           // Double reset detect if board implements 1-bit memory with RC components
           esp_rom_gpio_pad_select_gpio(PIN_DOUBLE_RESET_RC);
           PIN_INPUT_ENABLE(GPIO_PIN_MUX_REG[PIN_DOUBLE_RESET_RC]);
@@ -218,6 +218,12 @@ static int selected_boot_partition(const bootloader_state_t *bs) {
           }
 #endif
           if ( boot_index != FACTORY_INDEX ) {
+
+            // Only turn the default purple waiting color on if there is actualy waiting will happen
+            if (UF2_DETECTION_DELAY_MS > 0){
+              board_led_on();
+            }
+            
             esp_rom_gpio_pad_select_gpio(PIN_BUTTON_UF2);
             PIN_INPUT_ENABLE(GPIO_PIN_MUX_REG[PIN_BUTTON_UF2]);
             esp_rom_gpio_pad_pullup_only(PIN_BUTTON_UF2);

--- a/ports/espressif/components/bootloader/subproject/main/bootloader_start.c
+++ b/ports/espressif/components/bootloader/subproject/main/bootloader_start.c
@@ -202,24 +202,23 @@ static int selected_boot_partition(const bootloader_state_t *bs) {
         // UF2: check if GPIO0 is pressed and/or 1-bit RC on specific GPIO detect double reset
         // during this time. If yes then to load uf2 "bootloader".
         if ( boot_index != FACTORY_INDEX ) {
-
 #ifdef PIN_DOUBLE_RESET_RC
-          board_led_on();
           // Double reset detect if board implements 1-bit memory with RC components
           esp_rom_gpio_pad_select_gpio(PIN_DOUBLE_RESET_RC);
           PIN_INPUT_ENABLE(GPIO_PIN_MUX_REG[PIN_DOUBLE_RESET_RC]);
           if ( gpio_ll_get_level(&GPIO, PIN_DOUBLE_RESET_RC) == 1 ) {
+            // RC pin is already high, double reset detected
             ESP_LOGI(TAG, "Detect double reset using RC on GPIO %d to enter UF2 bootloader", PIN_DOUBLE_RESET_RC);
             boot_index = FACTORY_INDEX;
           }
           else {
+            // Set to high to charge the RC, indicating we are in reset
             gpio_ll_output_enable(&GPIO, PIN_DOUBLE_RESET_RC);
             gpio_ll_set_level(&GPIO, PIN_DOUBLE_RESET_RC, 1);
-          }
+#else
+          {
 #endif
-          if ( boot_index != FACTORY_INDEX ) {
-
-            // Only turn the default purple waiting color on if there is actually waiting happening
+            // turn led on if there is actually waiting
             if (UF2_DETECTION_DELAY_MS > 0){
               board_led_on();
             }
@@ -239,14 +238,16 @@ static int selected_boot_partition(const bootloader_state_t *bs) {
                 break;
               }
             } while (UF2_DETECTION_DELAY_MS > (esp_log_early_timestamp() - tm_start) );
+
+            board_led_off();
           }
 
 #if PIN_DOUBLE_RESET_RC
+          // Set to low to discharge the RC
+          gpio_ll_output_enable(&GPIO, PIN_DOUBLE_RESET_RC);
           gpio_ll_set_level(&GPIO, PIN_DOUBLE_RESET_RC, 0);
           gpio_ll_output_disable(&GPIO, PIN_DOUBLE_RESET_RC);
 #endif
-
-          board_led_off();
         }
 
         // Customer implementation.

--- a/ports/espressif/components/bootloader/subproject/main/bootloader_start.c
+++ b/ports/espressif/components/bootloader/subproject/main/bootloader_start.c
@@ -219,11 +219,11 @@ static int selected_boot_partition(const bootloader_state_t *bs) {
 #endif
           if ( boot_index != FACTORY_INDEX ) {
 
-            // Only turn the default purple waiting color on if there is actualy waiting will happen
+            // Only turn the default purple waiting color on if there is actually waiting happening
             if (UF2_DETECTION_DELAY_MS > 0){
               board_led_on();
             }
-            
+
             esp_rom_gpio_pad_select_gpio(PIN_BUTTON_UF2);
             PIN_INPUT_ENABLE(GPIO_PIN_MUX_REG[PIN_BUTTON_UF2]);
             esp_rom_gpio_pad_pullup_only(PIN_BUTTON_UF2);


### PR DESCRIPTION
## Description of Change

UF2_DETECTION_DELAY_MS can be set to zero when PIN_BUTTON_UF2 is not GPIO0 on ESP32. This causes the board to boot application firmware instantly if the PIN_BUTTON_UF2 is not pulled low by pressing the boot button. The problem is that the RGB LEDs still turn purple momentarily indicating that the bootloader is waiting for button press. This causes unwanted flash of the LEDs.  In this PR code skips board_led_on() is only called if UF2_DETECTION_DELAY_MS>0 condition is met!

Please note that for compatibility reasons if PIN_DOUBLE_RESET_RC is defined then board_led_on() will always be called regardless of UF2_DETECTION_DELAY_MS!