### PR TITLE
Fix backlight, reset entering uf2 and correct branding info for M5Stamp S3

### DIFF
--- a/ports/espressif/boards/m5stack_stamps3/board.h
+++ b/ports/espressif/boards/m5stack_stamps3/board.h
@@ -69,7 +69,7 @@
 #define DISPLAY_PIN_BL        45
 #define DISPLAY_BL_ON          1  // GPIO state to enable back light
 
-#define DISPLAY_PIN_POWER     21
+#define DISPLAY_PIN_POWER     38
 #define DISPLAY_POWER_ON       1  // GPIO state to enable TFT
 
 #define DISPLAY_WIDTH         240
@@ -82,7 +82,7 @@
 #define DISPLAY_MADCTL        (TFT_MADCTL_MX)
 #define DISPLAY_VSCSAD        0
 
-#define DISPLAY_TITLE         "M5 Stamp S3 TFT"
+#define DISPLAY_TITLE         "M5Stamp S3 TFT"
 
 //--------------------------------------------------------------------+
 // USB UF2
@@ -91,7 +91,7 @@
 #define USB_VID                  0x303A
 #define USB_PID                  0x811A
 
-#define USB_MANUFACTURER         "M5"
+#define USB_MANUFACTURER         "M5Stamp"
 #define USB_PRODUCT              "Stamp S3"
 
 #define UF2_PRODUCT_NAME         USB_MANUFACTURER " " USB_PRODUCT

--- a/ports/espressif/boards/m5stack_stamps3/board.h
+++ b/ports/espressif/boards/m5stack_stamps3/board.h
@@ -82,7 +82,7 @@
 #define DISPLAY_MADCTL        (TFT_MADCTL_MX)
 #define DISPLAY_VSCSAD        0
 
-#define DISPLAY_TITLE         "M5Stamp S3 TFT"
+#define DISPLAY_TITLE         "M5Stamp S3"
 
 //--------------------------------------------------------------------+
 // USB UF2
@@ -91,7 +91,7 @@
 #define USB_VID                  0x303A
 #define USB_PID                  0x811A
 
-#define USB_MANUFACTURER         "M5Stamp"
+#define USB_MANUFACTURER         "M5Stack"
 #define USB_PRODUCT              "Stamp S3"
 
 #define UF2_PRODUCT_NAME         USB_MANUFACTURER " " USB_PRODUCT

--- a/ports/espressif/boards/m5stack_stamps3/board.h
+++ b/ports/espressif/boards/m5stack_stamps3/board.h
@@ -37,7 +37,7 @@
 
 // GPIO that implement 1-bit memory with RC components which hold the
 // pin value long enough for double reset detection.
-#define PIN_DOUBLE_RESET_RC   38
+//#define PIN_DOUBLE_RESET_RC
 
 //--------------------------------------------------------------------+
 // LED


### PR DESCRIPTION
## Checklist

*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

- [x] Please provide specific title of the PR describing the change
- [x] Please provide related links (*eg. Issue which will be closed by this Pull Request*)

*This checklist items that are not applicable to your PR can be deleted.*

-----------

## Description of Change

Fixes.
The stamp is used for the cardputer. Testing on that.
Under circuitpython the panel works correctly, but not under uf2, this PR fixes that.
When sending a reset, the board sometimes entered uf2 mode, this is fixed by disabling double reset.
Additionally improved the branding a bit cuz it annoys me seeing wrong info.