### PR TITLE
prevent S3 enumerated as USB JTAG while waiting for 2nd reset

### DIFF
--- a/.github/actions/setup_toolchain/action.yml
+++ b/.github/actions/setup_toolchain/action.yml
@@ -4,8 +4,8 @@ inputs:
   toolchain:
     description: 'Toolchain name'
     required: true
-  toolchain_url:
-    description: 'Toolchain URL or version'
+  toolchain_version:
+    description: 'Toolchain version'
     required: false
 
 outputs:
@@ -28,7 +28,26 @@ runs:
       uses: ./.github/actions/setup_toolchain/espressif
       with:
         toolchain: ${{ inputs.toolchain }}
-        toolchain_url: ${{ inputs.toolchain_url }}
+        toolchain_version: ${{ inputs.toolchain_version }}
+
+    - name: Get Toolchain URL
+      if: >-
+        inputs.toolchain != 'arm-gcc' &&
+        inputs.toolchain != 'arm-iar' &&
+        inputs.toolchain != 'esp-idf'
+      id: set-toolchain-url
+      run: |
+        TOOLCHAIN_JSON='{
+          "aarch64-gcc": "https://developer.arm.com/-/media/Files/downloads/gnu-a/10.3-2021.07/binrel/gcc-arm-10.3-2021.07-x86_64-aarch64-none-elf.tar.xz",
+          "arm-clang": "https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases/download/release-17.0.1/LLVMEmbeddedToolchainForArm-17.0.1-Linux-x86_64.tar.xz",
+          "msp430-gcc": "http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPGCC/9_2_0_0/export/msp430-gcc-9.2.0.50_linux64.tar.bz2",
+          "riscv-gcc": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/xpack-riscv-none-elf-gcc-13.2.0-2-linux-x64.tar.gz",
+          "rx-gcc": "http://gcc-renesas.com/downloads/get.php?f=rx/8.3.0.202004-gnurx/gcc-8.3.0.202004-GNURX-ELF.run"
+        }'
+        TOOLCHAIN_URL=$(echo $TOOLCHAIN_JSON | jq -r '.["${{ inputs.toolchain }}"]')
+        echo "toolchain_url=$TOOLCHAIN_URL"
+        echo "toolchain_url=$TOOLCHAIN_URL" >> $GITHUB_OUTPUT
+      shell: bash
 
     - name: Download Toolchain
       if: >-
@@ -38,4 +57,4 @@ runs:
       uses: ./.github/actions/setup_toolchain/download
       with:
         toolchain: ${{ inputs.toolchain }}
-        toolchain_url: ${{ inputs.toolchain_url }}
+        toolchain_url: ${{ steps.set-toolchain-url.outputs.toolchain_url }}

--- a/.github/actions/setup_toolchain/espressif/action.yml
+++ b/.github/actions/setup_toolchain/espressif/action.yml
@@ -4,8 +4,8 @@ inputs:
   toolchain:
     description: 'Toolchain name'
     required: true
-  toolchain_url:
-    description: 'Toolchain URL or version'
+  toolchain_version:
+    description: 'Toolchain version'
     required: true
 
 runs:
@@ -22,14 +22,14 @@ runs:
       id: cache-toolchain-espressif
       with:
         path: ${{ env.DOCKER_ESP_IDF }}
-        key: ${{ inputs.toolchain }}-${{ inputs.toolchain_url }}
+        key: ${{ inputs.toolchain }}-${{ inputs.toolchain_version }}
 
     - name: Pull and Save Docker Image
       if: steps.cache-toolchain-espressif.outputs.cache-hit != 'true'
       run: |
-        docker pull espressif/idf:${{ inputs.toolchain_url }}
+        docker pull espressif/idf:${{ inputs.toolchain_version }}
         mkdir -p $(dirname $DOCKER_ESP_IDF)
-        docker save -o $DOCKER_ESP_IDF espressif/idf:${{ inputs.toolchain_url }}
+        docker save -o $DOCKER_ESP_IDF espressif/idf:${{ inputs.toolchain_version }}
         du -sh $DOCKER_ESP_IDF
       shell: bash
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,7 @@ jobs:
       boards: ${{ toJSON(fromJSON(needs.set-matrix.outputs.json)['espressif'].board) }}
       build-system: 'make'
       toolchain: 'esp-idf'
