### PR TITLE
Add Definition for generic ESP32-S3 Super Mini Board

### DIFF
--- a/ports/espressif/boards/generic_esp32s3_super_mini/board.cmake
+++ b/ports/espressif/boards/generic_esp32s3_super_mini/board.cmake
@@ -1,0 +1,2 @@
+# Apply board specific content here
+set(IDF_TARGET "esp32s3")

--- a/ports/espressif/boards/generic_esp32s3_super_mini/board.h
+++ b/ports/espressif/boards/generic_esp32s3_super_mini/board.h
@@ -1,0 +1,74 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef GENERIC_ESP32S3_SUPER_MINI_H_
+#define GENERIC_ESP32S3_SUPER_MINI_H_
+
+//--------------------------------------------------------------------+
+// Button
+//--------------------------------------------------------------------+
+
+// Enter UF2 mode if GPIO is pressed while 2nd stage bootloader indicator
+// is on e.g RGB = Purple. If it is GPIO0, user should not hold this while
+// reset since that will instead run the 1st stage ROM bootloader
+#define PIN_BUTTON_UF2        0
+
+// GPIO that implement 1-bit memory with RC components which hold the
+// pin value long enough for double reset detection.
+// #define PIN_DOUBLE_RESET_RC
+
+//--------------------------------------------------------------------+
+// LED
+//--------------------------------------------------------------------+
+
+// GPIO connected to Neopixel data
+#define NEOPIXEL_PIN          48
+
+// Brightness percentage from 1 to 255
+#define NEOPIXEL_BRIGHTNESS   0x10
+
+// Number of neopixels
+#define NEOPIXEL_NUMBER       1
+
+
+// LED for indicator and writing flash
+// If not defined neopixel will be use for flash writing instead
+// #define LED_PIN               13
+// #define LED_STATE_ON          1
+
+//--------------------------------------------------------------------+
+// USB UF2
+//--------------------------------------------------------------------+
+
+#define USB_VID                  0x303a
+#define USB_PID                  0x8248
+#define USB_MANUFACTURER         "GENERIC"
+#define USB_PRODUCT              "ESP32-S3-Super-Mini"
+
+#define UF2_PRODUCT_NAME         USB_MANUFACTURER " " USB_PRODUCT
+#define UF2_BOARD_ID             "ESP32-S3-Super-Mini"
+#define UF2_VOLUME_LABEL         "SprMiniBoot"
+#define UF2_INDEX_URL            "https://www.nologo.tech/product/esp32/esp32s3supermini/esp32S3SuperMini.html"
+
+#endif

--- a/ports/espressif/boards/generic_esp32s3_super_mini/sdkconfig
+++ b/ports/espressif/boards/generic_esp32s3_super_mini/sdkconfig
@@ -1,0 +1,9 @@
+# Board Specific Config
+
+# Partition Table
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-4MB-noota.csv"
+
+# Serial flasher config
+CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y
+CONFIG_FLASHMODE_DIO=n
+CONFIG_FLASHMODE_QIO=y


### PR DESCRIPTION
## Checklist

*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

- [x] Please provide specific title of the PR describing the change
- [x] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
- [x] If you are adding an new boards, please make sure
  - [x] Provide link to your allocated VID/PID if applicable
  - [x] `UF2_BOARD_ID` in your board.h follow correct format from [uf2 specs](https://github.com/microsoft/uf2#files-exposed-by-bootloaders)

*This checklist items that are not applicable to your PR can be deleted.*

-----------

## Description of Change

Adds support for a generic "ESP32-S3 Super Mini" dev board.
This board can be found on Aliexpress and other chinese marketplaces, but seemingly there is no actual info on the original creator or manufacturer.

The style is similar to the C3-variant, which seems to be a clone of the waveshare ESP32-C3 Super Mini. But there is no comparible S3-Variant.

The only info I could find, that is not a direct shop page, is on [this site](https://www.nologo.tech/product/esp32/esp32s3supermini/esp32S3SuperMini.html).

Because of this I propose the "generic" term, which I also used to request a PID from the espressif usb-pid repository.
Since the [PID PR](https://github.com/espressif/usb-pids/pull/183) is not yet accepted, I opened this PR as a draft and will update accordingly, once the PID is granted.

