### PR TITLE
Add lolin s3 mini

### DIFF
--- a/.github/workflows/build_esp32.yml
+++ b/.github/workflows/build_esp32.yml
@@ -105,6 +105,7 @@ jobs:
         - 'lilygo_ttgo_t_twr_plus'
         - 'lilygo_ttgo_tbeam_s3'
         - 'lolin_s3'
+        - 'lolin_s3_mini'
         - 'm5stack_atoms3'
         - 'm5stack_atoms3_lite'
         - 'm5stack_atoms3u'

--- a/ports/espressif/boards/lolin_s3_mini/board.cmake
+++ b/ports/espressif/boards/lolin_s3_mini/board.cmake
@@ -1,0 +1,2 @@
+# Apply board specific content here
+set(IDF_TARGET "esp32s3")

--- a/ports/espressif/boards/lolin_s3_mini/board.h
+++ b/ports/espressif/boards/lolin_s3_mini/board.h
@@ -1,0 +1,64 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef LOLIN_S3_MINI_H_
+#define LOLIN_S3_MINI_H_
+
+//--------------------------------------------------------------------+
+// Button
+//--------------------------------------------------------------------+
+
+// Enter UF2 mode if GPIO is pressed while 2nd stage bootloader indicator
+// is on e.g RGB = Purple. If it is GPIO0, user should not hold this while
+// reset since that will instead run the 1st stage ROM bootloader
+#define PIN_BUTTON_UF2        0
+
+//--------------------------------------------------------------------+
+// LED
+//--------------------------------------------------------------------+
+
+// GPIO connected to Neopixel data
+#define NEOPIXEL_PIN          47
+
+// Brightness percentage from 1 to 255
+#define NEOPIXEL_BRIGHTNESS   0x10
+
+// Number of neopixels
+#define NEOPIXEL_NUMBER       1
+
+//--------------------------------------------------------------------+
+// USB UF2
+//--------------------------------------------------------------------+
+
+#define USB_VID           0x303A
+#define USB_PID           0x8169
+#define USB_MANUFACTURER  "Lolin"
+#define USB_PRODUCT       "S3Mini"
+
+#define UF2_PRODUCT_NAME  USB_MANUFACTURER " " USB_PRODUCT
+#define UF2_BOARD_ID      "ESP32S3FH4R2-S3Mini-1-0-0"
+#define UF2_VOLUME_LABEL  "LOLIN3MBOOT"
+#define UF2_INDEX_URL     "https://www.wemos.cc/en/latest/s3/s3_mini.html"
+
+#endif

--- a/ports/espressif/boards/lolin_s3_mini/sdkconfig
+++ b/ports/espressif/boards/lolin_s3_mini/sdkconfig
@@ -1,0 +1,7 @@
+# Board Specific Config
+
+# Partition Table
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-4MB.csv"
+
+# Serial flasher config
+CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y


### PR DESCRIPTION


## Description of Change

Add support for Lolin S2-Mini board
PID was already allocated in Espressif USB-PIDS repository
0x8169 | LOLIN S3 Mini - UF2 Bootloader