-      toolchain_url: 'v5.1.1'
+      toolchain_version: 'v5.1.4'
 
   # ---------------------------------------
   # Build RISC-V
@@ -106,7 +106,6 @@ jobs:
       boards: ${{ toJSON(fromJSON(needs.set-matrix.outputs.json)[matrix.port].board) }}
       build-system: 'make'
       toolchain: 'riscv-gcc'
-      toolchain_url: 'https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/xpack-riscv-none-elf-gcc-13.2.0-2-linux-x64.tar.gz'
 
   # ---------------------------------------
   # Unit testing with ghostfat

--- a/.github/workflows/build_ghostfat.yml
+++ b/.github/workflows/build_ghostfat.yml
@@ -45,7 +45,7 @@ jobs:
         working-directory: ports/test_ghostfat/_build/${{ matrix.board }}
 
       - name: Save newly generated self-test images as CI artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: ghostfat_selftest_images
+          name: ghostfat_${{ matrix.board }}_image
           path: ./ports/test_ghostfat/_build/${{ matrix.board }}/ghostfat_${{ matrix.board }}.img.gz.gz

--- a/.github/workflows/build_util.yml
+++ b/.github/workflows/build_util.yml
@@ -16,7 +16,7 @@ on:
       toolchain:
         required: true
         type: string
-      toolchain_url:
+      toolchain_version:
         required: false
         type: string
 
@@ -41,7 +41,7 @@ jobs:
         uses: ./.github/actions/setup_toolchain
         with:
           toolchain: ${{ inputs.toolchain }}
-          toolchain_url: ${{ inputs.toolchain_url }}
+          toolchain_version: ${{ inputs.toolchain_version }}
 
       - name: Get Dependencies
         run: |
@@ -58,7 +58,7 @@ jobs:
 
       - name: Build using ESP-IDF docker
         if: inputs.toolchain == 'esp-idf'
