### PR TITLE
update tinyusb  and switch esp32 dcd driver to use dwc2

### DIFF
--- a/ports/espressif/components/tinyusb_src/CMakeLists.txt
+++ b/ports/espressif/components/tinyusb_src/CMakeLists.txt
@@ -35,8 +35,7 @@ list(APPEND srcs
   ${tusb_src}/class/hid/hid_device.c
   ${tusb_src}/class/msc/msc_device.c
 #  ${tusb_src}/class/vendor/vendor_device.c
-  ${tusb_src}/portable/espressif/esp32sx/dcd_esp32sx.c
-  #${tusb_src}/portable/synopsys/dwc2/dcd_dwc2.c
+  ${tusb_src}/portable/synopsys/dwc2/dcd_dwc2.c
   )
 
 if (DEFINED LOG)


### PR DESCRIPTION
- switch esp32 dcd driver to use dwc2
- update tinyusb to commit 3eea46056ea20aa12b73eea7c01d6c6e5b2d490a