### PR TITLE
Added 3 new Unexpected Maker boards

### DIFF
--- a/ports/espressif/boards/unexpectedmaker_omgs3/board.cmake
+++ b/ports/espressif/boards/unexpectedmaker_omgs3/board.cmake
@@ -1,0 +1,2 @@
+# Apply board specific content here
+set(IDF_TARGET "esp32s3")

--- a/ports/espressif/boards/unexpectedmaker_omgs3/board.h
+++ b/ports/espressif/boards/unexpectedmaker_omgs3/board.h
@@ -1,0 +1,71 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef UNEXPECTEDMAKER_OMGS3_H_
+#define UNEXPECTEDMAKER_OMGS3_H_
+
+//--------------------------------------------------------------------+
+// Button
+//--------------------------------------------------------------------+
+
+// Enter UF2 mode if GPIO is pressed while 2nd stage bootloader indicator
+// is on e.g RGB = Purple. If it is GPIO0, user should not hold this while
+// reset since that will instead run the 1st stage ROM bootloader
+#define PIN_BUTTON_UF2 0
+
+// GPIO that implement 1-bit memory with RC components which hold the
+// pin value long enough for double reset detection.
+// #define PIN_DOUBLE_RESET_RC   47
+
+//--------------------------------------------------------------------+
+// LED
+//--------------------------------------------------------------------+
+
+// GPIO connected to Neopixel data
+#define NEOPIXEL_PIN 35
+
+#define NEOPIXEL_POWER_PIN 34
+#define NEOPIXEL_POWER_STATE 1
+
+// Brightness percentage from 1 to 255
+#define NEOPIXEL_BRIGHTNESS 0x64
+
+// Number of neopixels
+#define NEOPIXEL_NUMBER 1
+
+//--------------------------------------------------------------------+
+// USB UF2
+//--------------------------------------------------------------------+
+
+#define USB_VID 0x303A
+#define USB_PID 0x8226
+#define USB_MANUFACTURER "Unexpected Maker"
+#define USB_PRODUCT "OMGS3"
+
+#define UF2_PRODUCT_NAME USB_MANUFACTURER " " USB_PRODUCT
+#define UF2_BOARD_ID "ESP32S3-OMGS3-01"
+#define UF2_VOLUME_LABEL "OMGS3BOOT"
+#define UF2_INDEX_URL "https://circuitpython.org/board/unexpectedmaker_omgs3/"
+
+#endif

--- a/ports/espressif/boards/unexpectedmaker_omgs3/sdkconfig
+++ b/ports/espressif/boards/unexpectedmaker_omgs3/sdkconfig
@@ -1,0 +1,7 @@
+# Board Specific Config
+
+# Partition Table
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-8MB.csv"
+
+# Serial flasher config
+CONFIG_ESPTOOLPY_FLASHSIZE_8MB=y

--- a/ports/espressif/boards/unexpectedmaker_rgbtouch_mini/board.cmake
+++ b/ports/espressif/boards/unexpectedmaker_rgbtouch_mini/board.cmake
@@ -1,0 +1,2 @@
+# Apply board specific content here
+set(IDF_TARGET "esp32s3")

--- a/ports/espressif/boards/unexpectedmaker_rgbtouch_mini/board.h
+++ b/ports/espressif/boards/unexpectedmaker_rgbtouch_mini/board.h
@@ -1,0 +1,72 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef UNEXPECTEDMAKER_RGBTOUCHMINI_H_
+#define UNEXPECTEDMAKER_RGBTOUCHMINI_H_
+
+//--------------------------------------------------------------------+
+// Button
+//--------------------------------------------------------------------+
+
+// Enter UF2 mode if GPIO is pressed while 2nd stage bootloader indicator
+// is on e.g RGB = Purple. If it is GPIO0, user should not hold this while
+// reset since that will instead run the 1st stage ROM bootloader
+#define PIN_BUTTON_UF2 0
+
+// GPIO that implement 1-bit memory with RC components which hold the
+// pin value long enough for double reset detection.
+// #define PIN_DOUBLE_RESET_RC 47
+
+//--------------------------------------------------------------------+
+// LED
+//--------------------------------------------------------------------+
+
+// GPIO connected to Neopixel data
+#define NEOPIXEL_PIN 39
+
+#define NEOPIXEL_POWER_PIN 38
+#define NEOPIXEL_POWER_STATE 1
+
+// Brightness percentage from 1 to 255
+#define NEOPIXEL_BRIGHTNESS 0x64
+
+// Number of neopixels
+#define NEOPIXEL_NUMBER 1
+
+//--------------------------------------------------------------------+
+// USB UF2
+//--------------------------------------------------------------------+
+
+#define USB_VID 0x303A
+#define USB_PID 0x8200
+#define USB_MANUFACTURER "Unexpected Maker"
+#define USB_PRODUCT "RGB Touch Mini"
+
+#define UF2_PRODUCT_NAME USB_MANUFACTURER " " USB_PRODUCT
+#define UF2_BOARD_ID "ESP32S3-RGBTouch-01"
+#define UF2_VOLUME_LABEL "RGBTMBOOT"
+#define UF2_INDEX_URL                                                          \
+  "https://circuitpython.org/board/unexpectedmaker_rgbtouch_mini/"
+
+#endif