-        run: docker run --rm -v $PWD:/project -w /project espressif/idf:${{ inputs.toolchain_url }} /bin/bash -c "git config --global --add safe.directory /project && make -C ports/espressif/ BOARD=${{ matrix.board }} all self-update copy-artifact"
+        run: docker run --rm -v $PWD:/project -w /project espressif/idf:${{ inputs.toolchain_version }} /bin/bash -c "git config --global --add safe.directory /project && make -C ports/espressif/ BOARD=${{ matrix.board }} all self-update copy-artifact"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/ports/espressif/CMakeLists.txt
+++ b/ports/espressif/CMakeLists.txt
@@ -39,8 +39,8 @@ add_custom_command(TARGET app POST_BUILD
 # Post build: update arduino-esp32 bootloader for debug purpose
 # -------------------------------------------------------------
 if (0)
-  #set(ARDUINO_VARIANT_DIR /home/hathach/code/arduino-esp32/variants/${BOARD})
-  set(ARDUINO_VARIANT_DIR /home/hathach/code/arduino-esp32/variants/adafruit_feather_esp32s3)
+  set(ARDUINO_VARIANT_DIR $ENV{HOME}/code/arduino-esp32/variants/${BOARD})
+  #set(ARDUINO_VARIANT_DIR $ENV{HOME}/code/arduino-esp32/variants/adafruit_feather_esp32s3)
 
   add_custom_command(TARGET bootloader POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/bootloader/bootloader.bin ${ARDUINO_VARIANT_DIR}/bootloader-tinyuf2.bin

--- a/ports/espressif/CMakeLists.txt
+++ b/ports/espressif/CMakeLists.txt
@@ -40,7 +40,7 @@ add_custom_command(TARGET app POST_BUILD
 # -------------------------------------------------------------
 if (0)
   set(ARDUINO_VARIANT_DIR $ENV{HOME}/code/arduino-esp32/variants/${BOARD})
-  #set(ARDUINO_VARIANT_DIR $ENV{HOME}/code/arduino-esp32/variants/adafruit_feather_esp32s3)
+  #set(ARDUINO_VARIANT_DIR $ENV{HOME}/code/arduino-esp32/variants/adafruit_feather_esp32s3_nopsram)
 
   add_custom_command(TARGET bootloader POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/bootloader/bootloader.bin ${ARDUINO_VARIANT_DIR}/bootloader-tinyuf2.bin
@@ -48,18 +48,5 @@ if (0)
 
   add_custom_command(TARGET app POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/tinyuf2.bin ${ARDUINO_VARIANT_DIR}/tinyuf2.bin
-    )
-
-  file(STRINGS ${CMAKE_CURRENT_LIST_DIR}/boards/${BOARD}/sdkconfig SDKCONFIG_CONTENTS)
-  foreach (line ${SDKCONFIG_CONTENTS})
-    if (line MATCHES "CONFIG_PARTITION_TABLE_CUSTOM_FILENAME=\"(.*).csv\"")
-      set(PARTITION_TABLE_CSV ${CMAKE_MATCH_1})
-      cmake_print_variables(PARTITION_TABLE_CSV)
-      break()
-    endif ()
-  endforeach ()
-
-  add_custom_command(TARGET app POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_LIST_DIR}/${PARTITION_TABLE_CSV}.csv ${ARDUINO_VARIANT_DIR}/${PARTITION_TABLE_CSV}-tinyuf2.csv
     )
 endif ()

--- a/ports/espressif/README.md
+++ b/ports/espressif/README.md
@@ -2,7 +2,7 @@
 
 The project is composed of customizing the 2nd stage bootloader from IDF and UF2 factory application as 3rd stage bootloader.
 
-**Note**: IDF is actively developed and change very often, TinyUF2 is developed and tested with IDF v5.1.1. Should you have a problem please try to change your IDF version.
+**Note**: IDF is actively developed and change very often, TinyUF2 is developed and tested with IDF v5.1.4. Should you have a problem please try to change your IDF version.
 
 Following boards are supported:
 

--- a/ports/espressif/boards/boards.c
+++ b/ports/espressif/boards/boards.c
@@ -345,7 +345,7 @@ void board_timer_stop(void) {
 
 #if CONFIG_IDF_TARGET_ESP32S3
 #include "hal/usb_serial_jtag_ll.h"
-#include "hal/usb_phy_ll.h"
+#include "hal/usb_fsls_phy_ll.h"
 
 static void hw_cdc_reset_handler(void *arg) {
   portBASE_TYPE xTaskWoken = 0;
@@ -389,7 +389,7 @@ static void usb_switch_to_cdc_jtag(void) {
   gpio_set_level((gpio_num_t)USBPHY_DP_NUM, 0);
 
   // Initialize CDC+JTAG ISR to listen for BUS_RESET
-  usb_phy_ll_int_jtag_enable(&USB_SERIAL_JTAG);
+  usb_fsls_phy_ll_int_jtag_enable(&USB_SERIAL_JTAG);
   usb_serial_jtag_ll_disable_intr_mask(USB_SERIAL_JTAG_LL_INTR_MASK);
   usb_serial_jtag_ll_clr_intsts_mask(USB_SERIAL_JTAG_LL_INTR_MASK);
   usb_serial_jtag_ll_ena_intr_mask(USB_SERIAL_JTAG_INTR_BUS_RESET);

--- a/ports/espressif/boards/boards.c
+++ b/ports/espressif/boards/boards.c
@@ -446,6 +446,8 @@ void tud_cdc_line_state_cb(uint8_t instance, bool dtr, bool rts) {
       // copied from Arduino's usb_persist_restart()
       esp_register_shutdown_handler(usb_persist_shutdown_handler);
 #if CONFIG_IDF_TARGET_ESP32S3
+      // Switch to JTAG since S3 bootrom has issue with uploading with USB OTG
+      // https://github.com/espressif/arduino-esp32/issues/6762#issuecomment-1128621518
       usb_switch_to_cdc_jtag();
 #endif
       esp_restart();


### PR DESCRIPTION
This partly fixes an issue https://github.com/adafruit/Adafruit_TinyUSB_Arduino/issues/436, when S3 is enumerated as USB JTAG while waiting for 2nd reset
- only attempt to wait for 2nd reset if reset by by by power on (En/nRST pin)
- temporarily change USB phy to OTG while waiting for 2nd reset to prevent S3 is enumerated with USB JTAG.
- also bump up idf to v5.1.4 to match latest arduino-esp32 idf version
- some tweak to ci build