--- a/ports/espressif/boards/unexpectedmaker_rgbtouch_mini/sdkconfig
+++ b/ports/espressif/boards/unexpectedmaker_rgbtouch_mini/sdkconfig
@@ -1,0 +1,7 @@
+# Board Specific Config
+
+# Partition Table
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-8MB.csv"
+
+# Serial flasher config
+CONFIG_ESPTOOLPY_FLASHSIZE_8MB=y

--- a/ports/espressif/boards/unexpectedmaker_tinywatchs3/board.cmake
+++ b/ports/espressif/boards/unexpectedmaker_tinywatchs3/board.cmake
@@ -1,0 +1,2 @@
+# Apply board specific content here
+set(IDF_TARGET "esp32s3")

--- a/ports/espressif/boards/unexpectedmaker_tinywatchs3/board.h
+++ b/ports/espressif/boards/unexpectedmaker_tinywatchs3/board.h
@@ -1,0 +1,72 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef UNEXPECTEDMAKER_TINYWATCHS3_H_
+#define UNEXPECTEDMAKER_TINYWATCHS3_H_
+
+//--------------------------------------------------------------------+
+// Button
+//--------------------------------------------------------------------+
+
+// Enter UF2 mode if GPIO is pressed while 2nd stage bootloader indicator
+// is on e.g RGB = Purple. If it is GPIO0, user should not hold this while
+// reset since that will instead run the 1st stage ROM bootloader
+#define PIN_BUTTON_UF2 0
+
+// GPIO that implement 1-bit memory with RC components which hold the
+// pin value long enough for double reset detection.
+// #define PIN_DOUBLE_RESET_RC 47
+
+//--------------------------------------------------------------------+
+// LED
+//--------------------------------------------------------------------+
+
+// GPIO connected to Neopixel data
+// #define NEOPIXEL_PIN 18
+
+// #define NEOPIXEL_POWER_PIN 17
+// #define NEOPIXEL_POWER_STATE 1
+
+// Brightness percentage from 1 to 255
+#define NEOPIXEL_BRIGHTNESS 0x64
+
+// Number of neopixels
+#define NEOPIXEL_NUMBER 0
+
+//--------------------------------------------------------------------+
+// USB UF2
+//--------------------------------------------------------------------+
+
+#define USB_VID 0x303A
+#define USB_PID 0x81B2
+#define USB_MANUFACTURER "Unexpected Maker"
+#define USB_PRODUCT "TinyWATCHS3"
+
+#define UF2_PRODUCT_NAME USB_MANUFACTURER " " USB_PRODUCT
+#define UF2_BOARD_ID "ESP32S3-TinyWATCHS3-01"
+#define UF2_VOLUME_LABEL "TWS3BOOT"
+#define UF2_INDEX_URL                                                          \
+  "https://circuitpython.org/board/unexpectedmaker_tinyswatchs3/"
+
+#endif

--- a/ports/espressif/boards/unexpectedmaker_tinywatchs3/sdkconfig
+++ b/ports/espressif/boards/unexpectedmaker_tinywatchs3/sdkconfig
@@ -1,0 +1,7 @@
+# Board Specific Config
+
+# Partition Table
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-8MB.csv"
+
+# Serial flasher config
+CONFIG_ESPTOOLPY_FLASHSIZE_8MB=y


### PR DESCRIPTION
Added my new OMGS3
Added my new RGB Touch Mini
Added my TinyWATCH S3

TinyWATCH S3 doesn't have a status LED or RGB LED, so I commented out the DATA and POWER pins, and set the number of RGB LEDs to 0.

I hope that is the correct way to handle this use case. It seems to work ok, but I am not sure if there's an alternate way to handle no status LED.

PIDs/VID supplied by Espressif