### PR TITLE
ports/mimxrt10xx/boards: Add board files for Seeed ARch Mix, Olimex RT1011 and Makerdiary RT1011 Nano Kit..

### DIFF
--- a/ports/mimxrt10xx/boards/arch_mix_1052/board.h
+++ b/ports/mimxrt10xx/boards/arch_mix_1052/board.h
@@ -1,0 +1,78 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Ha Thach for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+
+#ifndef BOARD_H_
+#define BOARD_H_
+
+// Size of on-board external flash
+#define BOARD_FLASH_SIZE      (8*1024*1024)
+
+//--------------------------------------------------------------------+
+// LED
+//--------------------------------------------------------------------+
+
+#define LED_PINMUX            IOMUXC_GPIO_AD_B0_09_GPIO1_IO09
+#define LED_PORT              GPIO1
+#define LED_PIN               9
+#define LED_STATE_ON          0
+
+//--------------------------------------------------------------------+
+// Neopixel
+//--------------------------------------------------------------------+
+
+// Number of neopixels
+#define NEOPIXEL_NUMBER       0
+
+//--------------------------------------------------------------------+
+// Button
+//--------------------------------------------------------------------+
+
+
+//--------------------------------------------------------------------+
+// USB UF2
+//--------------------------------------------------------------------+
+
+#define USB_VID           0x2886
+#define USB_PID           0x0010
+#define USB_MANUFACTURER  "Seeed Technology Co., Ltd."
+#define USB_PRODUCT       "RT1052 ARCH MIX"
+
+#define UF2_PRODUCT_NAME  USB_MANUFACTURER " " USB_PRODUCT
+#define UF2_BOARD_ID      "MIMXRT1052-ARCH_MIX-V1"
+#define UF2_VOLUME_LABEL  "ARCHMIXBOOT"
+#define UF2_INDEX_URL     "https://https://wiki.seeedstudio.com/Arch_Mix/"
+
+//--------------------------------------------------------------------+
+// UART
+//--------------------------------------------------------------------+
+
+#define UART_DEV              LPUART1
+#define UART_RX_PINMUX        IOMUXC_GPIO_AD_B0_13_LPUART1_RXD
+// On Rev A1 of the board this is on J31 closer to the edge.
+#define UART_TX_PINMUX        IOMUXC_GPIO_AD_B0_12_LPUART1_TXD
+
+#endif /* BOARD_H_ */

--- a/ports/mimxrt10xx/boards/arch_mix_1052/board.mk
+++ b/ports/mimxrt10xx/boards/arch_mix_1052/board.mk
@@ -1,0 +1,12 @@
+MCU = MIMXRT1052
+CFLAGS += -DCPU_MIMXRT1052DVL6B
+
+# For flash-jlink target
+JLINK_DEVICE = MIMXRT1052xxxxB
+
+# For flash-pyocd target
+PYOCD_TARGET = mimxrt1052
+
+# flash using pyocd
+flash: flash-pyocd-bin
+erase: erase-pyocd

--- a/ports/mimxrt10xx/boards/arch_mix_1052/clock_config.c
+++ b/ports/mimxrt10xx/boards/arch_mix_1052/clock_config.c
@@ -1,0 +1,934 @@
+/*
+ * Copyright 2022 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * How to setup clock using clock driver functions:
+ *
+ * 1. Call CLOCK_InitXXXPLL() to configure corresponding PLL clock.
+ *
+ * 2. Call CLOCK_InitXXXpfd() to configure corresponding PLL pfd clock.
+ *
+ * 3. Call CLOCK_SetMux() to configure corresponding clock source for target clock out.
+ *
+ * 4. Call CLOCK_SetDiv() to configure corresponding clock divider for target clock out.
+ *
+ * 5. Call CLOCK_SetXtalFreq() to set XTAL frequency based on board settings.
+ *
+ */
+
+/* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
+!!GlobalInfo
+product: Clocks v10.0
+processor: MIMXRT1052xxxxB
+package_id: MIMXRT1052DVL6B
+mcu_data: ksdk2_0
+processor_version: 0.12.10
+board: IMXRT1050-EVKB
+ * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
+
+#include "clock_config.h"
+#include "fsl_iomuxc.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+
+/*******************************************************************************
+ ************************ BOARD_InitBootClocks function ************************
+ ******************************************************************************/
+void BOARD_InitBootClocks(void)
+{
+    BOARD_BootClockRUN();
+}
+
+/*******************************************************************************
+ ********************** Configuration BOARD_BootClockRUN ***********************
+ ******************************************************************************/
+/* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
+!!Configuration
+name: BOARD_BootClockRUN
+called_from_default_init: true
+outputs:
+- {id: AHB_CLK_ROOT.outFreq, value: 600 MHz}
+- {id: CAN_CLK_ROOT.outFreq, value: 40 MHz}
+- {id: CKIL_SYNC_CLK_ROOT.outFreq, value: 32.768 kHz}
+- {id: CLK_1M.outFreq, value: 1 MHz}
+- {id: CLK_24M.outFreq, value: 24 MHz}
+- {id: CSI_CLK_ROOT.outFreq, value: 12 MHz}
+- {id: ENET_125M_CLK.outFreq, value: 2.4 MHz}
+- {id: ENET_25M_REF_CLK.outFreq, value: 1.2 MHz}
+- {id: FLEXIO1_CLK_ROOT.outFreq, value: 30 MHz}
+- {id: FLEXIO2_CLK_ROOT.outFreq, value: 30 MHz}
+- {id: FLEXSPI_CLK_ROOT.outFreq, value: 160 MHz}
+- {id: GPT1_ipg_clk_highfreq.outFreq, value: 75 MHz}
+- {id: GPT2_ipg_clk_highfreq.outFreq, value: 75 MHz}
+- {id: IPG_CLK_ROOT.outFreq, value: 150 MHz}
+- {id: LCDIF_CLK_ROOT.outFreq, value: 67.5 MHz}
+- {id: LPI2C_CLK_ROOT.outFreq, value: 60 MHz}
+- {id: LPSPI_CLK_ROOT.outFreq, value: 105.6 MHz}
+- {id: LVDS1_CLK.outFreq, value: 1.2 GHz}
+- {id: MQS_MCLK.outFreq, value: 1080/17 MHz}
+- {id: PERCLK_CLK_ROOT.outFreq, value: 75 MHz}
+- {id: PLL7_MAIN_CLK.outFreq, value: 24 MHz}
+- {id: SAI1_CLK_ROOT.outFreq, value: 1080/17 MHz}
+- {id: SAI1_MCLK1.outFreq, value: 1080/17 MHz}
+- {id: SAI1_MCLK2.outFreq, value: 1080/17 MHz}
+- {id: SAI1_MCLK3.outFreq, value: 30 MHz}
+- {id: SAI2_CLK_ROOT.outFreq, value: 1080/17 MHz}
+- {id: SAI2_MCLK1.outFreq, value: 1080/17 MHz}
+- {id: SAI2_MCLK3.outFreq, value: 30 MHz}
+- {id: SAI3_CLK_ROOT.outFreq, value: 1080/17 MHz}
+- {id: SAI3_MCLK1.outFreq, value: 1080/17 MHz}
+- {id: SAI3_MCLK3.outFreq, value: 30 MHz}
+- {id: SEMC_CLK_ROOT.outFreq, value: 75 MHz}
+- {id: SPDIF0_CLK_ROOT.outFreq, value: 30 MHz}
+- {id: TRACE_CLK_ROOT.outFreq, value: 132 MHz}
+- {id: UART_CLK_ROOT.outFreq, value: 80 MHz}
+- {id: USDHC1_CLK_ROOT.outFreq, value: 198 MHz}
+- {id: USDHC2_CLK_ROOT.outFreq, value: 198 MHz}
+settings:
+- {id: CCM.AHB_PODF.scale, value: '1', locked: true}
+- {id: CCM.ARM_PODF.scale, value: '2', locked: true}
+- {id: CCM.FLEXSPI_PODF.scale, value: '3', locked: true}
+- {id: CCM.FLEXSPI_SEL.sel, value: CCM.PLL3_SW_CLK_SEL}
+- {id: CCM.LPSPI_PODF.scale, value: '5', locked: true}
+- {id: CCM.PERCLK_PODF.scale, value: '2', locked: true}
+- {id: CCM.SEMC_PODF.scale, value: '8'}
+- {id: CCM.TRACE_CLK_SEL.sel, value: CCM_ANALOG.PLL2_MAIN_CLK}
+- {id: CCM_ANALOG.PLL1_BYPASS.sel, value: CCM_ANALOG.PLL1}
+- {id: CCM_ANALOG.PLL1_PREDIV.scale, value: '1', locked: true}
+- {id: CCM_ANALOG.PLL1_VDIV.scale, value: '50', locked: true}
+- {id: CCM_ANALOG.PLL2.denom, value: '1', locked: true}
+- {id: CCM_ANALOG.PLL2.num, value: '0', locked: true}
+- {id: CCM_ANALOG.PLL2_BYPASS.sel, value: CCM_ANALOG.PLL2_OUT_CLK}
+- {id: CCM_ANALOG.PLL2_PFD0_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD0}
+- {id: CCM_ANALOG.PLL2_PFD1_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD1}
+- {id: CCM_ANALOG.PLL2_PFD2_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD2}
+- {id: CCM_ANALOG.PLL2_PFD3_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD3}
+- {id: CCM_ANALOG.PLL3_BYPASS.sel, value: CCM_ANALOG.PLL3}
+- {id: CCM_ANALOG.PLL3_PFD0_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD0}
+- {id: CCM_ANALOG.PLL3_PFD0_DIV.scale, value: '33', locked: true}
+- {id: CCM_ANALOG.PLL3_PFD0_MUL.scale, value: '18', locked: true}
+- {id: CCM_ANALOG.PLL3_PFD1_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD1}
+- {id: CCM_ANALOG.PLL3_PFD2_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD2}
+- {id: CCM_ANALOG.PLL3_PFD3_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD3}
+- {id: CCM_ANALOG.PLL4.denom, value: '50'}
+- {id: CCM_ANALOG.PLL4.div, value: '47'}
+- {id: CCM_ANALOG.PLL5.denom, value: '1'}
+- {id: CCM_ANALOG.PLL5.div, value: '31', locked: true}
+- {id: CCM_ANALOG.PLL5.num, value: '0'}
+- {id: CCM_ANALOG.PLL5_BYPASS.sel, value: CCM_ANALOG.PLL5_POST_DIV}
+- {id: CCM_ANALOG.PLL5_POST_DIV.scale, value: '2'}
+- {id: CCM_ANALOG.VIDEO_DIV.scale, value: '4'}
+- {id: CCM_ANALOG_PLL_ENET_POWERDOWN_CFG, value: 'Yes'}
+- {id: CCM_ANALOG_PLL_USB1_POWER_CFG, value: 'Yes'}
+- {id: CCM_ANALOG_PLL_VIDEO_POWERDOWN_CFG, value: 'No'}
+sources:
+- {id: XTALOSC24M.RTC_OSC.outFreq, value: 32.768 kHz, enabled: true}
+ * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
+
+/*******************************************************************************
+ * Variables for BOARD_BootClockRUN configuration
+ ******************************************************************************/
+const clock_arm_pll_config_t armPllConfig_BOARD_BootClockRUN =
+    {
+        .loopDivider = 100,                       /* PLL loop divider, Fout = Fin * 50 */
+        .src = 0,                                 /* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+    };
+const clock_sys_pll_config_t sysPllConfig_BOARD_BootClockRUN =
+    {
+        .loopDivider = 1,                         /* PLL loop divider, Fout = Fin * ( 20 + loopDivider*2 + numerator / denominator ) */
+        .numerator = 0,                           /* 30 bit numerator of fractional loop divider */
+        .denominator = 1,                         /* 30 bit denominator of fractional loop divider */
+        .src = 0,                                 /* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+    };
+const clock_usb_pll_config_t usb1PllConfig_BOARD_BootClockRUN =
+    {
+        .loopDivider = 0,                         /* PLL loop divider, Fout = Fin * 20 */
+        .src = 0,                                 /* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+    };
+const clock_video_pll_config_t videoPllConfig_BOARD_BootClockRUN =
+    {
+        .loopDivider = 31,                        /* PLL loop divider, Fout = Fin * ( loopDivider + numerator / denominator ) */
+        .postDivider = 8,                         /* Divider after PLL */
+        .numerator = 0,                           /* 30 bit numerator of fractional loop divider, Fout = Fin * ( loopDivider + numerator / denominator ) */
+        .denominator = 1,                         /* 30 bit denominator of fractional loop divider, Fout = Fin * ( loopDivider + numerator / denominator ) */
+        .src = 0,                                 /* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+    };
+/*******************************************************************************
+ * Code for BOARD_BootClockRUN configuration
+ ******************************************************************************/
+void BOARD_BootClockRUN(void)
+{
+    /* Init RTC OSC clock frequency. */
+    CLOCK_SetRtcXtalFreq(32768U);
+    /* Enable 1MHz clock output. */
+    XTALOSC24M->OSC_CONFIG2 |= XTALOSC24M_OSC_CONFIG2_ENABLE_1M_MASK;
+    /* Use free 1MHz clock output. */
+    XTALOSC24M->OSC_CONFIG2 &= ~XTALOSC24M_OSC_CONFIG2_MUX_1M_MASK;
+    /* Set XTAL 24MHz clock frequency. */
+    CLOCK_SetXtalFreq(24000000U);
+    /* Enable XTAL 24MHz clock source. */
+    CLOCK_InitExternalClk(0);
+    /* Enable internal RC. */
+    CLOCK_InitRcOsc24M();
+    /* Switch clock source to external OSC. */
+    CLOCK_SwitchOsc(kCLOCK_XtalOsc);
+    /* Set Oscillator ready counter value. */
+    CCM->CCR = (CCM->CCR & (~CCM_CCR_OSCNT_MASK)) | CCM_CCR_OSCNT(127);
+    /* Setting PeriphClk2Mux and PeriphMux to provide stable clock before PLLs are initialed */
+    CLOCK_SetMux(kCLOCK_PeriphClk2Mux, 1); /* Set PERIPH_CLK2 MUX to OSC */
+    CLOCK_SetMux(kCLOCK_PeriphMux, 1);     /* Set PERIPH_CLK MUX to PERIPH_CLK2 */
+    /* Setting the VDD_SOC to 1.275V. It is necessary to config AHB to 600Mhz. */
+    DCDC->REG3 = (DCDC->REG3 & (~DCDC_REG3_TRG_MASK)) | DCDC_REG3_TRG(0x13);
+    /* Waiting for DCDC_STS_DC_OK bit is asserted */
+    while (DCDC_REG0_STS_DC_OK_MASK != (DCDC_REG0_STS_DC_OK_MASK & DCDC->REG0))
+    {
+    }
+    /* Set AHB_PODF. */
+    CLOCK_SetDiv(kCLOCK_AhbDiv, 0);
+    /* Disable IPG clock gate. */
+    CLOCK_DisableClock(kCLOCK_Adc1);
+    CLOCK_DisableClock(kCLOCK_Adc2);
+    CLOCK_DisableClock(kCLOCK_Xbar1);
+    CLOCK_DisableClock(kCLOCK_Xbar2);
+    CLOCK_DisableClock(kCLOCK_Xbar3);
+    /* Set IPG_PODF. */
+    CLOCK_SetDiv(kCLOCK_IpgDiv, 3);
+    /* Set ARM_PODF. */
+    CLOCK_SetDiv(kCLOCK_ArmDiv, 1);
+    /* Set PERIPH_CLK2_PODF. */
+    CLOCK_SetDiv(kCLOCK_PeriphClk2Div, 0);
+    /* Disable PERCLK clock gate. */
+    CLOCK_DisableClock(kCLOCK_Gpt1);
+    CLOCK_DisableClock(kCLOCK_Gpt1S);
+    CLOCK_DisableClock(kCLOCK_Gpt2);
+    CLOCK_DisableClock(kCLOCK_Gpt2S);
+    CLOCK_DisableClock(kCLOCK_Pit);
+    /* Set PERCLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_PerclkDiv, 1);
+    /* Disable USDHC1 clock gate. */
+    CLOCK_DisableClock(kCLOCK_Usdhc1);
+    /* Set USDHC1_PODF. */
+    CLOCK_SetDiv(kCLOCK_Usdhc1Div, 1);
+    /* Set Usdhc1 clock source. */
+    CLOCK_SetMux(kCLOCK_Usdhc1Mux, 0);
+    /* Disable USDHC2 clock gate. */
+    CLOCK_DisableClock(kCLOCK_Usdhc2);
+    /* Set USDHC2_PODF. */
+    CLOCK_SetDiv(kCLOCK_Usdhc2Div, 1);
+    /* Set Usdhc2 clock source. */
+    CLOCK_SetMux(kCLOCK_Usdhc2Mux, 0);
+    /* In SDK projects, SDRAM (configured by SEMC) will be initialized in either debug script or dcd.
+     * With this macro SKIP_SYSCLK_INIT, system pll (selected to be SEMC source clock in SDK projects) will be left unchanged.
+     * Note: If another clock source is selected for SEMC, user may want to avoid changing that clock as well.*/
+#ifndef SKIP_SYSCLK_INIT
+    /* Disable Semc clock gate. */
+    CLOCK_DisableClock(kCLOCK_Semc);
+    /* Set SEMC_PODF. */
+    CLOCK_SetDiv(kCLOCK_SemcDiv, 7);
+    /* Set Semc alt clock source. */
+    CLOCK_SetMux(kCLOCK_SemcAltMux, 0);
+    /* Set Semc clock source. */
+    CLOCK_SetMux(kCLOCK_SemcMux, 0);
+#endif
+    /* In SDK projects, external flash (configured by FLEXSPI) will be initialized by dcd.
+     * With this macro XIP_EXTERNAL_FLASH, usb1 pll (selected to be FLEXSPI clock source in SDK projects) will be left unchanged.
+     * Note: If another clock source is selected for FLEXSPI, user may want to avoid changing that clock as well.*/
+#if !(defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
+    /* Disable Flexspi clock gate. */
+    CLOCK_DisableClock(kCLOCK_FlexSpi);
+    /* Set FLEXSPI_PODF. */
+    CLOCK_SetDiv(kCLOCK_FlexspiDiv, 2);
+    /* Set Flexspi clock source. */
+    CLOCK_SetMux(kCLOCK_FlexspiMux, 1);
+#endif
+    /* Disable CSI clock gate. */
+    CLOCK_DisableClock(kCLOCK_Csi);
+    /* Set CSI_PODF. */
+    CLOCK_SetDiv(kCLOCK_CsiDiv, 1);
+    /* Set Csi clock source. */
+    CLOCK_SetMux(kCLOCK_CsiMux, 0);
+    /* Disable LPSPI clock gate. */
+    CLOCK_DisableClock(kCLOCK_Lpspi1);
+    CLOCK_DisableClock(kCLOCK_Lpspi2);
+    CLOCK_DisableClock(kCLOCK_Lpspi3);
+    CLOCK_DisableClock(kCLOCK_Lpspi4);
+    /* Set LPSPI_PODF. */
+    CLOCK_SetDiv(kCLOCK_LpspiDiv, 4);
+    /* Set Lpspi clock source. */
+    CLOCK_SetMux(kCLOCK_LpspiMux, 2);
+    /* Disable TRACE clock gate. */
+    CLOCK_DisableClock(kCLOCK_Trace);
+    /* Set TRACE_PODF. */
+    CLOCK_SetDiv(kCLOCK_TraceDiv, 3);
+    /* Set Trace clock source. */
+    CLOCK_SetMux(kCLOCK_TraceMux, 0);
+    /* Disable SAI1 clock gate. */
+    CLOCK_DisableClock(kCLOCK_Sai1);
+    /* Set SAI1_CLK_PRED. */
+    CLOCK_SetDiv(kCLOCK_Sai1PreDiv, 3);
+    /* Set SAI1_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Sai1Div, 1);
+    /* Set Sai1 clock source. */
+    CLOCK_SetMux(kCLOCK_Sai1Mux, 0);
+    /* Disable SAI2 clock gate. */
+    CLOCK_DisableClock(kCLOCK_Sai2);
+    /* Set SAI2_CLK_PRED. */
+    CLOCK_SetDiv(kCLOCK_Sai2PreDiv, 3);
+    /* Set SAI2_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Sai2Div, 1);
+    /* Set Sai2 clock source. */
+    CLOCK_SetMux(kCLOCK_Sai2Mux, 0);
+    /* Disable SAI3 clock gate. */
+    CLOCK_DisableClock(kCLOCK_Sai3);
+    /* Set SAI3_CLK_PRED. */
+    CLOCK_SetDiv(kCLOCK_Sai3PreDiv, 3);
+    /* Set SAI3_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Sai3Div, 1);
+    /* Set Sai3 clock source. */
+    CLOCK_SetMux(kCLOCK_Sai3Mux, 0);
+    /* Disable Lpi2c clock gate. */
+    CLOCK_DisableClock(kCLOCK_Lpi2c1);
+    CLOCK_DisableClock(kCLOCK_Lpi2c2);
+    CLOCK_DisableClock(kCLOCK_Lpi2c3);
+    /* Set LPI2C_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Lpi2cDiv, 0);
+    /* Set Lpi2c clock source. */
+    CLOCK_SetMux(kCLOCK_Lpi2cMux, 0);
+    /* Disable CAN clock gate. */
+    CLOCK_DisableClock(kCLOCK_Can1);
+    CLOCK_DisableClock(kCLOCK_Can2);
+    CLOCK_DisableClock(kCLOCK_Can1S);
+    CLOCK_DisableClock(kCLOCK_Can2S);
+    /* Set CAN_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_CanDiv, 1);
+    /* Set Can clock source. */
+    CLOCK_SetMux(kCLOCK_CanMux, 2);
+    /* Disable UART clock gate. */
+    CLOCK_DisableClock(kCLOCK_Lpuart1);
+    CLOCK_DisableClock(kCLOCK_Lpuart2);
+    CLOCK_DisableClock(kCLOCK_Lpuart3);
+    CLOCK_DisableClock(kCLOCK_Lpuart4);
+    CLOCK_DisableClock(kCLOCK_Lpuart5);
+    CLOCK_DisableClock(kCLOCK_Lpuart6);
+    CLOCK_DisableClock(kCLOCK_Lpuart7);
+    CLOCK_DisableClock(kCLOCK_Lpuart8);
+    /* Set UART_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_UartDiv, 0);
+    /* Set Uart clock source. */
+    CLOCK_SetMux(kCLOCK_UartMux, 0);
+    /* Disable LCDIF clock gate. */
+    CLOCK_DisableClock(kCLOCK_LcdPixel);
+    /* Set LCDIF_PRED. */
+    CLOCK_SetDiv(kCLOCK_LcdifPreDiv, 1);
+    /* Set LCDIF_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_LcdifDiv, 3);
+    /* Set Lcdif pre clock source. */
+    CLOCK_SetMux(kCLOCK_LcdifPreMux, 5);
+    /* Disable SPDIF clock gate. */
+    CLOCK_DisableClock(kCLOCK_Spdif);
+    /* Set SPDIF0_CLK_PRED. */
+    CLOCK_SetDiv(kCLOCK_Spdif0PreDiv, 1);
+    /* Set SPDIF0_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Spdif0Div, 7);
+    /* Set Spdif clock source. */
+    CLOCK_SetMux(kCLOCK_SpdifMux, 3);
+    /* Disable Flexio1 clock gate. */
+    CLOCK_DisableClock(kCLOCK_Flexio1);
+    /* Set FLEXIO1_CLK_PRED. */
+    CLOCK_SetDiv(kCLOCK_Flexio1PreDiv, 1);
+    /* Set FLEXIO1_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Flexio1Div, 7);
+    /* Set Flexio1 clock source. */
+    CLOCK_SetMux(kCLOCK_Flexio1Mux, 3);
+    /* Disable Flexio2 clock gate. */
+    CLOCK_DisableClock(kCLOCK_Flexio2);
+    /* Set FLEXIO2_CLK_PRED. */
+    CLOCK_SetDiv(kCLOCK_Flexio2PreDiv, 1);
+    /* Set FLEXIO2_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Flexio2Div, 7);
+    /* Set Flexio2 clock source. */
+    CLOCK_SetMux(kCLOCK_Flexio2Mux, 3);
+    /* Set Pll3 sw clock source. */
+    CLOCK_SetMux(kCLOCK_Pll3SwMux, 0);
+    /* Init ARM PLL. */
+    CLOCK_InitArmPll(&armPllConfig_BOARD_BootClockRUN);
+    /* In SDK projects, SDRAM (configured by SEMC) will be initialized in either debug script or dcd.
+     * With this macro SKIP_SYSCLK_INIT, system pll (selected to be SEMC source clock in SDK projects) will be left unchanged.
+     * Note: If another clock source is selected for SEMC, user may want to avoid changing that clock as well.*/
+#ifndef SKIP_SYSCLK_INIT
+#if defined(XIP_BOOT_HEADER_DCD_ENABLE) && (XIP_BOOT_HEADER_DCD_ENABLE == 1)
+    #warning "SKIP_SYSCLK_INIT should be defined to keep system pll (selected to be SEMC source clock in SDK projects) unchanged."
+#endif
+    /* Init System PLL. */
+    CLOCK_InitSysPll(&sysPllConfig_BOARD_BootClockRUN);
+    /* Init System pfd0. */
+    CLOCK_InitSysPfd(kCLOCK_Pfd0, 27);
+    /* Init System pfd1. */
+    CLOCK_InitSysPfd(kCLOCK_Pfd1, 16);
+    /* Init System pfd2. */
+    CLOCK_InitSysPfd(kCLOCK_Pfd2, 24);
+    /* Init System pfd3. */
+    CLOCK_InitSysPfd(kCLOCK_Pfd3, 16);
+#endif
+    /* In SDK projects, external flash (configured by FLEXSPI) will be initialized by dcd.
+     * With this macro XIP_EXTERNAL_FLASH, usb1 pll (selected to be FLEXSPI clock source in SDK projects) will be left unchanged.
+     * Note: If another clock source is selected for FLEXSPI, user may want to avoid changing that clock as well.*/
+#if !(defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
+    /* Init Usb1 PLL. */
+    CLOCK_InitUsb1Pll(&usb1PllConfig_BOARD_BootClockRUN);
+    /* Init Usb1 pfd0. */
+    CLOCK_InitUsb1Pfd(kCLOCK_Pfd0, 33);
+    /* Init Usb1 pfd1. */
+    CLOCK_InitUsb1Pfd(kCLOCK_Pfd1, 16);
+    /* Init Usb1 pfd2. */
+    CLOCK_InitUsb1Pfd(kCLOCK_Pfd2, 17);
+    /* Init Usb1 pfd3. */
+    CLOCK_InitUsb1Pfd(kCLOCK_Pfd3, 19);
+    /* Disable Usb1 PLL output for USBPHY1. */
+    CCM_ANALOG->PLL_USB1 &= ~CCM_ANALOG_PLL_USB1_EN_USB_CLKS_MASK;
+#endif
+    /* DeInit Audio PLL. */
+    CLOCK_DeinitAudioPll();
+    /* Bypass Audio PLL. */
+    CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllAudio, 1);
+    /* Set divider for Audio PLL. */
+    CCM_ANALOG->MISC2 &= ~CCM_ANALOG_MISC2_AUDIO_DIV_LSB_MASK;
+    CCM_ANALOG->MISC2 &= ~CCM_ANALOG_MISC2_AUDIO_DIV_MSB_MASK;
+    /* Enable Audio PLL output. */
+    CCM_ANALOG->PLL_AUDIO |= CCM_ANALOG_PLL_AUDIO_ENABLE_MASK;
+    /* Init Video PLL. */
+    uint32_t pllVideo;
+    /* Disable Video PLL output before initial Video PLL. */
+    CCM_ANALOG->PLL_VIDEO &= ~CCM_ANALOG_PLL_VIDEO_ENABLE_MASK;
+    /* Bypass PLL first */
+    CCM_ANALOG->PLL_VIDEO = (CCM_ANALOG->PLL_VIDEO & (~CCM_ANALOG_PLL_VIDEO_BYPASS_CLK_SRC_MASK)) |
+                            CCM_ANALOG_PLL_VIDEO_BYPASS_MASK | CCM_ANALOG_PLL_VIDEO_BYPASS_CLK_SRC(0);
+    CCM_ANALOG->PLL_VIDEO_NUM = CCM_ANALOG_PLL_VIDEO_NUM_A(0);
+    CCM_ANALOG->PLL_VIDEO_DENOM = CCM_ANALOG_PLL_VIDEO_DENOM_B(1);
+    pllVideo = (CCM_ANALOG->PLL_VIDEO & (~(CCM_ANALOG_PLL_VIDEO_DIV_SELECT_MASK | CCM_ANALOG_PLL_VIDEO_POWERDOWN_MASK))) |
+               CCM_ANALOG_PLL_VIDEO_ENABLE_MASK |CCM_ANALOG_PLL_VIDEO_DIV_SELECT(31);
+    pllVideo |= CCM_ANALOG_PLL_VIDEO_POST_DIV_SELECT(1);
+    CCM_ANALOG->MISC2 = (CCM_ANALOG->MISC2 & (~CCM_ANALOG_MISC2_VIDEO_DIV_MASK)) | CCM_ANALOG_MISC2_VIDEO_DIV(3);
+    CCM_ANALOG->PLL_VIDEO = pllVideo;
+    while ((CCM_ANALOG->PLL_VIDEO & CCM_ANALOG_PLL_VIDEO_LOCK_MASK) == 0)
+    {
+    }
+    /* Disable bypass for Video PLL. */
+    CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllVideo, 0);
+    /* DeInit Enet PLL. */
+    CLOCK_DeinitEnetPll();
+    /* Bypass Enet PLL. */
+    CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllEnet, 1);
+    /* Set Enet output divider. */
+    CCM_ANALOG->PLL_ENET = (CCM_ANALOG->PLL_ENET & (~CCM_ANALOG_PLL_ENET_DIV_SELECT_MASK)) | CCM_ANALOG_PLL_ENET_DIV_SELECT(1);
+    /* Enable Enet output. */
+    CCM_ANALOG->PLL_ENET |= CCM_ANALOG_PLL_ENET_ENABLE_MASK;
+    /* Enable Enet25M output. */
+    CCM_ANALOG->PLL_ENET |= CCM_ANALOG_PLL_ENET_ENET_25M_REF_EN_MASK;
+    /* DeInit Usb2 PLL. */
+    CLOCK_DeinitUsb2Pll();
+    /* Bypass Usb2 PLL. */
+    CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllUsb2, 1);
+    /* Enable Usb2 PLL output. */
+    CCM_ANALOG->PLL_USB2 |= CCM_ANALOG_PLL_USB2_ENABLE_MASK;
+    /* Set preperiph clock source. */
+    CLOCK_SetMux(kCLOCK_PrePeriphMux, 3);
+    /* Set periph clock source. */
+    CLOCK_SetMux(kCLOCK_PeriphMux, 0);
+    /* Set periph clock2 clock source. */
+    CLOCK_SetMux(kCLOCK_PeriphClk2Mux, 0);
+    /* Set per clock source. */
+    CLOCK_SetMux(kCLOCK_PerclkMux, 0);
+    /* Set lvds1 clock source. */
+    CCM_ANALOG->MISC1 = (CCM_ANALOG->MISC1 & (~CCM_ANALOG_MISC1_LVDS1_CLK_SEL_MASK)) | CCM_ANALOG_MISC1_LVDS1_CLK_SEL(0);
+    /* Set clock out1 divider. */
+    CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO1_DIV_MASK)) | CCM_CCOSR_CLKO1_DIV(0);
+    /* Set clock out1 source. */
+    CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO1_SEL_MASK)) | CCM_CCOSR_CLKO1_SEL(1);
+    /* Set clock out2 divider. */
+    CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO2_DIV_MASK)) | CCM_CCOSR_CLKO2_DIV(0);
+    /* Set clock out2 source. */
+    CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO2_SEL_MASK)) | CCM_CCOSR_CLKO2_SEL(18);
+    /* Set clock out1 drives clock out1. */
+    CCM->CCOSR &= ~CCM_CCOSR_CLK_OUT_SEL_MASK;
+    /* Disable clock out1. */
+    CCM->CCOSR &= ~CCM_CCOSR_CLKO1_EN_MASK;
+    /* Disable clock out2. */
+    CCM->CCOSR &= ~CCM_CCOSR_CLKO2_EN_MASK;
+    /* Set SAI1 MCLK1 clock source. */
+    IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk1Sel, 0);
+    /* Set SAI1 MCLK2 clock source. */
+    IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk2Sel, 0);
+    /* Set SAI1 MCLK3 clock source. */
+    IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk3Sel, 0);
+    /* Set SAI2 MCLK3 clock source. */
+    IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI2MClk3Sel, 0);
+    /* Set SAI3 MCLK3 clock source. */
+    IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI3MClk3Sel, 0);
+    /* Set MQS configuration. */
+    IOMUXC_MQSConfig(IOMUXC_GPR,kIOMUXC_MqsPwmOverSampleRate32, 0);
+    /* Set ENET Ref clock source. */
+#if defined(IOMUXC_GPR_GPR1_ENET_REF_CLK_DIR_MASK)
+    IOMUXC_GPR->GPR1 &= ~IOMUXC_GPR_GPR1_ENET_REF_CLK_DIR_MASK;
+#elif defined(IOMUXC_GPR_GPR1_ENET1_TX_CLK_DIR_MASK)
+    /* Backward compatibility for original bitfield name */
+    IOMUXC_GPR->GPR1 &= ~IOMUXC_GPR_GPR1_ENET1_TX_CLK_DIR_MASK;
+#else
+#error "Neither IOMUXC_GPR_GPR1_ENET_REF_CLK_DIR_MASK nor IOMUXC_GPR_GPR1_ENET1_TX_CLK_DIR_MASK is defined."
+#endif /* defined(IOMUXC_GPR_GPR1_ENET_REF_CLK_DIR_MASK) */
+    /* Set GPT1 High frequency reference clock source. */
+    IOMUXC_GPR->GPR5 &= ~IOMUXC_GPR_GPR5_VREF_1M_CLK_GPT1_MASK;
+    /* Set GPT2 High frequency reference clock source. */
+    IOMUXC_GPR->GPR5 &= ~IOMUXC_GPR_GPR5_VREF_1M_CLK_GPT2_MASK;
+    /* Set SystemCoreClock variable. */
+    SystemCoreClock = BOARD_BOOTCLOCKRUN_CORE_CLOCK;
+}
+
+/*******************************************************************************
+ ******************* Configuration BOARD_BootClockRUN_528M *********************
+ ******************************************************************************/
+/* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
+!!Configuration
+name: BOARD_BootClockRUN_528M
+outputs:
+- {id: AHB_CLK_ROOT.outFreq, value: 528 MHz}
+- {id: CAN_CLK_ROOT.outFreq, value: 40 MHz}
+- {id: CKIL_SYNC_CLK_ROOT.outFreq, value: 32.768 kHz}
+- {id: CLK_1M.outFreq, value: 1 MHz}
+- {id: CLK_24M.outFreq, value: 24 MHz}
+- {id: CSI_CLK_ROOT.outFreq, value: 12 MHz}
+- {id: ENET_125M_CLK.outFreq, value: 2.4 MHz}
+- {id: ENET_25M_REF_CLK.outFreq, value: 1.2 MHz}
+- {id: FLEXIO1_CLK_ROOT.outFreq, value: 30 MHz}
+- {id: FLEXIO2_CLK_ROOT.outFreq, value: 30 MHz}
+- {id: FLEXSPI_CLK_ROOT.outFreq, value: 160 MHz}
+- {id: GPT1_ipg_clk_highfreq.outFreq, value: 66 MHz}
+- {id: GPT2_ipg_clk_highfreq.outFreq, value: 66 MHz}
+- {id: IPG_CLK_ROOT.outFreq, value: 132 MHz}
+- {id: LCDIF_CLK_ROOT.outFreq, value: 67.5 MHz}
+- {id: LPI2C_CLK_ROOT.outFreq, value: 60 MHz}
+- {id: LPSPI_CLK_ROOT.outFreq, value: 105.6 MHz}
+- {id: LVDS1_CLK.outFreq, value: 1.2 GHz}
+- {id: MQS_MCLK.outFreq, value: 1080/17 MHz}
+- {id: PERCLK_CLK_ROOT.outFreq, value: 66 MHz}
+- {id: PLL7_MAIN_CLK.outFreq, value: 24 MHz}
+- {id: SAI1_CLK_ROOT.outFreq, value: 1080/17 MHz}
+- {id: SAI1_MCLK1.outFreq, value: 1080/17 MHz}
+- {id: SAI1_MCLK2.outFreq, value: 1080/17 MHz}
+- {id: SAI1_MCLK3.outFreq, value: 30 MHz}
+- {id: SAI2_CLK_ROOT.outFreq, value: 1080/17 MHz}
+- {id: SAI2_MCLK1.outFreq, value: 1080/17 MHz}
+- {id: SAI2_MCLK3.outFreq, value: 30 MHz}
+- {id: SAI3_CLK_ROOT.outFreq, value: 1080/17 MHz}
+- {id: SAI3_MCLK1.outFreq, value: 1080/17 MHz}
+- {id: SAI3_MCLK3.outFreq, value: 30 MHz}
+- {id: SEMC_CLK_ROOT.outFreq, value: 66 MHz}
+- {id: SPDIF0_CLK_ROOT.outFreq, value: 30 MHz}
+- {id: TRACE_CLK_ROOT.outFreq, value: 132 MHz}
+- {id: UART_CLK_ROOT.outFreq, value: 80 MHz}
+- {id: USDHC1_CLK_ROOT.outFreq, value: 198 MHz}
+- {id: USDHC2_CLK_ROOT.outFreq, value: 198 MHz}
+settings:
+- {id: CCM.AHB_PODF.scale, value: '1', locked: true}
+- {id: CCM.ARM_PODF.scale, value: '2', locked: true}
+- {id: CCM.FLEXSPI_PODF.scale, value: '3', locked: true}
+- {id: CCM.FLEXSPI_SEL.sel, value: CCM.PLL3_SW_CLK_SEL}
+- {id: CCM.LPSPI_PODF.scale, value: '5', locked: true}
+- {id: CCM.PERCLK_PODF.scale, value: '2', locked: true}
+- {id: CCM.PRE_PERIPH_CLK_SEL.sel, value: CCM_ANALOG.PLL2_MAIN_CLK}
+- {id: CCM.SEMC_PODF.scale, value: '8'}
+- {id: CCM.TRACE_CLK_SEL.sel, value: CCM_ANALOG.PLL2_MAIN_CLK}
+- {id: CCM_ANALOG.PLL1_BYPASS.sel, value: CCM_ANALOG.PLL1}
+- {id: CCM_ANALOG.PLL1_PREDIV.scale, value: '1', locked: true}
+- {id: CCM_ANALOG.PLL1_VDIV.scale, value: '50', locked: true}
+- {id: CCM_ANALOG.PLL2.denom, value: '1', locked: true}
+- {id: CCM_ANALOG.PLL2.num, value: '0', locked: true}
+- {id: CCM_ANALOG.PLL2_BYPASS.sel, value: CCM_ANALOG.PLL2_OUT_CLK}
+- {id: CCM_ANALOG.PLL2_PFD0_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD0}
+- {id: CCM_ANALOG.PLL2_PFD1_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD1}
+- {id: CCM_ANALOG.PLL2_PFD2_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD2}
+- {id: CCM_ANALOG.PLL2_PFD3_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD3}
+- {id: CCM_ANALOG.PLL3_BYPASS.sel, value: CCM_ANALOG.PLL3}
+- {id: CCM_ANALOG.PLL3_PFD0_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD0}
+- {id: CCM_ANALOG.PLL3_PFD0_DIV.scale, value: '33', locked: true}
+- {id: CCM_ANALOG.PLL3_PFD0_MUL.scale, value: '18', locked: true}
+- {id: CCM_ANALOG.PLL3_PFD1_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD1}
+- {id: CCM_ANALOG.PLL3_PFD2_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD2}
+- {id: CCM_ANALOG.PLL3_PFD3_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD3}
+- {id: CCM_ANALOG.PLL4.denom, value: '50'}
+- {id: CCM_ANALOG.PLL4.div, value: '47'}
+- {id: CCM_ANALOG.PLL5.denom, value: '1'}
+- {id: CCM_ANALOG.PLL5.div, value: '31', locked: true}
+- {id: CCM_ANALOG.PLL5.num, value: '0'}
+- {id: CCM_ANALOG.PLL5_BYPASS.sel, value: CCM_ANALOG.PLL5_POST_DIV}
+- {id: CCM_ANALOG.PLL5_POST_DIV.scale, value: '2'}
+- {id: CCM_ANALOG.VIDEO_DIV.scale, value: '4'}
+- {id: CCM_ANALOG_PLL_ENET_POWERDOWN_CFG, value: 'Yes'}
+- {id: CCM_ANALOG_PLL_USB1_POWER_CFG, value: 'Yes'}
+- {id: CCM_ANALOG_PLL_VIDEO_POWERDOWN_CFG, value: 'No'}
+sources:
+- {id: XTALOSC24M.RTC_OSC.outFreq, value: 32.768 kHz, enabled: true}
+ * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
+
+/*******************************************************************************
+ * Variables for BOARD_BootClockRUN_528M configuration
+ ******************************************************************************/
+const clock_arm_pll_config_t armPllConfig_BOARD_BootClockRUN_528M =
+    {
+        .loopDivider = 100,                       /* PLL loop divider, Fout = Fin * 50 */
+        .src = 0,                                 /* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+    };
+const clock_sys_pll_config_t sysPllConfig_BOARD_BootClockRUN_528M =
+    {
+        .loopDivider = 1,                         /* PLL loop divider, Fout = Fin * ( 20 + loopDivider*2 + numerator / denominator ) */
+        .numerator = 0,                           /* 30 bit numerator of fractional loop divider */
+        .denominator = 1,                         /* 30 bit denominator of fractional loop divider */
+        .src = 0,                                 /* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+    };
+const clock_usb_pll_config_t usb1PllConfig_BOARD_BootClockRUN_528M =
+    {
+        .loopDivider = 0,                         /* PLL loop divider, Fout = Fin * 20 */
+        .src = 0,                                 /* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+    };
+const clock_video_pll_config_t videoPllConfig_BOARD_BootClockRUN_528M =
+    {
+        .loopDivider = 31,                        /* PLL loop divider, Fout = Fin * ( loopDivider + numerator / denominator ) */
+        .postDivider = 8,                         /* Divider after PLL */
+        .numerator = 0,                           /* 30 bit numerator of fractional loop divider, Fout = Fin * ( loopDivider + numerator / denominator ) */
+        .denominator = 1,                         /* 30 bit denominator of fractional loop divider, Fout = Fin * ( loopDivider + numerator / denominator ) */
+        .src = 0,                                 /* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+    };
+/*******************************************************************************
+ * Code for BOARD_BootClockRUN_528M configuration
+ ******************************************************************************/
+void BOARD_BootClockRUN_528M(void)
+{
+    /* Init RTC OSC clock frequency. */
+    CLOCK_SetRtcXtalFreq(32768U);
+    /* Enable 1MHz clock output. */
+    XTALOSC24M->OSC_CONFIG2 |= XTALOSC24M_OSC_CONFIG2_ENABLE_1M_MASK;
+    /* Use free 1MHz clock output. */
+    XTALOSC24M->OSC_CONFIG2 &= ~XTALOSC24M_OSC_CONFIG2_MUX_1M_MASK;
+    /* Set XTAL 24MHz clock frequency. */
+    CLOCK_SetXtalFreq(24000000U);
+    /* Enable XTAL 24MHz clock source. */
+    CLOCK_InitExternalClk(0);
+    /* Enable internal RC. */
+    CLOCK_InitRcOsc24M();
+    /* Switch clock source to external OSC. */
+    CLOCK_SwitchOsc(kCLOCK_XtalOsc);
+    /* Set Oscillator ready counter value. */
+    CCM->CCR = (CCM->CCR & (~CCM_CCR_OSCNT_MASK)) | CCM_CCR_OSCNT(127);
+    /* Setting PeriphClk2Mux and PeriphMux to provide stable clock before PLLs are initialed */
+    CLOCK_SetMux(kCLOCK_PeriphClk2Mux, 1); /* Set PERIPH_CLK2 MUX to OSC */
+    CLOCK_SetMux(kCLOCK_PeriphMux, 1);     /* Set PERIPH_CLK MUX to PERIPH_CLK2 */
+    /* Set AHB_PODF. */
+    CLOCK_SetDiv(kCLOCK_AhbDiv, 0);
+    /* Disable IPG clock gate. */
+    CLOCK_DisableClock(kCLOCK_Adc1);
+    CLOCK_DisableClock(kCLOCK_Adc2);
+    CLOCK_DisableClock(kCLOCK_Xbar1);
+    CLOCK_DisableClock(kCLOCK_Xbar2);
+    CLOCK_DisableClock(kCLOCK_Xbar3);
+    /* Set IPG_PODF. */
+    CLOCK_SetDiv(kCLOCK_IpgDiv, 3);
+    /* Set ARM_PODF. */
+    CLOCK_SetDiv(kCLOCK_ArmDiv, 1);
+    /* Set PERIPH_CLK2_PODF. */
+    CLOCK_SetDiv(kCLOCK_PeriphClk2Div, 0);
+    /* Disable PERCLK clock gate. */
+    CLOCK_DisableClock(kCLOCK_Gpt1);
+    CLOCK_DisableClock(kCLOCK_Gpt1S);
+    CLOCK_DisableClock(kCLOCK_Gpt2);
+    CLOCK_DisableClock(kCLOCK_Gpt2S);
+    CLOCK_DisableClock(kCLOCK_Pit);
+    /* Set PERCLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_PerclkDiv, 1);
+    /* Disable USDHC1 clock gate. */
+    CLOCK_DisableClock(kCLOCK_Usdhc1);
+    /* Set USDHC1_PODF. */
+    CLOCK_SetDiv(kCLOCK_Usdhc1Div, 1);
+    /* Set Usdhc1 clock source. */
+    CLOCK_SetMux(kCLOCK_Usdhc1Mux, 0);
+    /* Disable USDHC2 clock gate. */
+    CLOCK_DisableClock(kCLOCK_Usdhc2);
+    /* Set USDHC2_PODF. */
+    CLOCK_SetDiv(kCLOCK_Usdhc2Div, 1);
+    /* Set Usdhc2 clock source. */
+    CLOCK_SetMux(kCLOCK_Usdhc2Mux, 0);
+    /* In SDK projects, SDRAM (configured by SEMC) will be initialized in either debug script or dcd.
+     * With this macro SKIP_SYSCLK_INIT, system pll (selected to be SEMC source clock in SDK projects) will be left unchanged.
+     * Note: If another clock source is selected for SEMC, user may want to avoid changing that clock as well.*/
+#ifndef SKIP_SYSCLK_INIT
+    /* Disable Semc clock gate. */
+    CLOCK_DisableClock(kCLOCK_Semc);
+    /* Set SEMC_PODF. */
+    CLOCK_SetDiv(kCLOCK_SemcDiv, 7);
+    /* Set Semc alt clock source. */
+    CLOCK_SetMux(kCLOCK_SemcAltMux, 0);
+    /* Set Semc clock source. */
+    CLOCK_SetMux(kCLOCK_SemcMux, 0);
+#endif
+    /* In SDK projects, external flash (configured by FLEXSPI) will be initialized by dcd.
+     * With this macro XIP_EXTERNAL_FLASH, usb1 pll (selected to be FLEXSPI clock source in SDK projects) will be left unchanged.
+     * Note: If another clock source is selected for FLEXSPI, user may want to avoid changing that clock as well.*/
+#if !(defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
+    /* Disable Flexspi clock gate. */
+    CLOCK_DisableClock(kCLOCK_FlexSpi);
+    /* Set FLEXSPI_PODF. */
+    CLOCK_SetDiv(kCLOCK_FlexspiDiv, 2);
+    /* Set Flexspi clock source. */
+    CLOCK_SetMux(kCLOCK_FlexspiMux, 1);
+#endif
+    /* Disable CSI clock gate. */
+    CLOCK_DisableClock(kCLOCK_Csi);
+    /* Set CSI_PODF. */
+    CLOCK_SetDiv(kCLOCK_CsiDiv, 1);
+    /* Set Csi clock source. */
+    CLOCK_SetMux(kCLOCK_CsiMux, 0);
+    /* Disable LPSPI clock gate. */
+    CLOCK_DisableClock(kCLOCK_Lpspi1);
+    CLOCK_DisableClock(kCLOCK_Lpspi2);
+    CLOCK_DisableClock(kCLOCK_Lpspi3);
+    CLOCK_DisableClock(kCLOCK_Lpspi4);
+    /* Set LPSPI_PODF. */
+    CLOCK_SetDiv(kCLOCK_LpspiDiv, 4);
+    /* Set Lpspi clock source. */
+    CLOCK_SetMux(kCLOCK_LpspiMux, 2);
+    /* Disable TRACE clock gate. */
+    CLOCK_DisableClock(kCLOCK_Trace);
+    /* Set TRACE_PODF. */
+    CLOCK_SetDiv(kCLOCK_TraceDiv, 3);
+    /* Set Trace clock source. */
+    CLOCK_SetMux(kCLOCK_TraceMux, 0);
+    /* Disable SAI1 clock gate. */
+    CLOCK_DisableClock(kCLOCK_Sai1);
+    /* Set SAI1_CLK_PRED. */
+    CLOCK_SetDiv(kCLOCK_Sai1PreDiv, 3);
+    /* Set SAI1_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Sai1Div, 1);
+    /* Set Sai1 clock source. */
+    CLOCK_SetMux(kCLOCK_Sai1Mux, 0);
+    /* Disable SAI2 clock gate. */
+    CLOCK_DisableClock(kCLOCK_Sai2);
+    /* Set SAI2_CLK_PRED. */
+    CLOCK_SetDiv(kCLOCK_Sai2PreDiv, 3);
+    /* Set SAI2_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Sai2Div, 1);
+    /* Set Sai2 clock source. */
+    CLOCK_SetMux(kCLOCK_Sai2Mux, 0);
+    /* Disable SAI3 clock gate. */
+    CLOCK_DisableClock(kCLOCK_Sai3);
+    /* Set SAI3_CLK_PRED. */
+    CLOCK_SetDiv(kCLOCK_Sai3PreDiv, 3);
+    /* Set SAI3_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Sai3Div, 1);
+    /* Set Sai3 clock source. */
+    CLOCK_SetMux(kCLOCK_Sai3Mux, 0);
+    /* Disable Lpi2c clock gate. */
+    CLOCK_DisableClock(kCLOCK_Lpi2c1);
+    CLOCK_DisableClock(kCLOCK_Lpi2c2);
+    CLOCK_DisableClock(kCLOCK_Lpi2c3);
+    /* Set LPI2C_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Lpi2cDiv, 0);
+    /* Set Lpi2c clock source. */
+    CLOCK_SetMux(kCLOCK_Lpi2cMux, 0);
+    /* Disable CAN clock gate. */
+    CLOCK_DisableClock(kCLOCK_Can1);
+    CLOCK_DisableClock(kCLOCK_Can2);
+    CLOCK_DisableClock(kCLOCK_Can1S);
+    CLOCK_DisableClock(kCLOCK_Can2S);
+    /* Set CAN_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_CanDiv, 1);
+    /* Set Can clock source. */
+    CLOCK_SetMux(kCLOCK_CanMux, 2);
+    /* Disable UART clock gate. */
+    CLOCK_DisableClock(kCLOCK_Lpuart1);
+    CLOCK_DisableClock(kCLOCK_Lpuart2);
+    CLOCK_DisableClock(kCLOCK_Lpuart3);
+    CLOCK_DisableClock(kCLOCK_Lpuart4);
+    CLOCK_DisableClock(kCLOCK_Lpuart5);
+    CLOCK_DisableClock(kCLOCK_Lpuart6);
+    CLOCK_DisableClock(kCLOCK_Lpuart7);
+    CLOCK_DisableClock(kCLOCK_Lpuart8);
+    /* Set UART_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_UartDiv, 0);
+    /* Set Uart clock source. */
+    CLOCK_SetMux(kCLOCK_UartMux, 0);
+    /* Disable LCDIF clock gate. */
+    CLOCK_DisableClock(kCLOCK_LcdPixel);
+    /* Set LCDIF_PRED. */
+    CLOCK_SetDiv(kCLOCK_LcdifPreDiv, 1);
+    /* Set LCDIF_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_LcdifDiv, 3);
+    /* Set Lcdif pre clock source. */
+    CLOCK_SetMux(kCLOCK_LcdifPreMux, 5);
+    /* Disable SPDIF clock gate. */
+    CLOCK_DisableClock(kCLOCK_Spdif);
+    /* Set SPDIF0_CLK_PRED. */
+    CLOCK_SetDiv(kCLOCK_Spdif0PreDiv, 1);
+    /* Set SPDIF0_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Spdif0Div, 7);
+    /* Set Spdif clock source. */
+    CLOCK_SetMux(kCLOCK_SpdifMux, 3);
+    /* Disable Flexio1 clock gate. */
+    CLOCK_DisableClock(kCLOCK_Flexio1);
+    /* Set FLEXIO1_CLK_PRED. */
+    CLOCK_SetDiv(kCLOCK_Flexio1PreDiv, 1);
+    /* Set FLEXIO1_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Flexio1Div, 7);
+    /* Set Flexio1 clock source. */
+    CLOCK_SetMux(kCLOCK_Flexio1Mux, 3);
+    /* Disable Flexio2 clock gate. */
+    CLOCK_DisableClock(kCLOCK_Flexio2);
+    /* Set FLEXIO2_CLK_PRED. */
+    CLOCK_SetDiv(kCLOCK_Flexio2PreDiv, 1);
+    /* Set FLEXIO2_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Flexio2Div, 7);
+    /* Set Flexio2 clock source. */
+    CLOCK_SetMux(kCLOCK_Flexio2Mux, 3);
+    /* Set Pll3 sw clock source. */
+    CLOCK_SetMux(kCLOCK_Pll3SwMux, 0);
+    /* Init ARM PLL. */
+    CLOCK_InitArmPll(&armPllConfig_BOARD_BootClockRUN_528M);
+    /* In SDK projects, SDRAM (configured by SEMC) will be initialized in either debug script or dcd.
+     * With this macro SKIP_SYSCLK_INIT, system pll (selected to be SEMC source clock in SDK projects) will be left unchanged.
+     * Note: If another clock source is selected for SEMC, user may want to avoid changing that clock as well.*/
+#ifndef SKIP_SYSCLK_INIT
+#if defined(XIP_BOOT_HEADER_DCD_ENABLE) && (XIP_BOOT_HEADER_DCD_ENABLE == 1)
+    #warning "SKIP_SYSCLK_INIT should be defined to keep system pll (selected to be SEMC source clock in SDK projects) unchanged."
+#endif
+    /* Init System PLL. */
+    CLOCK_InitSysPll(&sysPllConfig_BOARD_BootClockRUN_528M);
+    /* Init System pfd0. */
+    CLOCK_InitSysPfd(kCLOCK_Pfd0, 27);
+    /* Init System pfd1. */
+    CLOCK_InitSysPfd(kCLOCK_Pfd1, 16);
+    /* Init System pfd2. */
+    CLOCK_InitSysPfd(kCLOCK_Pfd2, 24);
+    /* Init System pfd3. */
+    CLOCK_InitSysPfd(kCLOCK_Pfd3, 16);
+#endif
+    /* In SDK projects, external flash (configured by FLEXSPI) will be initialized by dcd.
+     * With this macro XIP_EXTERNAL_FLASH, usb1 pll (selected to be FLEXSPI clock source in SDK projects) will be left unchanged.
+     * Note: If another clock source is selected for FLEXSPI, user may want to avoid changing that clock as well.*/
+#if !(defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
+    /* Init Usb1 PLL. */
+    CLOCK_InitUsb1Pll(&usb1PllConfig_BOARD_BootClockRUN_528M);
+    /* Init Usb1 pfd0. */
+    CLOCK_InitUsb1Pfd(kCLOCK_Pfd0, 33);
+    /* Init Usb1 pfd1. */
+    CLOCK_InitUsb1Pfd(kCLOCK_Pfd1, 16);
+    /* Init Usb1 pfd2. */
+    CLOCK_InitUsb1Pfd(kCLOCK_Pfd2, 17);
+    /* Init Usb1 pfd3. */
+    CLOCK_InitUsb1Pfd(kCLOCK_Pfd3, 19);
+    /* Disable Usb1 PLL output for USBPHY1. */
+    CCM_ANALOG->PLL_USB1 &= ~CCM_ANALOG_PLL_USB1_EN_USB_CLKS_MASK;
+#endif
+    /* DeInit Audio PLL. */
+    CLOCK_DeinitAudioPll();
+    /* Bypass Audio PLL. */
+    CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllAudio, 1);
+    /* Set divider for Audio PLL. */
+    CCM_ANALOG->MISC2 &= ~CCM_ANALOG_MISC2_AUDIO_DIV_LSB_MASK;
+    CCM_ANALOG->MISC2 &= ~CCM_ANALOG_MISC2_AUDIO_DIV_MSB_MASK;
+    /* Enable Audio PLL output. */
+    CCM_ANALOG->PLL_AUDIO |= CCM_ANALOG_PLL_AUDIO_ENABLE_MASK;
+    /* Init Video PLL. */
+    uint32_t pllVideo;
+    /* Disable Video PLL output before initial Video PLL. */
+    CCM_ANALOG->PLL_VIDEO &= ~CCM_ANALOG_PLL_VIDEO_ENABLE_MASK;
+    /* Bypass PLL first */
+    CCM_ANALOG->PLL_VIDEO = (CCM_ANALOG->PLL_VIDEO & (~CCM_ANALOG_PLL_VIDEO_BYPASS_CLK_SRC_MASK)) |
+                            CCM_ANALOG_PLL_VIDEO_BYPASS_MASK | CCM_ANALOG_PLL_VIDEO_BYPASS_CLK_SRC(0);
+    CCM_ANALOG->PLL_VIDEO_NUM = CCM_ANALOG_PLL_VIDEO_NUM_A(0);
+    CCM_ANALOG->PLL_VIDEO_DENOM = CCM_ANALOG_PLL_VIDEO_DENOM_B(1);
+    pllVideo = (CCM_ANALOG->PLL_VIDEO & (~(CCM_ANALOG_PLL_VIDEO_DIV_SELECT_MASK | CCM_ANALOG_PLL_VIDEO_POWERDOWN_MASK))) |
+               CCM_ANALOG_PLL_VIDEO_ENABLE_MASK |CCM_ANALOG_PLL_VIDEO_DIV_SELECT(31);
+    pllVideo |= CCM_ANALOG_PLL_VIDEO_POST_DIV_SELECT(1);
+    CCM_ANALOG->MISC2 = (CCM_ANALOG->MISC2 & (~CCM_ANALOG_MISC2_VIDEO_DIV_MASK)) | CCM_ANALOG_MISC2_VIDEO_DIV(3);
+    CCM_ANALOG->PLL_VIDEO = pllVideo;
+    while ((CCM_ANALOG->PLL_VIDEO & CCM_ANALOG_PLL_VIDEO_LOCK_MASK) == 0)
+    {
+    }
+    /* Disable bypass for Video PLL. */
+    CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllVideo, 0);
+    /* DeInit Enet PLL. */
+    CLOCK_DeinitEnetPll();
+    /* Bypass Enet PLL. */
+    CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllEnet, 1);
+    /* Set Enet output divider. */
+    CCM_ANALOG->PLL_ENET = (CCM_ANALOG->PLL_ENET & (~CCM_ANALOG_PLL_ENET_DIV_SELECT_MASK)) | CCM_ANALOG_PLL_ENET_DIV_SELECT(1);
+    /* Enable Enet output. */
+    CCM_ANALOG->PLL_ENET |= CCM_ANALOG_PLL_ENET_ENABLE_MASK;
+    /* Enable Enet25M output. */
+    CCM_ANALOG->PLL_ENET |= CCM_ANALOG_PLL_ENET_ENET_25M_REF_EN_MASK;
+    /* DeInit Usb2 PLL. */
+    CLOCK_DeinitUsb2Pll();
+    /* Bypass Usb2 PLL. */
+    CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllUsb2, 1);
+    /* Enable Usb2 PLL output. */
+    CCM_ANALOG->PLL_USB2 |= CCM_ANALOG_PLL_USB2_ENABLE_MASK;
+    /* Set preperiph clock source. */
+    CLOCK_SetMux(kCLOCK_PrePeriphMux, 0);
+    /* Set periph clock source. */
+    CLOCK_SetMux(kCLOCK_PeriphMux, 0);
+    /* Set periph clock2 clock source. */
+    CLOCK_SetMux(kCLOCK_PeriphClk2Mux, 0);
+    /* Set per clock source. */
+    CLOCK_SetMux(kCLOCK_PerclkMux, 0);
+    /* Set lvds1 clock source. */
+    CCM_ANALOG->MISC1 = (CCM_ANALOG->MISC1 & (~CCM_ANALOG_MISC1_LVDS1_CLK_SEL_MASK)) | CCM_ANALOG_MISC1_LVDS1_CLK_SEL(0);
+    /* Set clock out1 divider. */
+    CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO1_DIV_MASK)) | CCM_CCOSR_CLKO1_DIV(0);
+    /* Set clock out1 source. */
+    CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO1_SEL_MASK)) | CCM_CCOSR_CLKO1_SEL(1);
+    /* Set clock out2 divider. */
+    CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO2_DIV_MASK)) | CCM_CCOSR_CLKO2_DIV(0);
+    /* Set clock out2 source. */
+    CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO2_SEL_MASK)) | CCM_CCOSR_CLKO2_SEL(18);
+    /* Set clock out1 drives clock out1. */
+    CCM->CCOSR &= ~CCM_CCOSR_CLK_OUT_SEL_MASK;
+    /* Disable clock out1. */
+    CCM->CCOSR &= ~CCM_CCOSR_CLKO1_EN_MASK;
+    /* Disable clock out2. */
+    CCM->CCOSR &= ~CCM_CCOSR_CLKO2_EN_MASK;
+    /* Set SAI1 MCLK1 clock source. */
+    IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk1Sel, 0);
+    /* Set SAI1 MCLK2 clock source. */
+    IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk2Sel, 0);
+    /* Set SAI1 MCLK3 clock source. */
+    IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk3Sel, 0);
+    /* Set SAI2 MCLK3 clock source. */
+    IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI2MClk3Sel, 0);
+    /* Set SAI3 MCLK3 clock source. */
+    IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI3MClk3Sel, 0);
+    /* Set MQS configuration. */
+    IOMUXC_MQSConfig(IOMUXC_GPR,kIOMUXC_MqsPwmOverSampleRate32, 0);
+    /* Set ENET Ref clock source. */
+#if defined(IOMUXC_GPR_GPR1_ENET_REF_CLK_DIR_MASK)
+    IOMUXC_GPR->GPR1 &= ~IOMUXC_GPR_GPR1_ENET_REF_CLK_DIR_MASK;
+#elif defined(IOMUXC_GPR_GPR1_ENET1_TX_CLK_DIR_MASK)
+    /* Backward compatibility for original bitfield name */
+    IOMUXC_GPR->GPR1 &= ~IOMUXC_GPR_GPR1_ENET1_TX_CLK_DIR_MASK;
+#else
+#error "Neither IOMUXC_GPR_GPR1_ENET_REF_CLK_DIR_MASK nor IOMUXC_GPR_GPR1_ENET1_TX_CLK_DIR_MASK is defined."
+#endif /* defined(IOMUXC_GPR_GPR1_ENET_REF_CLK_DIR_MASK) */
+    /* Set GPT1 High frequency reference clock source. */
+    IOMUXC_GPR->GPR5 &= ~IOMUXC_GPR_GPR5_VREF_1M_CLK_GPT1_MASK;
+    /* Set GPT2 High frequency reference clock source. */
+    IOMUXC_GPR->GPR5 &= ~IOMUXC_GPR_GPR5_VREF_1M_CLK_GPT2_MASK;
+    /* Set SystemCoreClock variable. */
+    SystemCoreClock = BOARD_BOOTCLOCKRUN_528M_CORE_CLOCK;
+}

--- a/ports/mimxrt10xx/boards/arch_mix_1052/clock_config.h
+++ b/ports/mimxrt10xx/boards/arch_mix_1052/clock_config.h
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2022 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _CLOCK_CONFIG_H_
+#define _CLOCK_CONFIG_H_
+
+#include "fsl_common.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+#define BOARD_XTAL0_CLK_HZ                         24000000U  /*!< Board xtal0 frequency in Hz */
+
+#define BOARD_XTAL32K_CLK_HZ                          32768U  /*!< Board xtal32k frequency in Hz */
+/*******************************************************************************
+ ************************ BOARD_InitBootClocks function ************************
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+/*!
+ * @brief This function executes default configuration of clocks.
+ *
+ */
+void BOARD_InitBootClocks(void);
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus*/
+
+/*******************************************************************************
+ ********************** Configuration BOARD_BootClockRUN ***********************
+ ******************************************************************************/
+/*******************************************************************************
+ * Definitions for BOARD_BootClockRUN configuration
+ ******************************************************************************/
+#define BOARD_BOOTCLOCKRUN_CORE_CLOCK             600000000U  /*!< Core clock frequency: 600000000Hz */
+
+/* Clock outputs (values are in Hz): */
+#define BOARD_BOOTCLOCKRUN_AHB_CLK_ROOT               600000000UL
+#define BOARD_BOOTCLOCKRUN_CAN_CLK_ROOT               40000000UL
+#define BOARD_BOOTCLOCKRUN_CKIL_SYNC_CLK_ROOT         32768UL
+#define BOARD_BOOTCLOCKRUN_CLKO1_CLK                  0UL
+#define BOARD_BOOTCLOCKRUN_CLKO2_CLK                  0UL
+#define BOARD_BOOTCLOCKRUN_CLK_1M                     1000000UL
+#define BOARD_BOOTCLOCKRUN_CLK_24M                    24000000UL
+#define BOARD_BOOTCLOCKRUN_CSI_CLK_ROOT               12000000UL
+#define BOARD_BOOTCLOCKRUN_ENET_125M_CLK              2400000UL
+#define BOARD_BOOTCLOCKRUN_ENET_25M_REF_CLK           1200000UL
+#define BOARD_BOOTCLOCKRUN_ENET_REF_CLK               0UL
+#define BOARD_BOOTCLOCKRUN_ENET_TX_CLK                0UL
+#define BOARD_BOOTCLOCKRUN_FLEXIO1_CLK_ROOT           30000000UL
+#define BOARD_BOOTCLOCKRUN_FLEXIO2_CLK_ROOT           30000000UL
+#define BOARD_BOOTCLOCKRUN_FLEXSPI_CLK_ROOT           160000000UL
+#define BOARD_BOOTCLOCKRUN_GPT1_IPG_CLK_HIGHFREQ      75000000UL
+#define BOARD_BOOTCLOCKRUN_GPT2_IPG_CLK_HIGHFREQ      75000000UL
+#define BOARD_BOOTCLOCKRUN_IPG_CLK_ROOT               150000000UL
+#define BOARD_BOOTCLOCKRUN_LCDIF_CLK_ROOT             67500000UL
+#define BOARD_BOOTCLOCKRUN_LPI2C_CLK_ROOT             60000000UL
+#define BOARD_BOOTCLOCKRUN_LPSPI_CLK_ROOT             105600000UL
+#define BOARD_BOOTCLOCKRUN_LVDS1_CLK                  1200000000UL
+#define BOARD_BOOTCLOCKRUN_MQS_MCLK                   63529411UL
+#define BOARD_BOOTCLOCKRUN_PERCLK_CLK_ROOT            75000000UL
+#define BOARD_BOOTCLOCKRUN_PLL7_MAIN_CLK              24000000UL
+#define BOARD_BOOTCLOCKRUN_SAI1_CLK_ROOT              63529411UL
+#define BOARD_BOOTCLOCKRUN_SAI1_MCLK1                 63529411UL
+#define BOARD_BOOTCLOCKRUN_SAI1_MCLK2                 63529411UL
+#define BOARD_BOOTCLOCKRUN_SAI1_MCLK3                 30000000UL
+#define BOARD_BOOTCLOCKRUN_SAI2_CLK_ROOT              63529411UL
+#define BOARD_BOOTCLOCKRUN_SAI2_MCLK1                 63529411UL
+#define BOARD_BOOTCLOCKRUN_SAI2_MCLK2                 0UL
+#define BOARD_BOOTCLOCKRUN_SAI2_MCLK3                 30000000UL
+#define BOARD_BOOTCLOCKRUN_SAI3_CLK_ROOT              63529411UL
+#define BOARD_BOOTCLOCKRUN_SAI3_MCLK1                 63529411UL
+#define BOARD_BOOTCLOCKRUN_SAI3_MCLK2                 0UL
+#define BOARD_BOOTCLOCKRUN_SAI3_MCLK3                 30000000UL
+#define BOARD_BOOTCLOCKRUN_SEMC_CLK_ROOT              75000000UL
+#define BOARD_BOOTCLOCKRUN_SPDIF0_CLK_ROOT            30000000UL
+#define BOARD_BOOTCLOCKRUN_SPDIF0_EXTCLK_OUT          0UL
+#define BOARD_BOOTCLOCKRUN_TRACE_CLK_ROOT             132000000UL
+#define BOARD_BOOTCLOCKRUN_UART_CLK_ROOT              80000000UL
+#define BOARD_BOOTCLOCKRUN_USBPHY1_CLK                0UL
+#define BOARD_BOOTCLOCKRUN_USBPHY2_CLK                0UL
+#define BOARD_BOOTCLOCKRUN_USDHC1_CLK_ROOT            198000000UL
+#define BOARD_BOOTCLOCKRUN_USDHC2_CLK_ROOT            198000000UL
+
+/*! @brief Arm PLL set for BOARD_BootClockRUN configuration.
+ */
+extern const clock_arm_pll_config_t armPllConfig_BOARD_BootClockRUN;
+/*! @brief Usb1 PLL set for BOARD_BootClockRUN configuration.
+ */
+extern const clock_usb_pll_config_t usb1PllConfig_BOARD_BootClockRUN;
+/*! @brief Sys PLL for BOARD_BootClockRUN configuration.
+ */
+extern const clock_sys_pll_config_t sysPllConfig_BOARD_BootClockRUN;
+/*! @brief Video PLL set for BOARD_BootClockRUN configuration.
+ */
+extern const clock_video_pll_config_t videoPllConfig_BOARD_BootClockRUN;
+
+/*******************************************************************************
+ * API for BOARD_BootClockRUN configuration
+ ******************************************************************************/
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+/*!
+ * @brief This function executes configuration of clocks.
+ *
+ */
+void BOARD_BootClockRUN(void);
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus*/
+
+/*******************************************************************************
+ ******************* Configuration BOARD_BootClockRUN_528M *********************
+ ******************************************************************************/
+/*******************************************************************************
+ * Definitions for BOARD_BootClockRUN_528M configuration
+ ******************************************************************************/
+#define BOARD_BOOTCLOCKRUN_528M_CORE_CLOCK        528000000U  /*!< Core clock frequency: 528000000Hz */
+
+/* Clock outputs (values are in Hz): */
+#define BOARD_BOOTCLOCKRUN_528M_AHB_CLK_ROOT          528000000UL
+#define BOARD_BOOTCLOCKRUN_528M_CAN_CLK_ROOT          40000000UL
+#define BOARD_BOOTCLOCKRUN_528M_CKIL_SYNC_CLK_ROOT    32768UL
+#define BOARD_BOOTCLOCKRUN_528M_CLKO1_CLK             0UL
+#define BOARD_BOOTCLOCKRUN_528M_CLKO2_CLK             0UL
+#define BOARD_BOOTCLOCKRUN_528M_CLK_1M                1000000UL
+#define BOARD_BOOTCLOCKRUN_528M_CLK_24M               24000000UL
+#define BOARD_BOOTCLOCKRUN_528M_CSI_CLK_ROOT          12000000UL
+#define BOARD_BOOTCLOCKRUN_528M_ENET_125M_CLK         2400000UL
+#define BOARD_BOOTCLOCKRUN_528M_ENET_25M_REF_CLK      1200000UL
+#define BOARD_BOOTCLOCKRUN_528M_ENET_REF_CLK          0UL
+#define BOARD_BOOTCLOCKRUN_528M_ENET_TX_CLK           0UL
+#define BOARD_BOOTCLOCKRUN_528M_FLEXIO1_CLK_ROOT      30000000UL
+#define BOARD_BOOTCLOCKRUN_528M_FLEXIO2_CLK_ROOT      30000000UL
+#define BOARD_BOOTCLOCKRUN_528M_FLEXSPI_CLK_ROOT      160000000UL
+#define BOARD_BOOTCLOCKRUN_528M_GPT1_IPG_CLK_HIGHFREQ 66000000UL
+#define BOARD_BOOTCLOCKRUN_528M_GPT2_IPG_CLK_HIGHFREQ 66000000UL
+#define BOARD_BOOTCLOCKRUN_528M_IPG_CLK_ROOT          132000000UL
+#define BOARD_BOOTCLOCKRUN_528M_LCDIF_CLK_ROOT        67500000UL
+#define BOARD_BOOTCLOCKRUN_528M_LPI2C_CLK_ROOT        60000000UL
+#define BOARD_BOOTCLOCKRUN_528M_LPSPI_CLK_ROOT        105600000UL
+#define BOARD_BOOTCLOCKRUN_528M_LVDS1_CLK             1200000000UL
+#define BOARD_BOOTCLOCKRUN_528M_MQS_MCLK              63529411UL
+#define BOARD_BOOTCLOCKRUN_528M_PERCLK_CLK_ROOT       66000000UL
+#define BOARD_BOOTCLOCKRUN_528M_PLL7_MAIN_CLK         24000000UL
+#define BOARD_BOOTCLOCKRUN_528M_SAI1_CLK_ROOT         63529411UL
+#define BOARD_BOOTCLOCKRUN_528M_SAI1_MCLK1            63529411UL
+#define BOARD_BOOTCLOCKRUN_528M_SAI1_MCLK2            63529411UL
+#define BOARD_BOOTCLOCKRUN_528M_SAI1_MCLK3            30000000UL
+#define BOARD_BOOTCLOCKRUN_528M_SAI2_CLK_ROOT         63529411UL
+#define BOARD_BOOTCLOCKRUN_528M_SAI2_MCLK1            63529411UL
+#define BOARD_BOOTCLOCKRUN_528M_SAI2_MCLK2            0UL
+#define BOARD_BOOTCLOCKRUN_528M_SAI2_MCLK3            30000000UL
+#define BOARD_BOOTCLOCKRUN_528M_SAI3_CLK_ROOT         63529411UL
+#define BOARD_BOOTCLOCKRUN_528M_SAI3_MCLK1            63529411UL
+#define BOARD_BOOTCLOCKRUN_528M_SAI3_MCLK2            0UL
+#define BOARD_BOOTCLOCKRUN_528M_SAI3_MCLK3            30000000UL
+#define BOARD_BOOTCLOCKRUN_528M_SEMC_CLK_ROOT         66000000UL
+#define BOARD_BOOTCLOCKRUN_528M_SPDIF0_CLK_ROOT       30000000UL
+#define BOARD_BOOTCLOCKRUN_528M_SPDIF0_EXTCLK_OUT     0UL
+#define BOARD_BOOTCLOCKRUN_528M_TRACE_CLK_ROOT        132000000UL
+#define BOARD_BOOTCLOCKRUN_528M_UART_CLK_ROOT         80000000UL
+#define BOARD_BOOTCLOCKRUN_528M_USBPHY1_CLK           0UL
+#define BOARD_BOOTCLOCKRUN_528M_USBPHY2_CLK           0UL
+#define BOARD_BOOTCLOCKRUN_528M_USDHC1_CLK_ROOT       198000000UL
+#define BOARD_BOOTCLOCKRUN_528M_USDHC2_CLK_ROOT       198000000UL
+
+/*! @brief Arm PLL set for BOARD_BootClockRUN_528M configuration.
+ */
+extern const clock_arm_pll_config_t armPllConfig_BOARD_BootClockRUN_528M;
+/*! @brief Usb1 PLL set for BOARD_BootClockRUN_528M configuration.
+ */
+extern const clock_usb_pll_config_t usb1PllConfig_BOARD_BootClockRUN_528M;
+/*! @brief Sys PLL for BOARD_BootClockRUN_528M configuration.
+ */
+extern const clock_sys_pll_config_t sysPllConfig_BOARD_BootClockRUN_528M;
+/*! @brief Video PLL set for BOARD_BootClockRUN_528M configuration.
+ */
+extern const clock_video_pll_config_t videoPllConfig_BOARD_BootClockRUN_528M;
+
+/*******************************************************************************
+ * API for BOARD_BootClockRUN_528M configuration
+ ******************************************************************************/
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+/*!
+ * @brief This function executes configuration of clocks.
+ *
+ */
+void BOARD_BootClockRUN_528M(void);
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus*/
+
+#endif /* _CLOCK_CONFIG_H_ */

--- a/ports/mimxrt10xx/boards/arch_mix_1052/flash_config.c
+++ b/ports/mimxrt10xx/boards/arch_mix_1052/flash_config.c
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2017 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "flexspi_nor_flash.h"
+#include "fsl_flexspi_nor_boot.h"
+#include "boards.h"
+
+
+__attribute__((section(".boot_hdr.ivt")))
+/*************************************
+ *  IVT Data
+ *************************************/
+const ivt image_vector_table = {
+  IVT_HEADER,                         /* IVT Header */
+  IMAGE_ENTRY_ADDRESS,                /* Image Entry Function */
+  IVT_RSVD,                           /* Reserved = 0 */
+  (uint32_t)DCD_ADDRESS,              /* Address where DCD information is stored */
+  (uint32_t)BOOT_DATA_ADDRESS,        /* Address where BOOT Data Structure is stored */
+  (uint32_t)&image_vector_table,      /* Pointer to IVT Self (absolute address) */
+  (uint32_t)CSF_ADDRESS,              /* Address where CSF file is stored */
+  IVT_RSVD                            /* Reserved = 0 */
+};
+
+__attribute__((section(".boot_hdr.boot_data")))
+/*************************************
+ *  Boot Data
+ *************************************/
+const BOOT_DATA_T g_boot_data = {
+  BOARD_BOOT_START,           /* boot start location */
+  BOARD_BOOT_LENGTH,
+  PLUGIN_FLAG,                /* Plugin flag */
+  0xFFFFFFFF                  /* empty - extra data word */
+};
+
+// Config for IS25WP064A with QSPI after changing resistors to send signal to
+// QSPI instead of hyper flash!
+__attribute__((section(".boot_hdr.conf")))
+const flexspi_nor_config_t qspiflash_config = {
+    .pageSize           = 256u,
+    .sectorSize         = 4u * 1024u,
+    .ipcmdSerialClkFreq = kFlexSpiSerialClk_30MHz,
+    .blockSize          = 0x00010000,
+    .isUniformBlockSize = false,
+    .memConfig =
+    {
+        .tag              = FLEXSPI_CFG_BLK_TAG,
+        .version          = FLEXSPI_CFG_BLK_VERSION,
+        .readSampleClkSrc = kFlexSPIReadSampleClk_LoopbackFromSckPad,
+        .csHoldTime       = 3u,
+        .csSetupTime      = 3u,
+
+        .busyOffset = 0u, // Status bit 0 indicates busy.
+        .busyBitPolarity = 0u, // Busy when the bit is 1.
+
+        .deviceModeCfgEnable = 1u,
+        .deviceModeType = kDeviceConfigCmdType_QuadEnable,
+        .deviceModeSeq = {
+          .seqId = 4u,
+          .seqNum = 1u,
+        },
+        .deviceModeArg = 0x40,
+        .deviceType    = kFlexSpiDeviceType_SerialNOR,
+        .sflashPadType = kSerialFlash_4Pads,
+        .serialClkFreq = kFlexSpiSerialClk_60MHz,
+        .sflashA1Size  = FLASH_SIZE,
+        .lookupTable =
+        {
+            // FLEXSPI_LUT_SEQ(cmd0, pad0, op0, cmd1, pad1, op1)
+            // The high 16 bits is command 1 and the low are command 0.
+            // Within a command, the top 6 bits are the opcode, the next two are the number
+            // of pads and then last byte is the operand. The operand's meaning changes
+            // per opcode.
+
+            // Indices with ROM should always have the same function because the ROM
+            // bootloader uses it.
+
+            // 0: ROM: Read LUTs
+            // Quad version
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR,   FLEXSPI_1PAD, 0xEB /* the command to send */,
+                                     RADDR_SDR, FLEXSPI_4PAD, 24 /* bits to transmit */),
+                     FLEXSPI_LUT_SEQ(DUMMY_SDR, FLEXSPI_4PAD, 6 /* 6 dummy cycles, 2 for M7-0 and 4 dummy */,
+                                     READ_SDR,  FLEXSPI_4PAD, 0x04),
+            // Single fast read version, good for debugging.
+            // FLEXSPI_LUT_SEQ(CMD_SDR,   FLEXSPI_1PAD, 0x0B /* the command to send */,
+            //                 RADDR_SDR, FLEXSPI_1PAD, 24  /* bits to transmit */),
+            // FLEXSPI_LUT_SEQ(DUMMY_SDR, FLEXSPI_1PAD, 8 /* 8 dummy clocks */,
+            //                 READ_SDR,  FLEXSPI_1PAD, 0x04),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 1: ROM: Read status
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR,  FLEXSPI_1PAD, 0x05  /* the command to send */,
+                                     READ_SDR, FLEXSPI_1PAD, 0x02),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 2: Empty
+            EMPTY_SEQUENCE,
+
+            // 3: ROM: Write Enable
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x06  /* the command to send */,
+                                     STOP,    FLEXSPI_1PAD, 0x00),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 4: Config: Write Status
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR,   FLEXSPI_1PAD, 0x01  /* the command to send */,
+                                     WRITE_SDR, FLEXSPI_1PAD, 0x01),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 5: ROM: Erase Sector
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR,   FLEXSPI_1PAD, 0x20  /* the command to send */,
+                                     RADDR_SDR, FLEXSPI_1PAD, 24 /* bits to transmit */),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 6: Empty
+            EMPTY_SEQUENCE,
+
+            // 7: Empty
+            EMPTY_SEQUENCE,
+
+            // 8: Block Erase
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR,   FLEXSPI_1PAD, 0xD8  /* the command to send */,
+                                     RADDR_SDR, FLEXSPI_1PAD, 24 /* bits to transmit */),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 9: ROM: Page program
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR,   FLEXSPI_1PAD, 0x02  /* the command to send */,
+                                     RADDR_SDR, FLEXSPI_1PAD, 24 /* bits to transmit */),
+
+                     FLEXSPI_LUT_SEQ(WRITE_SDR, FLEXSPI_1PAD, 0x04  /* data out */,
+                                     STOP,      FLEXSPI_1PAD, 0),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 10: Empty
+            EMPTY_SEQUENCE,
+
+            // 11: ROM: Chip erase
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x60  /* the command to send */,
+                                     STOP,    FLEXSPI_1PAD, 0),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 12: Empty
+            EMPTY_SEQUENCE,
+
+            // 13: ROM: Read SFDP
+            EMPTY_SEQUENCE,
+
+            // 14: ROM: Restore no cmd
+            EMPTY_SEQUENCE,
+
+            // 15: ROM: Dummy
+            EMPTY_SEQUENCE
+        },
+    },
+};

--- a/ports/mimxrt10xx/boards/makerdiary_rt1011/board.h
+++ b/ports/mimxrt10xx/boards/makerdiary_rt1011/board.h
@@ -1,0 +1,99 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Ha Thach for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+
+#ifndef BOARD_H_
+#define BOARD_H_
+
+// Size of on-board external flash
+#define BOARD_FLASH_SIZE     (16*1024*1024)
+
+//--------------------------------------------------------------------+
+// LED
+//--------------------------------------------------------------------+
+
+#define LED_PINMUX            IOMUXC_GPIO_SD_04_GPIO2_IO04
+#define LED_PORT              GPIO2
+#define LED_PIN               4
+#define LED_STATE_ON          1
+
+#if 0
+// PWM Test on Arduino header D8
+#define LED_PWM_PINMUX        IOMUXC_GPIO_SD_02_FLEXPWM1_PWM0_A
+#define LED_PWM_BASE          PWM1
+#define LED_PWM_MODULE        kPWM_Module_0
+#define LED_PWM_CHANNEL       kPWM_PwmA
+#endif
+
+//--------------------------------------------------------------------+
+// Neopixel
+//--------------------------------------------------------------------+
+
+// Number of neopixels
+#if 1
+#define NEOPIXEL_NUMBER       0
+
+#else
+// Neopixel Test on Arduino header A0
+#define NEOPIXEL_NUMBER       1
+#define NEOPIXEL_PINMUX       IOMUXC_GPIO_AD_07_GPIOMUX_IO21
+#define NEOPIXEL_PORT         GPIO1
+#define NEOPIXEL_PIN          21
+#endif
+
+//--------------------------------------------------------------------+
+// Button
+//--------------------------------------------------------------------+
+
+// SW8 button
+#define BUTTON_PINMUX         IOMUXC_GPIO_SD_11_GPIO2_IO11
+#define BUTTON_PORT           GPIO2
+#define BUTTON_PIN            11
+#define BUTTON_STATE_ACTIVE   0
+
+//--------------------------------------------------------------------+
+// USB UF2
+//--------------------------------------------------------------------+
+
+#define USB_VID           0x2886
+#define USB_PID           0xf00f
+#define USB_MANUFACTURER  "Makerdiary"
+#define USB_PRODUCT       "iMX RT1011 Nano Kit"
+
+#define UF2_PRODUCT_NAME  USB_MANUFACTURER " " USB_PRODUCT
+#define UF2_BOARD_ID      "MIMXRT1011-iMXRT1011_Nano_Kit-V1"
+#define UF2_VOLUME_LABEL  "NANOKITBOOT"
+#define UF2_INDEX_URL     "https://makerdiary.com/products/imxrt1011-nanokit/"
+
+//--------------------------------------------------------------------+
+// UART
+//--------------------------------------------------------------------+
+
+#define UART_DEV              LPUART1
+#define UART_RX_PINMUX        IOMUXC_GPIO_09_LPUART1_RXD
+#define UART_TX_PINMUX        IOMUXC_GPIO_10_LPUART1_TXD
+
+#endif /* BOARD_H_ */

--- a/ports/mimxrt10xx/boards/makerdiary_rt1011/board.mk
+++ b/ports/mimxrt10xx/boards/makerdiary_rt1011/board.mk
@@ -1,0 +1,12 @@
+MCU = MIMXRT1011
+CFLAGS += -DCPU_MIMXRT1011DAE5A
+
+# For flash-jlink target
+JLINK_DEVICE = MIMXRT1011DAE5A
+
+# For flash-pyocd target
+PYOCD_TARGET = mimxrt1010
+
+# flash using pyocd
+flash: flash-pyocd-bin
+erase: erase-pyocd

--- a/ports/mimxrt10xx/boards/makerdiary_rt1011/clock_config.c
+++ b/ports/mimxrt10xx/boards/makerdiary_rt1011/clock_config.c
@@ -1,0 +1,345 @@
+/*
+ * Copyright 2019 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * How to setup clock using clock driver functions:
+ *
+ * 1. Call CLOCK_InitXXXPLL() to configure corresponding PLL clock.
+ *
+ * 2. Call CLOCK_InitXXXpfd() to configure corresponding PLL pfd clock.
+ *
+ * 3. Call CLOCK_SetMux() to configure corresponding clock source for target clock out.
+ *
+ * 4. Call CLOCK_SetDiv() to configure corresponding clock divider for target clock out.
+ *
+ * 5. Call CLOCK_SetXtalFreq() to set XTAL frequency based on board settings.
+ *
+ */
+
+/* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
+!!GlobalInfo
+product: Clocks v6.0
+processor: MIMXRT1011xxxxx
+package_id: MIMXRT1011DAE5A
+mcu_data: ksdk2_0
+processor_version: 0.0.1
+board: MIMXRT1010-EVK
+ * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
+
+#include "clock_config.h"
+#include "fsl_iomuxc.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+/* System clock frequency. */
+extern uint32_t SystemCoreClock;
+
+/*******************************************************************************
+ ************************ BOARD_InitBootClocks function ************************
+ ******************************************************************************/
+void BOARD_InitBootClocks(void)
+{
+    BOARD_BootClockRUN();
+}
+
+/*******************************************************************************
+ ********************** Configuration BOARD_BootClockRUN ***********************
+ ******************************************************************************/
+/* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
+!!Configuration
+name: BOARD_BootClockRUN
+called_from_default_init: true
+outputs:
+- {id: ADC_ALT_CLK.outFreq, value: 40 MHz}
+- {id: CKIL_SYNC_CLK_ROOT.outFreq, value: 32.768 kHz}
+- {id: CLK_1M.outFreq, value: 1 MHz}
+- {id: CLK_24M.outFreq, value: 24 MHz}
+- {id: CORE_CLK_ROOT.outFreq, value: 500 MHz}
+- {id: ENET_500M_REF_CLK.outFreq, value: 500 MHz}
+- {id: FLEXIO1_CLK_ROOT.outFreq, value: 30 MHz}
+- {id: FLEXSPI_CLK_ROOT.outFreq, value: 132 MHz}
+- {id: GPT1_ipg_clk_highfreq.outFreq, value: 62.5 MHz}
+- {id: GPT2_ipg_clk_highfreq.outFreq, value: 62.5 MHz}
+- {id: IPG_CLK_ROOT.outFreq, value: 125 MHz}
+- {id: LPI2C_CLK_ROOT.outFreq, value: 60 MHz}
+- {id: LPSPI_CLK_ROOT.outFreq, value: 105.6 MHz}
+- {id: MQS_MCLK.outFreq, value: 1080/17 MHz}
+- {id: PERCLK_CLK_ROOT.outFreq, value: 62.5 MHz}
+- {id: SAI1_CLK_ROOT.outFreq, value: 1080/17 MHz}
+- {id: SAI1_MCLK1.outFreq, value: 1080/17 MHz}
+- {id: SAI1_MCLK2.outFreq, value: 1080/17 MHz}
+- {id: SAI1_MCLK3.outFreq, value: 30 MHz}
+- {id: SAI3_CLK_ROOT.outFreq, value: 1080/17 MHz}
+- {id: SAI3_MCLK1.outFreq, value: 1080/17 MHz}
+- {id: SAI3_MCLK3.outFreq, value: 30 MHz}
+- {id: SPDIF0_CLK_ROOT.outFreq, value: 30 MHz}
+- {id: TRACE_CLK_ROOT.outFreq, value: 352/3 MHz}
+- {id: UART_CLK_ROOT.outFreq, value: 80 MHz}
+settings:
+- {id: CCM.ADC_ACLK_PODF.scale, value: '12', locked: true}
+- {id: CCM.AHB_PODF.scale, value: '1', locked: true}
+- {id: CCM.FLEXSPI_PODF.scale, value: '4', locked: true}
+- {id: CCM.IPG_PODF.scale, value: '4'}
+- {id: CCM.LPSPI_PODF.scale, value: '5', locked: true}
+- {id: CCM.PERCLK_PODF.scale, value: '2', locked: true}
+- {id: CCM.PRE_PERIPH_CLK_SEL.sel, value: CCM_ANALOG.ENET_500M_REF_CLK}
+- {id: CCM.SAI1_CLK_SEL.sel, value: CCM_ANALOG.PLL3_PFD2_CLK}
+- {id: CCM.SAI3_CLK_SEL.sel, value: CCM_ANALOG.PLL3_PFD2_CLK}
+- {id: CCM.TRACE_PODF.scale, value: '3', locked: true}
+- {id: CCM_ANALOG.PLL2.denom, value: '1'}
+- {id: CCM_ANALOG.PLL2.div, value: '22'}
+- {id: CCM_ANALOG.PLL2.num, value: '0'}
+- {id: CCM_ANALOG.PLL2_BYPASS.sel, value: CCM_ANALOG.PLL2_OUT_CLK}
+- {id: CCM_ANALOG.PLL2_PFD0_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD0}
+- {id: CCM_ANALOG.PLL2_PFD1_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD1}
+- {id: CCM_ANALOG.PLL2_PFD2_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD2}
+- {id: CCM_ANALOG.PLL2_PFD2_DIV.scale, value: '18', locked: true}
+- {id: CCM_ANALOG.PLL2_PFD2_MUL.scale, value: '18', locked: true}
+- {id: CCM_ANALOG.PLL2_PFD3_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD3}
+- {id: CCM_ANALOG.PLL2_PFD3_DIV.scale, value: '18', locked: true}
+- {id: CCM_ANALOG.PLL2_PFD3_MUL.scale, value: '18', locked: true}
+- {id: CCM_ANALOG.PLL3_BYPASS.sel, value: CCM_ANALOG.PLL3}
+- {id: CCM_ANALOG.PLL3_PFD0_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD0}
+- {id: CCM_ANALOG.PLL3_PFD0_DIV.scale, value: '22', locked: true}
+- {id: CCM_ANALOG.PLL3_PFD0_MUL.scale, value: '18', locked: true}
+- {id: CCM_ANALOG.PLL3_PFD1_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD1}
+- {id: CCM_ANALOG.PLL3_PFD2_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD2}
+- {id: CCM_ANALOG.PLL3_PFD3_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD3}
+- {id: CCM_ANALOG.PLL3_PFD3_DIV.scale, value: '18', locked: true}
+- {id: CCM_ANALOG.PLL3_PFD3_MUL.scale, value: '18', locked: true}
+- {id: CCM_ANALOG.PLL6_BYPASS.sel, value: CCM_ANALOG.PLL6}
+- {id: CCM_ANALOG_PLL_USB1_POWER_CFG, value: 'Yes'}
+sources:
+- {id: XTALOSC24M.OSC.outFreq, value: 24 MHz, enabled: true}
+- {id: XTALOSC24M.RTC_OSC.outFreq, value: 32.768 kHz, enabled: true}
+ * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
+
+/*******************************************************************************
+ * Variables for BOARD_BootClockRUN configuration
+ ******************************************************************************/
+const clock_sys_pll_config_t sysPllConfig_BOARD_BootClockRUN = {
+    .loopDivider = 1, /* PLL loop divider, Fout = Fin * ( 20 + loopDivider*2 + numerator / denominator ) */
+    .numerator   = 0, /* 30 bit numerator of fractional loop divider */
+    .denominator = 1, /* 30 bit denominator of fractional loop divider */
+    .src         = 0, /* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+};
+const clock_usb_pll_config_t usb1PllConfig_BOARD_BootClockRUN = {
+    .loopDivider = 0, /* PLL loop divider, Fout = Fin * 20 */
+    .src         = 0, /* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+};
+const clock_enet_pll_config_t enetPllConfig_BOARD_BootClockRUN = {
+    .enableClkOutput500M = true, /* Enable the PLL providing the ENET 500MHz reference clock */
+    .src                 = 0,    /* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+};
+/*******************************************************************************
+ * Code for BOARD_BootClockRUN configuration
+ ******************************************************************************/
+void BOARD_BootClockRUN(void)
+{
+    /* Init RTC OSC clock frequency. */
+    CLOCK_SetRtcXtalFreq(32768U);
+    /* Enable 1MHz clock output. */
+    XTALOSC24M->OSC_CONFIG2 |= XTALOSC24M_OSC_CONFIG2_ENABLE_1M_MASK;
+    /* Use free 1MHz clock output. */
+    XTALOSC24M->OSC_CONFIG2 &= ~XTALOSC24M_OSC_CONFIG2_MUX_1M_MASK;
+    /* Set XTAL 24MHz clock frequency. */
+    CLOCK_SetXtalFreq(24000000U);
+    /* Enable XTAL 24MHz clock source. */
+    CLOCK_InitExternalClk(0);
+    /* Enable internal RC. */
+    CLOCK_InitRcOsc24M();
+    /* Switch clock source to external OSC. */
+    CLOCK_SwitchOsc(kCLOCK_XtalOsc);
+    /* Set Oscillator ready counter value. */
+    CCM->CCR = (CCM->CCR & (~CCM_CCR_OSCNT_MASK)) | CCM_CCR_OSCNT(127);
+    /* Setting PeriphClk2Mux and PeriphMux to provide stable clock before PLLs are initialed */
+    CLOCK_SetMux(kCLOCK_PeriphClk2Mux, 1); /* Set PERIPH_CLK2 MUX to OSC */
+    CLOCK_SetMux(kCLOCK_PeriphMux, 1);     /* Set PERIPH_CLK MUX to PERIPH_CLK2 */
+    /* Setting the VDD_SOC to 1.5V. It is necessary to config CORE to 500Mhz. */
+    DCDC->REG3 = (DCDC->REG3 & (~DCDC_REG3_TRG_MASK)) | DCDC_REG3_TRG(0x12);
+    /* Waiting for DCDC_STS_DC_OK bit is asserted */
+    while (DCDC_REG0_STS_DC_OK_MASK != (DCDC_REG0_STS_DC_OK_MASK & DCDC->REG0))
+    {
+    }
+    /* Set AHB_PODF. */
+    CLOCK_SetDiv(kCLOCK_AhbDiv, 0);
+    /* Disable IPG clock gate. */
+    CLOCK_DisableClock(kCLOCK_Adc1);
+    CLOCK_DisableClock(kCLOCK_Xbar1);
+    /* Set IPG_PODF. */
+    CLOCK_SetDiv(kCLOCK_IpgDiv, 3);
+    /* Disable PERCLK clock gate. */
+    CLOCK_DisableClock(kCLOCK_Gpt1);
+    CLOCK_DisableClock(kCLOCK_Gpt1S);
+    CLOCK_DisableClock(kCLOCK_Gpt2);
+    CLOCK_DisableClock(kCLOCK_Gpt2S);
+    CLOCK_DisableClock(kCLOCK_Pit);
+    /* Set PERCLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_PerclkDiv, 1);
+    /* In SDK projects, external flash (configured by FLEXSPI) will be initialized by dcd.
+     * With this macro XIP_EXTERNAL_FLASH, usb1 pll (selected to be FLEXSPI clock source in SDK projects) will be left
+     * unchanged. Note: If another clock source is selected for FLEXSPI, user may want to avoid changing that clock as
+     * well.*/
+#if !(defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
+    /* Disable Flexspi clock gate. */
+    CLOCK_DisableClock(kCLOCK_FlexSpi);
+    /* Set FLEXSPI_PODF. */
+    CLOCK_SetDiv(kCLOCK_FlexspiDiv, 3);
+    /* Set Flexspi clock source. */
+    CLOCK_SetMux(kCLOCK_FlexspiMux, 0);
+    CLOCK_SetMux(kCLOCK_FlexspiSrcMux, 0);
+#endif
+    /* Disable ADC_ACLK_EN clock gate. */
+    CCM->CSCMR2 &= ~CCM_CSCMR2_ADC_ACLK_EN_MASK;
+    /* Set ADC_ACLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_AdcDiv, 11);
+    /* Disable LPSPI clock gate. */
+    CLOCK_DisableClock(kCLOCK_Lpspi1);
+    CLOCK_DisableClock(kCLOCK_Lpspi2);
+    /* Set LPSPI_PODF. */
+    CLOCK_SetDiv(kCLOCK_LpspiDiv, 4);
+    /* Set Lpspi clock source. */
+    CLOCK_SetMux(kCLOCK_LpspiMux, 2);
+    /* Disable TRACE clock gate. */
+    CLOCK_DisableClock(kCLOCK_Trace);
+    /* Set TRACE_PODF. */
+    CLOCK_SetDiv(kCLOCK_TraceDiv, 2);
+    /* Set Trace clock source. */
+    CLOCK_SetMux(kCLOCK_TraceMux, 2);
+    /* Disable SAI1 clock gate. */
+    CLOCK_DisableClock(kCLOCK_Sai1);
+    /* Set SAI1_CLK_PRED. */
+    CLOCK_SetDiv(kCLOCK_Sai1PreDiv, 3);
+    /* Set SAI1_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Sai1Div, 1);
+    /* Set Sai1 clock source. */
+    CLOCK_SetMux(kCLOCK_Sai1Mux, 0);
+    /* Disable SAI3 clock gate. */
+    CLOCK_DisableClock(kCLOCK_Sai3);
+    /* Set SAI3_CLK_PRED. */
+    CLOCK_SetDiv(kCLOCK_Sai3PreDiv, 3);
+    /* Set SAI3_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Sai3Div, 1);
+    /* Set Sai3 clock source. */
+    CLOCK_SetMux(kCLOCK_Sai3Mux, 0);
+    /* Disable Lpi2c clock gate. */
+    CLOCK_DisableClock(kCLOCK_Lpi2c1);
+    CLOCK_DisableClock(kCLOCK_Lpi2c2);
+    /* Set LPI2C_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Lpi2cDiv, 0);
+    /* Set Lpi2c clock source. */
+    CLOCK_SetMux(kCLOCK_Lpi2cMux, 0);
+    /* Disable UART clock gate. */
+    CLOCK_DisableClock(kCLOCK_Lpuart1);
+    CLOCK_DisableClock(kCLOCK_Lpuart2);
+    CLOCK_DisableClock(kCLOCK_Lpuart3);
+    CLOCK_DisableClock(kCLOCK_Lpuart4);
+    /* Set UART_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_UartDiv, 0);
+    /* Set Uart clock source. */
+    CLOCK_SetMux(kCLOCK_UartMux, 0);
+    /* Disable SPDIF clock gate. */
+    CLOCK_DisableClock(kCLOCK_Spdif);
+    /* Set SPDIF0_CLK_PRED. */
+    CLOCK_SetDiv(kCLOCK_Spdif0PreDiv, 1);
+    /* Set SPDIF0_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Spdif0Div, 7);
+    /* Set Spdif clock source. */
+    CLOCK_SetMux(kCLOCK_SpdifMux, 3);
+    /* Disable Flexio1 clock gate. */
+    CLOCK_DisableClock(kCLOCK_Flexio1);
+    /* Set FLEXIO1_CLK_PRED. */
+    CLOCK_SetDiv(kCLOCK_Flexio1PreDiv, 1);
+    /* Set FLEXIO1_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Flexio1Div, 7);
+    /* Set Flexio1 clock source. */
+    CLOCK_SetMux(kCLOCK_Flexio1Mux, 3);
+    /* Set Pll3 sw clock source. */
+    CLOCK_SetMux(kCLOCK_Pll3SwMux, 0);
+    /* Init System PLL. */
+    CLOCK_InitSysPll(&sysPllConfig_BOARD_BootClockRUN);
+    /* Init System pfd0. */
+    CLOCK_InitSysPfd(kCLOCK_Pfd0, 27);
+    /* Init System pfd1. */
+    CLOCK_InitSysPfd(kCLOCK_Pfd1, 16);
+    /* Init System pfd2. */
+    CLOCK_InitSysPfd(kCLOCK_Pfd2, 18);
+    /* Init System pfd3. */
+    CLOCK_InitSysPfd(kCLOCK_Pfd3, 18);
+    /* In SDK projects, external flash (configured by FLEXSPI) will be initialized by dcd.
+     * With this macro XIP_EXTERNAL_FLASH, usb1 pll (selected to be FLEXSPI clock source in SDK projects) will be left
+     * unchanged. Note: If another clock source is selected for FLEXSPI, user may want to avoid changing that clock as
+     * well.*/
+#if !(defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
+    /* Init Usb1 PLL. */
+    CLOCK_InitUsb1Pll(&usb1PllConfig_BOARD_BootClockRUN);
+    /* Init Usb1 pfd0. */
+    CLOCK_InitUsb1Pfd(kCLOCK_Pfd0, 22);
+    /* Init Usb1 pfd1. */
+    CLOCK_InitUsb1Pfd(kCLOCK_Pfd1, 16);
+    /* Init Usb1 pfd2. */
+    CLOCK_InitUsb1Pfd(kCLOCK_Pfd2, 17);
+    /* Init Usb1 pfd3. */
+    CLOCK_InitUsb1Pfd(kCLOCK_Pfd3, 18);
+    /* Disable Usb1 PLL output for USBPHY1. */
+    CCM_ANALOG->PLL_USB1 &= ~CCM_ANALOG_PLL_USB1_EN_USB_CLKS_MASK;
+#endif
+    /* DeInit Audio PLL. */
+    CLOCK_DeinitAudioPll();
+    /* Bypass Audio PLL. */
+    CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllAudio, 1);
+    /* Set divider for Audio PLL. */
+    CCM_ANALOG->MISC2 &= ~CCM_ANALOG_MISC2_AUDIO_DIV_LSB_MASK;
+    CCM_ANALOG->MISC2 &= ~CCM_ANALOG_MISC2_AUDIO_DIV_MSB_MASK;
+    /* Enable Audio PLL output. */
+    CCM_ANALOG->PLL_AUDIO |= CCM_ANALOG_PLL_AUDIO_ENABLE_MASK;
+    /* Init Enet PLL. */
+    CLOCK_InitEnetPll(&enetPllConfig_BOARD_BootClockRUN);
+    /* Set preperiph clock source. */
+    CLOCK_SetMux(kCLOCK_PrePeriphMux, 3);
+    /* Set periph clock source. */
+    CLOCK_SetMux(kCLOCK_PeriphMux, 0);
+    /* Set periph clock2 clock source. */
+    CLOCK_SetMux(kCLOCK_PeriphClk2Mux, 0);
+    /* Set per clock source. */
+    CLOCK_SetMux(kCLOCK_PerclkMux, 0);
+    /* Set clock out1 divider. */
+    CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO1_DIV_MASK)) | CCM_CCOSR_CLKO1_DIV(0);
+    /* Set clock out1 source. */
+    CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO1_SEL_MASK)) | CCM_CCOSR_CLKO1_SEL(1);
+    /* Set clock out2 divider. */
+    CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO2_DIV_MASK)) | CCM_CCOSR_CLKO2_DIV(0);
+    /* Set clock out2 source. */
+    CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO2_SEL_MASK)) | CCM_CCOSR_CLKO2_SEL(18);
+    /* Set clock out1 drives clock out1. */
+    CCM->CCOSR &= ~CCM_CCOSR_CLK_OUT_SEL_MASK;
+    /* Disable clock out1. */
+    CCM->CCOSR &= ~CCM_CCOSR_CLKO1_EN_MASK;
+    /* Disable clock out2. */
+    CCM->CCOSR &= ~CCM_CCOSR_CLKO2_EN_MASK;
+    /* Set SAI1 MCLK1 clock source. */
+    IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk1Sel, 0);
+    /* Set SAI1 MCLK2 clock source. */
+    IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk2Sel, 0);
+    /* Set SAI1 MCLK3 clock source. */
+    IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk3Sel, 0);
+    /* Set SAI3 MCLK3 clock source. */
+    IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI3MClk3Sel, 0);
+    /* Set MQS configuration. */
+    IOMUXC_MQSConfig(IOMUXC_GPR, kIOMUXC_MqsPwmOverSampleRate32, 0);
+    /* Set GPT1 High frequency reference clock source. */
+    IOMUXC_GPR->GPR5 &= ~IOMUXC_GPR_GPR5_VREF_1M_CLK_GPT1_MASK;
+    /* Set GPT2 High frequency reference clock source. */
+    IOMUXC_GPR->GPR5 &= ~IOMUXC_GPR_GPR5_VREF_1M_CLK_GPT2_MASK;
+    /* Set SystemCoreClock variable. */
+    SystemCoreClock = BOARD_BOOTCLOCKRUN_CORE_CLOCK;
+}

--- a/ports/mimxrt10xx/boards/makerdiary_rt1011/clock_config.h
+++ b/ports/mimxrt10xx/boards/makerdiary_rt1011/clock_config.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2019 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _CLOCK_CONFIG_H_
+#define _CLOCK_CONFIG_H_
+
+#include "fsl_common.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+#define BOARD_XTAL0_CLK_HZ 24000000U /*!< Board xtal0 frequency in Hz */
+
+#define BOARD_XTAL32K_CLK_HZ 32768U /*!< Board xtal32k frequency in Hz */
+/*******************************************************************************
+ ************************ BOARD_InitBootClocks function ************************
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+/*!
+ * @brief This function executes default configuration of clocks.
+ *
+ */
+void BOARD_InitBootClocks(void);
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus*/
+
+/*******************************************************************************
+ ********************** Configuration BOARD_BootClockRUN ***********************
+ ******************************************************************************/
+/*******************************************************************************
+ * Definitions for BOARD_BootClockRUN configuration
+ ******************************************************************************/
+#define BOARD_BOOTCLOCKRUN_CORE_CLOCK 500000000U /*!< Core clock frequency: 500000000Hz */
+
+/* Clock outputs (values are in Hz): */
+#define BOARD_BOOTCLOCKRUN_ADC_ALT_CLK 40000000UL
+#define BOARD_BOOTCLOCKRUN_CKIL_SYNC_CLK_ROOT 32768UL
+#define BOARD_BOOTCLOCKRUN_CLKO1_CLK 0UL
+#define BOARD_BOOTCLOCKRUN_CLKO2_CLK 0UL
+#define BOARD_BOOTCLOCKRUN_CLK_1M 1000000UL
+#define BOARD_BOOTCLOCKRUN_CLK_24M 24000000UL
+#define BOARD_BOOTCLOCKRUN_CORE_CLK_ROOT 500000000UL
+#define BOARD_BOOTCLOCKRUN_ENET_500M_REF_CLK 500000000UL
+#define BOARD_BOOTCLOCKRUN_FLEXIO1_CLK_ROOT 30000000UL
+#define BOARD_BOOTCLOCKRUN_FLEXSPI_CLK_ROOT 132000000UL
+#define BOARD_BOOTCLOCKRUN_GPT1_IPG_CLK_HIGHFREQ 62500000UL
+#define BOARD_BOOTCLOCKRUN_GPT2_IPG_CLK_HIGHFREQ 62500000UL
+#define BOARD_BOOTCLOCKRUN_IPG_CLK_ROOT 125000000UL
+#define BOARD_BOOTCLOCKRUN_LPI2C_CLK_ROOT 60000000UL
+#define BOARD_BOOTCLOCKRUN_LPSPI_CLK_ROOT 105600000UL
+#define BOARD_BOOTCLOCKRUN_MQS_MCLK 63529411UL
+#define BOARD_BOOTCLOCKRUN_PERCLK_CLK_ROOT 62500000UL
+#define BOARD_BOOTCLOCKRUN_SAI1_CLK_ROOT 63529411UL
+#define BOARD_BOOTCLOCKRUN_SAI1_MCLK1 63529411UL
+#define BOARD_BOOTCLOCKRUN_SAI1_MCLK2 63529411UL
+#define BOARD_BOOTCLOCKRUN_SAI1_MCLK3 30000000UL
+#define BOARD_BOOTCLOCKRUN_SAI3_CLK_ROOT 63529411UL
+#define BOARD_BOOTCLOCKRUN_SAI3_MCLK1 63529411UL
+#define BOARD_BOOTCLOCKRUN_SAI3_MCLK2 0UL
+#define BOARD_BOOTCLOCKRUN_SAI3_MCLK3 30000000UL
+#define BOARD_BOOTCLOCKRUN_SPDIF0_CLK_ROOT 30000000UL
+#define BOARD_BOOTCLOCKRUN_SPDIF0_EXTCLK_OUT 0UL
+#define BOARD_BOOTCLOCKRUN_TRACE_CLK_ROOT 117333333UL
+#define BOARD_BOOTCLOCKRUN_UART_CLK_ROOT 80000000UL
+#define BOARD_BOOTCLOCKRUN_USBPHY_CLK 0UL
+
+/*! @brief Usb1 PLL set for BOARD_BootClockRUN configuration.
+ */
+extern const clock_usb_pll_config_t usb1PllConfig_BOARD_BootClockRUN;
+/*! @brief Sys PLL for BOARD_BootClockRUN configuration.
+ */
+extern const clock_sys_pll_config_t sysPllConfig_BOARD_BootClockRUN;
+/*! @brief Enet PLL set for BOARD_BootClockRUN configuration.
+ */
+extern const clock_enet_pll_config_t enetPllConfig_BOARD_BootClockRUN;
+
+/*******************************************************************************
+ * API for BOARD_BootClockRUN configuration
+ ******************************************************************************/
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+/*!
+ * @brief This function executes configuration of clocks.
+ *
+ */
+void BOARD_BootClockRUN(void);
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus*/
+
+#endif /* _CLOCK_CONFIG_H_ */

--- a/ports/mimxrt10xx/boards/makerdiary_rt1011/flash_config.c
+++ b/ports/mimxrt10xx/boards/makerdiary_rt1011/flash_config.c
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2017 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "flexspi_nor_flash.h"
+#include "fsl_flexspi_nor_boot.h"
+#include "boards.h"
+
+
+__attribute__((section(".boot_hdr.ivt")))
+/*************************************
+ *  IVT Data
+ *************************************/
+const ivt image_vector_table = {
+  IVT_HEADER,                         /* IVT Header */
+  IMAGE_ENTRY_ADDRESS,                /* Image Entry Function */
+  IVT_RSVD,                           /* Reserved = 0 */
+  (uint32_t)DCD_ADDRESS,              /* Address where DCD information is stored */
+  (uint32_t)BOOT_DATA_ADDRESS,        /* Address where BOOT Data Structure is stored */
+  (uint32_t)&image_vector_table,      /* Pointer to IVT Self (absolute address) */
+  (uint32_t)CSF_ADDRESS,              /* Address where CSF file is stored */
+  IVT_RSVD                            /* Reserved = 0 */
+};
+
+__attribute__((section(".boot_hdr.boot_data")))
+/*************************************
+ *  Boot Data
+ *************************************/
+const BOOT_DATA_T g_boot_data = {
+  BOARD_BOOT_START,           /* boot start location */
+  BOARD_BOOT_LENGTH,
+  PLUGIN_FLAG,                /* Plugin flag */
+  0xFFFFFFFF                  /* empty - extra data word */
+};
+
+// Config for AT25SF128A with QSPI routed.
+__attribute__((section(".boot_hdr.conf")))
+const flexspi_nor_config_t qspiflash_config = {
+    .pageSize           = 256u,
+    .sectorSize         = 4u * 1024u,
+    .ipcmdSerialClkFreq = kFlexSpiSerialClk_30MHz,
+    .blockSize          = 0x00010000,
+    .isUniformBlockSize = false,
+    .memConfig =
+    {
+        .tag              = FLEXSPI_CFG_BLK_TAG,
+        .version          = FLEXSPI_CFG_BLK_VERSION,
+        .readSampleClkSrc = kFlexSPIReadSampleClk_LoopbackFromSckPad,
+        .csHoldTime       = 3u,
+        .csSetupTime      = 3u,
+
+        .busyOffset = 0u, // Status bit 0 indicates busy.
+        .busyBitPolarity = 0u, // Busy when the bit is 1.
+
+        .deviceModeCfgEnable = 1u,
+        .deviceModeType = kDeviceConfigCmdType_QuadEnable,
+        .deviceModeSeq = {
+          .seqId = 4u,
+          .seqNum = 1u,
+        },
+        .deviceModeArg = 0x200,
+        .deviceType    = kFlexSpiDeviceType_SerialNOR,
+        .sflashPadType = kSerialFlash_4Pads,
+        .serialClkFreq = kFlexSpiSerialClk_60MHz,
+        .sflashA1Size  = FLASH_SIZE,
+        .lookupTable =
+        {
+            // FLEXSPI_LUT_SEQ(cmd0, pad0, op0, cmd1, pad1, op1)
+            // The high 16 bits is command 1 and the low are command 0.
+            // Within a command, the top 6 bits are the opcode, the next two are the number
+            // of pads and then last byte is the operand. The operand's meaning changes
+            // per opcode.
+
+            // Indices with ROM should always have the same function because the ROM
+            // bootloader uses it.
+
+            // 0: ROM: Read LUTs
+            // Quad version
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR,   FLEXSPI_1PAD, 0xEB /* the command to send */,
+                                     RADDR_SDR, FLEXSPI_4PAD, 24 /* bits to transmit */),
+                     FLEXSPI_LUT_SEQ(DUMMY_SDR, FLEXSPI_4PAD, 6 /* 6 dummy cycles, 2 for M7-0 and 4 dummy */,
+                                     READ_SDR,  FLEXSPI_4PAD, 0x04),
+            // Single fast read version, good for debugging.
+            // FLEXSPI_LUT_SEQ(CMD_SDR,   FLEXSPI_1PAD, 0x0B /* the command to send */,
+            //                 RADDR_SDR, FLEXSPI_1PAD, 24  /* bits to transmit */),
+            // FLEXSPI_LUT_SEQ(DUMMY_SDR, FLEXSPI_1PAD, 8 /* 8 dummy clocks */,
+            //                 READ_SDR,  FLEXSPI_1PAD, 0x04),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 1: ROM: Read status
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR,  FLEXSPI_1PAD, 0x05  /* the command to send */,
+                                     READ_SDR, FLEXSPI_1PAD, 0x02),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 2: Empty
+            EMPTY_SEQUENCE,
+
+            // 3: ROM: Write Enable
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x06  /* the command to send */,
+                                     STOP,    FLEXSPI_1PAD, 0x00),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 4: Config: Write Status
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR,   FLEXSPI_1PAD, 0x01  /* the command to send */,
+                                     WRITE_SDR, FLEXSPI_1PAD, 0x02),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 5: ROM: Erase Sector
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR,   FLEXSPI_1PAD, 0x20  /* the command to send */,
+                                     RADDR_SDR, FLEXSPI_1PAD, 24 /* bits to transmit */),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 6: Empty
+            EMPTY_SEQUENCE,
+
+            // 7: Empty
+            EMPTY_SEQUENCE,
+
+            // 8: Block Erase
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR,   FLEXSPI_1PAD, 0xD8  /* the command to send */,
+                                     RADDR_SDR, FLEXSPI_1PAD, 24 /* bits to transmit */),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 9: ROM: Page program
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR,   FLEXSPI_1PAD, 0x02  /* the command to send */,
+                                     RADDR_SDR, FLEXSPI_1PAD, 24 /* bits to transmit */),
+
+                     FLEXSPI_LUT_SEQ(WRITE_SDR, FLEXSPI_1PAD, 0x04  /* data out */,
+                                     STOP,      FLEXSPI_1PAD, 0),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 10: Empty
+            EMPTY_SEQUENCE,
+
+            // 11: ROM: Chip erase
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x60  /* the command to send */,
+                                     STOP,    FLEXSPI_1PAD, 0),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 12: Empty
+            EMPTY_SEQUENCE,
+
+            // 13: ROM: Read SFDP
+            EMPTY_SEQUENCE,
+
+            // 14: ROM: Restore no cmd
+            EMPTY_SEQUENCE,
+
+            // 15: ROM: Dummy
+            EMPTY_SEQUENCE
+        },
+    },
+};

--- a/ports/mimxrt10xx/boards/olimex_rt1010/board.h
+++ b/ports/mimxrt10xx/boards/olimex_rt1010/board.h
@@ -1,0 +1,99 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Ha Thach for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+
+#ifndef BOARD_H_
+#define BOARD_H_
+
+// Size of on-board external flash
+#define BOARD_FLASH_SIZE     (2*1024*1024)
+
+//--------------------------------------------------------------------+
+// LED
+//--------------------------------------------------------------------+
+
+#define LED_PINMUX            IOMUXC_GPIO_11_GPIOMUX_IO11
+#define LED_PORT              GPIO1
+#define LED_PIN               11
+#define LED_STATE_ON          1
+
+#if 0
+// PWM Test on Arduino header D8
+#define LED_PWM_PINMUX        IOMUXC_GPIO_SD_02_FLEXPWM1_PWM0_A
+#define LED_PWM_BASE          PWM1
+#define LED_PWM_MODULE        kPWM_Module_0
+#define LED_PWM_CHANNEL       kPWM_PwmA
+#endif
+
+//--------------------------------------------------------------------+
+// Neopixel
+//--------------------------------------------------------------------+
+
+// Number of neopixels
+#if 1
+#define NEOPIXEL_NUMBER       0
+
+#else
+// Neopixel Test on Arduino header A0
+#define NEOPIXEL_NUMBER       1
+#define NEOPIXEL_PINMUX       IOMUXC_GPIO_AD_07_GPIOMUX_IO21
+#define NEOPIXEL_PORT         GPIO1
+#define NEOPIXEL_PIN          21
+#endif
+
+//--------------------------------------------------------------------+
+// Button
+//--------------------------------------------------------------------+
+
+// SW8 button
+#define BUTTON_PINMUX         IOMUXC_GPIO_SD_05_GPIO2_IO05
+#define BUTTON_PORT           GPIO2
+#define BUTTON_PIN            5
+#define BUTTON_STATE_ACTIVE   0
+
+//--------------------------------------------------------------------+
+// USB UF2
+//--------------------------------------------------------------------+
+
+#define USB_VID           0x15ba
+#define USB_PID           0x0046
+#define USB_MANUFACTURER  "Olimex"
+#define USB_PRODUCT       "RT1010"
+
+#define UF2_PRODUCT_NAME  USB_MANUFACTURER " " USB_PRODUCT
+#define UF2_BOARD_ID      "MIMXRT1011-RT1010Py-V1"
+#define UF2_VOLUME_LABEL  "RT1010BOOT"
+#define UF2_INDEX_URL     "https://www.olimex.com/Products/MicroPython/RT1010-Py"
+
+//--------------------------------------------------------------------+
+// UART
+//--------------------------------------------------------------------+
+
+#define UART_DEV              LPUART1
+#define UART_RX_PINMUX        IOMUXC_GPIO_09_LPUART1_RXD
+#define UART_TX_PINMUX        IOMUXC_GPIO_10_LPUART1_TXD
+
+#endif /* BOARD_H_ */

--- a/ports/mimxrt10xx/boards/olimex_rt1010/board.mk
+++ b/ports/mimxrt10xx/boards/olimex_rt1010/board.mk
@@ -1,0 +1,12 @@
+MCU = MIMXRT1011
+CFLAGS += -DCPU_MIMXRT1011DAE5A
+
+# For flash-jlink target
+JLINK_DEVICE = MIMXRT1011DAE5A
+
+# For flash-pyocd target
+PYOCD_TARGET = mimxrt1010
+
+# flash using pyocd
+flash: flash-pyocd-bin
+erase: erase-pyocd

--- a/ports/mimxrt10xx/boards/olimex_rt1010/clock_config.c
+++ b/ports/mimxrt10xx/boards/olimex_rt1010/clock_config.c
@@ -1,0 +1,345 @@
+/*
+ * Copyright 2019 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * How to setup clock using clock driver functions:
+ *
+ * 1. Call CLOCK_InitXXXPLL() to configure corresponding PLL clock.
+ *
+ * 2. Call CLOCK_InitXXXpfd() to configure corresponding PLL pfd clock.
+ *
+ * 3. Call CLOCK_SetMux() to configure corresponding clock source for target clock out.
+ *
+ * 4. Call CLOCK_SetDiv() to configure corresponding clock divider for target clock out.
+ *
+ * 5. Call CLOCK_SetXtalFreq() to set XTAL frequency based on board settings.
+ *
+ */
+
+/* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
+!!GlobalInfo
+product: Clocks v6.0
+processor: MIMXRT1011xxxxx
+package_id: MIMXRT1011DAE5A
+mcu_data: ksdk2_0
+processor_version: 0.0.1
+board: MIMXRT1010-EVK
+ * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
+
+#include "clock_config.h"
+#include "fsl_iomuxc.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+/* System clock frequency. */
+extern uint32_t SystemCoreClock;
+
+/*******************************************************************************
+ ************************ BOARD_InitBootClocks function ************************
+ ******************************************************************************/
+void BOARD_InitBootClocks(void)
+{
+    BOARD_BootClockRUN();
+}
+
+/*******************************************************************************
+ ********************** Configuration BOARD_BootClockRUN ***********************
+ ******************************************************************************/
+/* TEXT BELOW IS USED AS SETTING FOR TOOLS *************************************
+!!Configuration
+name: BOARD_BootClockRUN
+called_from_default_init: true
+outputs:
+- {id: ADC_ALT_CLK.outFreq, value: 40 MHz}
+- {id: CKIL_SYNC_CLK_ROOT.outFreq, value: 32.768 kHz}
+- {id: CLK_1M.outFreq, value: 1 MHz}
+- {id: CLK_24M.outFreq, value: 24 MHz}
+- {id: CORE_CLK_ROOT.outFreq, value: 500 MHz}
+- {id: ENET_500M_REF_CLK.outFreq, value: 500 MHz}
+- {id: FLEXIO1_CLK_ROOT.outFreq, value: 30 MHz}
+- {id: FLEXSPI_CLK_ROOT.outFreq, value: 132 MHz}
+- {id: GPT1_ipg_clk_highfreq.outFreq, value: 62.5 MHz}
+- {id: GPT2_ipg_clk_highfreq.outFreq, value: 62.5 MHz}
+- {id: IPG_CLK_ROOT.outFreq, value: 125 MHz}
+- {id: LPI2C_CLK_ROOT.outFreq, value: 60 MHz}
+- {id: LPSPI_CLK_ROOT.outFreq, value: 105.6 MHz}
+- {id: MQS_MCLK.outFreq, value: 1080/17 MHz}
+- {id: PERCLK_CLK_ROOT.outFreq, value: 62.5 MHz}
+- {id: SAI1_CLK_ROOT.outFreq, value: 1080/17 MHz}
+- {id: SAI1_MCLK1.outFreq, value: 1080/17 MHz}
+- {id: SAI1_MCLK2.outFreq, value: 1080/17 MHz}
+- {id: SAI1_MCLK3.outFreq, value: 30 MHz}
+- {id: SAI3_CLK_ROOT.outFreq, value: 1080/17 MHz}
+- {id: SAI3_MCLK1.outFreq, value: 1080/17 MHz}
+- {id: SAI3_MCLK3.outFreq, value: 30 MHz}
+- {id: SPDIF0_CLK_ROOT.outFreq, value: 30 MHz}
+- {id: TRACE_CLK_ROOT.outFreq, value: 352/3 MHz}
+- {id: UART_CLK_ROOT.outFreq, value: 80 MHz}
+settings:
+- {id: CCM.ADC_ACLK_PODF.scale, value: '12', locked: true}
+- {id: CCM.AHB_PODF.scale, value: '1', locked: true}
+- {id: CCM.FLEXSPI_PODF.scale, value: '4', locked: true}
+- {id: CCM.IPG_PODF.scale, value: '4'}
+- {id: CCM.LPSPI_PODF.scale, value: '5', locked: true}
+- {id: CCM.PERCLK_PODF.scale, value: '2', locked: true}
+- {id: CCM.PRE_PERIPH_CLK_SEL.sel, value: CCM_ANALOG.ENET_500M_REF_CLK}
+- {id: CCM.SAI1_CLK_SEL.sel, value: CCM_ANALOG.PLL3_PFD2_CLK}
+- {id: CCM.SAI3_CLK_SEL.sel, value: CCM_ANALOG.PLL3_PFD2_CLK}
+- {id: CCM.TRACE_PODF.scale, value: '3', locked: true}
+- {id: CCM_ANALOG.PLL2.denom, value: '1'}
+- {id: CCM_ANALOG.PLL2.div, value: '22'}
+- {id: CCM_ANALOG.PLL2.num, value: '0'}
+- {id: CCM_ANALOG.PLL2_BYPASS.sel, value: CCM_ANALOG.PLL2_OUT_CLK}
+- {id: CCM_ANALOG.PLL2_PFD0_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD0}
+- {id: CCM_ANALOG.PLL2_PFD1_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD1}
+- {id: CCM_ANALOG.PLL2_PFD2_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD2}
+- {id: CCM_ANALOG.PLL2_PFD2_DIV.scale, value: '18', locked: true}
+- {id: CCM_ANALOG.PLL2_PFD2_MUL.scale, value: '18', locked: true}
+- {id: CCM_ANALOG.PLL2_PFD3_BYPASS.sel, value: CCM_ANALOG.PLL2_PFD3}
+- {id: CCM_ANALOG.PLL2_PFD3_DIV.scale, value: '18', locked: true}
+- {id: CCM_ANALOG.PLL2_PFD3_MUL.scale, value: '18', locked: true}
+- {id: CCM_ANALOG.PLL3_BYPASS.sel, value: CCM_ANALOG.PLL3}
+- {id: CCM_ANALOG.PLL3_PFD0_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD0}
+- {id: CCM_ANALOG.PLL3_PFD0_DIV.scale, value: '22', locked: true}
+- {id: CCM_ANALOG.PLL3_PFD0_MUL.scale, value: '18', locked: true}
+- {id: CCM_ANALOG.PLL3_PFD1_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD1}
+- {id: CCM_ANALOG.PLL3_PFD2_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD2}
+- {id: CCM_ANALOG.PLL3_PFD3_BYPASS.sel, value: CCM_ANALOG.PLL3_PFD3}
+- {id: CCM_ANALOG.PLL3_PFD3_DIV.scale, value: '18', locked: true}
+- {id: CCM_ANALOG.PLL3_PFD3_MUL.scale, value: '18', locked: true}
+- {id: CCM_ANALOG.PLL6_BYPASS.sel, value: CCM_ANALOG.PLL6}
+- {id: CCM_ANALOG_PLL_USB1_POWER_CFG, value: 'Yes'}
+sources:
+- {id: XTALOSC24M.OSC.outFreq, value: 24 MHz, enabled: true}
+- {id: XTALOSC24M.RTC_OSC.outFreq, value: 32.768 kHz, enabled: true}
+ * BE CAREFUL MODIFYING THIS COMMENT - IT IS YAML SETTINGS FOR TOOLS **********/
+
+/*******************************************************************************
+ * Variables for BOARD_BootClockRUN configuration
+ ******************************************************************************/
+const clock_sys_pll_config_t sysPllConfig_BOARD_BootClockRUN = {
+    .loopDivider = 1, /* PLL loop divider, Fout = Fin * ( 20 + loopDivider*2 + numerator / denominator ) */
+    .numerator   = 0, /* 30 bit numerator of fractional loop divider */
+    .denominator = 1, /* 30 bit denominator of fractional loop divider */
+    .src         = 0, /* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+};
+const clock_usb_pll_config_t usb1PllConfig_BOARD_BootClockRUN = {
+    .loopDivider = 0, /* PLL loop divider, Fout = Fin * 20 */
+    .src         = 0, /* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+};
+const clock_enet_pll_config_t enetPllConfig_BOARD_BootClockRUN = {
+    .enableClkOutput500M = true, /* Enable the PLL providing the ENET 500MHz reference clock */
+    .src                 = 0,    /* Bypass clock source, 0 - OSC 24M, 1 - CLK1_P and CLK1_N */
+};
+/*******************************************************************************
+ * Code for BOARD_BootClockRUN configuration
+ ******************************************************************************/
+void BOARD_BootClockRUN(void)
+{
+    /* Init RTC OSC clock frequency. */
+    CLOCK_SetRtcXtalFreq(32768U);
+    /* Enable 1MHz clock output. */
+    XTALOSC24M->OSC_CONFIG2 |= XTALOSC24M_OSC_CONFIG2_ENABLE_1M_MASK;
+    /* Use free 1MHz clock output. */
+    XTALOSC24M->OSC_CONFIG2 &= ~XTALOSC24M_OSC_CONFIG2_MUX_1M_MASK;
+    /* Set XTAL 24MHz clock frequency. */
+    CLOCK_SetXtalFreq(24000000U);
+    /* Enable XTAL 24MHz clock source. */
+    CLOCK_InitExternalClk(0);
+    /* Enable internal RC. */
+    CLOCK_InitRcOsc24M();
+    /* Switch clock source to external OSC. */
+    CLOCK_SwitchOsc(kCLOCK_XtalOsc);
+    /* Set Oscillator ready counter value. */
+    CCM->CCR = (CCM->CCR & (~CCM_CCR_OSCNT_MASK)) | CCM_CCR_OSCNT(127);
+    /* Setting PeriphClk2Mux and PeriphMux to provide stable clock before PLLs are initialed */
+    CLOCK_SetMux(kCLOCK_PeriphClk2Mux, 1); /* Set PERIPH_CLK2 MUX to OSC */
+    CLOCK_SetMux(kCLOCK_PeriphMux, 1);     /* Set PERIPH_CLK MUX to PERIPH_CLK2 */
+    /* Setting the VDD_SOC to 1.5V. It is necessary to config CORE to 500Mhz. */
+    DCDC->REG3 = (DCDC->REG3 & (~DCDC_REG3_TRG_MASK)) | DCDC_REG3_TRG(0x12);
+    /* Waiting for DCDC_STS_DC_OK bit is asserted */
+    while (DCDC_REG0_STS_DC_OK_MASK != (DCDC_REG0_STS_DC_OK_MASK & DCDC->REG0))
+    {
+    }
+    /* Set AHB_PODF. */
+    CLOCK_SetDiv(kCLOCK_AhbDiv, 0);
+    /* Disable IPG clock gate. */
+    CLOCK_DisableClock(kCLOCK_Adc1);
+    CLOCK_DisableClock(kCLOCK_Xbar1);
+    /* Set IPG_PODF. */
+    CLOCK_SetDiv(kCLOCK_IpgDiv, 3);
+    /* Disable PERCLK clock gate. */
+    CLOCK_DisableClock(kCLOCK_Gpt1);
+    CLOCK_DisableClock(kCLOCK_Gpt1S);
+    CLOCK_DisableClock(kCLOCK_Gpt2);
+    CLOCK_DisableClock(kCLOCK_Gpt2S);
+    CLOCK_DisableClock(kCLOCK_Pit);
+    /* Set PERCLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_PerclkDiv, 1);
+    /* In SDK projects, external flash (configured by FLEXSPI) will be initialized by dcd.
+     * With this macro XIP_EXTERNAL_FLASH, usb1 pll (selected to be FLEXSPI clock source in SDK projects) will be left
+     * unchanged. Note: If another clock source is selected for FLEXSPI, user may want to avoid changing that clock as
+     * well.*/
+#if !(defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
+    /* Disable Flexspi clock gate. */
+    CLOCK_DisableClock(kCLOCK_FlexSpi);
+    /* Set FLEXSPI_PODF. */
+    CLOCK_SetDiv(kCLOCK_FlexspiDiv, 3);
+    /* Set Flexspi clock source. */
+    CLOCK_SetMux(kCLOCK_FlexspiMux, 0);
+    CLOCK_SetMux(kCLOCK_FlexspiSrcMux, 0);
+#endif
+    /* Disable ADC_ACLK_EN clock gate. */
+    CCM->CSCMR2 &= ~CCM_CSCMR2_ADC_ACLK_EN_MASK;
+    /* Set ADC_ACLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_AdcDiv, 11);
+    /* Disable LPSPI clock gate. */
+    CLOCK_DisableClock(kCLOCK_Lpspi1);
+    CLOCK_DisableClock(kCLOCK_Lpspi2);
+    /* Set LPSPI_PODF. */
+    CLOCK_SetDiv(kCLOCK_LpspiDiv, 4);
+    /* Set Lpspi clock source. */
+    CLOCK_SetMux(kCLOCK_LpspiMux, 2);
+    /* Disable TRACE clock gate. */
+    CLOCK_DisableClock(kCLOCK_Trace);
+    /* Set TRACE_PODF. */
+    CLOCK_SetDiv(kCLOCK_TraceDiv, 2);
+    /* Set Trace clock source. */
+    CLOCK_SetMux(kCLOCK_TraceMux, 2);
+    /* Disable SAI1 clock gate. */
+    CLOCK_DisableClock(kCLOCK_Sai1);
+    /* Set SAI1_CLK_PRED. */
+    CLOCK_SetDiv(kCLOCK_Sai1PreDiv, 3);
+    /* Set SAI1_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Sai1Div, 1);
+    /* Set Sai1 clock source. */
+    CLOCK_SetMux(kCLOCK_Sai1Mux, 0);
+    /* Disable SAI3 clock gate. */
+    CLOCK_DisableClock(kCLOCK_Sai3);
+    /* Set SAI3_CLK_PRED. */
+    CLOCK_SetDiv(kCLOCK_Sai3PreDiv, 3);
+    /* Set SAI3_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Sai3Div, 1);
+    /* Set Sai3 clock source. */
+    CLOCK_SetMux(kCLOCK_Sai3Mux, 0);
+    /* Disable Lpi2c clock gate. */
+    CLOCK_DisableClock(kCLOCK_Lpi2c1);
+    CLOCK_DisableClock(kCLOCK_Lpi2c2);
+    /* Set LPI2C_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Lpi2cDiv, 0);
+    /* Set Lpi2c clock source. */
+    CLOCK_SetMux(kCLOCK_Lpi2cMux, 0);
+    /* Disable UART clock gate. */
+    CLOCK_DisableClock(kCLOCK_Lpuart1);
+    CLOCK_DisableClock(kCLOCK_Lpuart2);
+    CLOCK_DisableClock(kCLOCK_Lpuart3);
+    CLOCK_DisableClock(kCLOCK_Lpuart4);
+    /* Set UART_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_UartDiv, 0);
+    /* Set Uart clock source. */
+    CLOCK_SetMux(kCLOCK_UartMux, 0);
+    /* Disable SPDIF clock gate. */
+    CLOCK_DisableClock(kCLOCK_Spdif);
+    /* Set SPDIF0_CLK_PRED. */
+    CLOCK_SetDiv(kCLOCK_Spdif0PreDiv, 1);
+    /* Set SPDIF0_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Spdif0Div, 7);
+    /* Set Spdif clock source. */
+    CLOCK_SetMux(kCLOCK_SpdifMux, 3);
+    /* Disable Flexio1 clock gate. */
+    CLOCK_DisableClock(kCLOCK_Flexio1);
+    /* Set FLEXIO1_CLK_PRED. */
+    CLOCK_SetDiv(kCLOCK_Flexio1PreDiv, 1);
+    /* Set FLEXIO1_CLK_PODF. */
+    CLOCK_SetDiv(kCLOCK_Flexio1Div, 7);
+    /* Set Flexio1 clock source. */
+    CLOCK_SetMux(kCLOCK_Flexio1Mux, 3);
+    /* Set Pll3 sw clock source. */
+    CLOCK_SetMux(kCLOCK_Pll3SwMux, 0);
+    /* Init System PLL. */
+    CLOCK_InitSysPll(&sysPllConfig_BOARD_BootClockRUN);
+    /* Init System pfd0. */
+    CLOCK_InitSysPfd(kCLOCK_Pfd0, 27);
+    /* Init System pfd1. */
+    CLOCK_InitSysPfd(kCLOCK_Pfd1, 16);
+    /* Init System pfd2. */
+    CLOCK_InitSysPfd(kCLOCK_Pfd2, 18);
+    /* Init System pfd3. */
+    CLOCK_InitSysPfd(kCLOCK_Pfd3, 18);
+    /* In SDK projects, external flash (configured by FLEXSPI) will be initialized by dcd.
+     * With this macro XIP_EXTERNAL_FLASH, usb1 pll (selected to be FLEXSPI clock source in SDK projects) will be left
+     * unchanged. Note: If another clock source is selected for FLEXSPI, user may want to avoid changing that clock as
+     * well.*/
+#if !(defined(XIP_EXTERNAL_FLASH) && (XIP_EXTERNAL_FLASH == 1))
+    /* Init Usb1 PLL. */
+    CLOCK_InitUsb1Pll(&usb1PllConfig_BOARD_BootClockRUN);
+    /* Init Usb1 pfd0. */
+    CLOCK_InitUsb1Pfd(kCLOCK_Pfd0, 22);
+    /* Init Usb1 pfd1. */
+    CLOCK_InitUsb1Pfd(kCLOCK_Pfd1, 16);
+    /* Init Usb1 pfd2. */
+    CLOCK_InitUsb1Pfd(kCLOCK_Pfd2, 17);
+    /* Init Usb1 pfd3. */
+    CLOCK_InitUsb1Pfd(kCLOCK_Pfd3, 18);
+    /* Disable Usb1 PLL output for USBPHY1. */
+    CCM_ANALOG->PLL_USB1 &= ~CCM_ANALOG_PLL_USB1_EN_USB_CLKS_MASK;
+#endif
+    /* DeInit Audio PLL. */
+    CLOCK_DeinitAudioPll();
+    /* Bypass Audio PLL. */
+    CLOCK_SetPllBypass(CCM_ANALOG, kCLOCK_PllAudio, 1);
+    /* Set divider for Audio PLL. */
+    CCM_ANALOG->MISC2 &= ~CCM_ANALOG_MISC2_AUDIO_DIV_LSB_MASK;
+    CCM_ANALOG->MISC2 &= ~CCM_ANALOG_MISC2_AUDIO_DIV_MSB_MASK;
+    /* Enable Audio PLL output. */
+    CCM_ANALOG->PLL_AUDIO |= CCM_ANALOG_PLL_AUDIO_ENABLE_MASK;
+    /* Init Enet PLL. */
+    CLOCK_InitEnetPll(&enetPllConfig_BOARD_BootClockRUN);
+    /* Set preperiph clock source. */
+    CLOCK_SetMux(kCLOCK_PrePeriphMux, 3);
+    /* Set periph clock source. */
+    CLOCK_SetMux(kCLOCK_PeriphMux, 0);
+    /* Set periph clock2 clock source. */
+    CLOCK_SetMux(kCLOCK_PeriphClk2Mux, 0);
+    /* Set per clock source. */
+    CLOCK_SetMux(kCLOCK_PerclkMux, 0);
+    /* Set clock out1 divider. */
+    CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO1_DIV_MASK)) | CCM_CCOSR_CLKO1_DIV(0);
+    /* Set clock out1 source. */
+    CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO1_SEL_MASK)) | CCM_CCOSR_CLKO1_SEL(1);
+    /* Set clock out2 divider. */
+    CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO2_DIV_MASK)) | CCM_CCOSR_CLKO2_DIV(0);
+    /* Set clock out2 source. */
+    CCM->CCOSR = (CCM->CCOSR & (~CCM_CCOSR_CLKO2_SEL_MASK)) | CCM_CCOSR_CLKO2_SEL(18);
+    /* Set clock out1 drives clock out1. */
+    CCM->CCOSR &= ~CCM_CCOSR_CLK_OUT_SEL_MASK;
+    /* Disable clock out1. */
+    CCM->CCOSR &= ~CCM_CCOSR_CLKO1_EN_MASK;
+    /* Disable clock out2. */
+    CCM->CCOSR &= ~CCM_CCOSR_CLKO2_EN_MASK;
+    /* Set SAI1 MCLK1 clock source. */
+    IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk1Sel, 0);
+    /* Set SAI1 MCLK2 clock source. */
+    IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk2Sel, 0);
+    /* Set SAI1 MCLK3 clock source. */
+    IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI1MClk3Sel, 0);
+    /* Set SAI3 MCLK3 clock source. */
+    IOMUXC_SetSaiMClkClockSource(IOMUXC_GPR, kIOMUXC_GPR_SAI3MClk3Sel, 0);
+    /* Set MQS configuration. */
+    IOMUXC_MQSConfig(IOMUXC_GPR, kIOMUXC_MqsPwmOverSampleRate32, 0);
+    /* Set GPT1 High frequency reference clock source. */
+    IOMUXC_GPR->GPR5 &= ~IOMUXC_GPR_GPR5_VREF_1M_CLK_GPT1_MASK;
+    /* Set GPT2 High frequency reference clock source. */
+    IOMUXC_GPR->GPR5 &= ~IOMUXC_GPR_GPR5_VREF_1M_CLK_GPT2_MASK;
+    /* Set SystemCoreClock variable. */
+    SystemCoreClock = BOARD_BOOTCLOCKRUN_CORE_CLOCK;
+}

--- a/ports/mimxrt10xx/boards/olimex_rt1010/clock_config.h
+++ b/ports/mimxrt10xx/boards/olimex_rt1010/clock_config.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2019 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _CLOCK_CONFIG_H_
+#define _CLOCK_CONFIG_H_
+
+#include "fsl_common.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+#define BOARD_XTAL0_CLK_HZ 24000000U /*!< Board xtal0 frequency in Hz */
+
+#define BOARD_XTAL32K_CLK_HZ 32768U /*!< Board xtal32k frequency in Hz */
+/*******************************************************************************
+ ************************ BOARD_InitBootClocks function ************************
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+/*!
+ * @brief This function executes default configuration of clocks.
+ *
+ */
+void BOARD_InitBootClocks(void);
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus*/
+
+/*******************************************************************************
+ ********************** Configuration BOARD_BootClockRUN ***********************
+ ******************************************************************************/
+/*******************************************************************************
+ * Definitions for BOARD_BootClockRUN configuration
+ ******************************************************************************/
+#define BOARD_BOOTCLOCKRUN_CORE_CLOCK 500000000U /*!< Core clock frequency: 500000000Hz */
+
+/* Clock outputs (values are in Hz): */
+#define BOARD_BOOTCLOCKRUN_ADC_ALT_CLK 40000000UL
+#define BOARD_BOOTCLOCKRUN_CKIL_SYNC_CLK_ROOT 32768UL
+#define BOARD_BOOTCLOCKRUN_CLKO1_CLK 0UL
+#define BOARD_BOOTCLOCKRUN_CLKO2_CLK 0UL
+#define BOARD_BOOTCLOCKRUN_CLK_1M 1000000UL
+#define BOARD_BOOTCLOCKRUN_CLK_24M 24000000UL
+#define BOARD_BOOTCLOCKRUN_CORE_CLK_ROOT 500000000UL
+#define BOARD_BOOTCLOCKRUN_ENET_500M_REF_CLK 500000000UL
+#define BOARD_BOOTCLOCKRUN_FLEXIO1_CLK_ROOT 30000000UL
+#define BOARD_BOOTCLOCKRUN_FLEXSPI_CLK_ROOT 132000000UL
+#define BOARD_BOOTCLOCKRUN_GPT1_IPG_CLK_HIGHFREQ 62500000UL
+#define BOARD_BOOTCLOCKRUN_GPT2_IPG_CLK_HIGHFREQ 62500000UL
+#define BOARD_BOOTCLOCKRUN_IPG_CLK_ROOT 125000000UL
+#define BOARD_BOOTCLOCKRUN_LPI2C_CLK_ROOT 60000000UL
+#define BOARD_BOOTCLOCKRUN_LPSPI_CLK_ROOT 105600000UL
+#define BOARD_BOOTCLOCKRUN_MQS_MCLK 63529411UL
+#define BOARD_BOOTCLOCKRUN_PERCLK_CLK_ROOT 62500000UL
+#define BOARD_BOOTCLOCKRUN_SAI1_CLK_ROOT 63529411UL
+#define BOARD_BOOTCLOCKRUN_SAI1_MCLK1 63529411UL
+#define BOARD_BOOTCLOCKRUN_SAI1_MCLK2 63529411UL
+#define BOARD_BOOTCLOCKRUN_SAI1_MCLK3 30000000UL
+#define BOARD_BOOTCLOCKRUN_SAI3_CLK_ROOT 63529411UL
+#define BOARD_BOOTCLOCKRUN_SAI3_MCLK1 63529411UL
+#define BOARD_BOOTCLOCKRUN_SAI3_MCLK2 0UL
+#define BOARD_BOOTCLOCKRUN_SAI3_MCLK3 30000000UL
+#define BOARD_BOOTCLOCKRUN_SPDIF0_CLK_ROOT 30000000UL
+#define BOARD_BOOTCLOCKRUN_SPDIF0_EXTCLK_OUT 0UL
+#define BOARD_BOOTCLOCKRUN_TRACE_CLK_ROOT 117333333UL
+#define BOARD_BOOTCLOCKRUN_UART_CLK_ROOT 80000000UL
+#define BOARD_BOOTCLOCKRUN_USBPHY_CLK 0UL
+
+/*! @brief Usb1 PLL set for BOARD_BootClockRUN configuration.
+ */
+extern const clock_usb_pll_config_t usb1PllConfig_BOARD_BootClockRUN;
+/*! @brief Sys PLL for BOARD_BootClockRUN configuration.
+ */
+extern const clock_sys_pll_config_t sysPllConfig_BOARD_BootClockRUN;
+/*! @brief Enet PLL set for BOARD_BootClockRUN configuration.
+ */
+extern const clock_enet_pll_config_t enetPllConfig_BOARD_BootClockRUN;
+
+/*******************************************************************************
+ * API for BOARD_BootClockRUN configuration
+ ******************************************************************************/
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+/*!
+ * @brief This function executes configuration of clocks.
+ *
+ */
+void BOARD_BootClockRUN(void);
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus*/
+
+#endif /* _CLOCK_CONFIG_H_ */

--- a/ports/mimxrt10xx/boards/olimex_rt1010/flash_config.c
+++ b/ports/mimxrt10xx/boards/olimex_rt1010/flash_config.c
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2017 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "flexspi_nor_flash.h"
+#include "fsl_flexspi_nor_boot.h"
+#include "boards.h"
+
+
+__attribute__((section(".boot_hdr.ivt")))
+/*************************************
+ *  IVT Data
+ *************************************/
+const ivt image_vector_table = {
+  IVT_HEADER,                         /* IVT Header */
+  IMAGE_ENTRY_ADDRESS,                /* Image Entry Function */
+  IVT_RSVD,                           /* Reserved = 0 */
+  (uint32_t)DCD_ADDRESS,              /* Address where DCD information is stored */
+  (uint32_t)BOOT_DATA_ADDRESS,        /* Address where BOOT Data Structure is stored */
+  (uint32_t)&image_vector_table,      /* Pointer to IVT Self (absolute address) */
+  (uint32_t)CSF_ADDRESS,              /* Address where CSF file is stored */
+  IVT_RSVD                            /* Reserved = 0 */
+};
+
+__attribute__((section(".boot_hdr.boot_data")))
+/*************************************
+ *  Boot Data
+ *************************************/
+const BOOT_DATA_T g_boot_data = {
+  BOARD_BOOT_START,           /* boot start location */
+  BOARD_BOOT_LENGTH,
+  PLUGIN_FLAG,                /* Plugin flag */
+  0xFFFFFFFF                  /* empty - extra data word */
+};
+
+// Config for AT25SF128A with QSPI routed.
+__attribute__((section(".boot_hdr.conf")))
+const flexspi_nor_config_t qspiflash_config = {
+    .pageSize           = 256u,
+    .sectorSize         = 4u * 1024u,
+    .ipcmdSerialClkFreq = kFlexSpiSerialClk_30MHz,
+    .blockSize          = 0x00010000,
+    .isUniformBlockSize = false,
+    .memConfig =
+    {
+        .tag              = FLEXSPI_CFG_BLK_TAG,
+        .version          = FLEXSPI_CFG_BLK_VERSION,
+        .readSampleClkSrc = kFlexSPIReadSampleClk_LoopbackFromSckPad,
+        .csHoldTime       = 3u,
+        .csSetupTime      = 3u,
+
+        .busyOffset = 0u, // Status bit 0 indicates busy.
+        .busyBitPolarity = 0u, // Busy when the bit is 1.
+
+        .deviceModeCfgEnable = 1u,
+        .deviceModeType = kDeviceConfigCmdType_QuadEnable,
+        .deviceModeSeq = {
+          .seqId = 4u,
+          .seqNum = 1u,
+        },
+        .deviceModeArg = 0x200,
+        .deviceType    = kFlexSpiDeviceType_SerialNOR,
+        .sflashPadType = kSerialFlash_4Pads,
+        .serialClkFreq = kFlexSpiSerialClk_60MHz,
+        .sflashA1Size  = FLASH_SIZE,
+        .lookupTable =
+        {
+            // FLEXSPI_LUT_SEQ(cmd0, pad0, op0, cmd1, pad1, op1)
+            // The high 16 bits is command 1 and the low are command 0.
+            // Within a command, the top 6 bits are the opcode, the next two are the number
+            // of pads and then last byte is the operand. The operand's meaning changes
+            // per opcode.
+
+            // Indices with ROM should always have the same function because the ROM
+            // bootloader uses it.
+
+            // 0: ROM: Read LUTs
+            // Quad version
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR,   FLEXSPI_1PAD, 0xEB /* the command to send */,
+                                     RADDR_SDR, FLEXSPI_4PAD, 24 /* bits to transmit */),
+                     FLEXSPI_LUT_SEQ(DUMMY_SDR, FLEXSPI_4PAD, 6 /* 6 dummy cycles, 2 for M7-0 and 4 dummy */,
+                                     READ_SDR,  FLEXSPI_4PAD, 0x04),
+            // Single fast read version, good for debugging.
+            // FLEXSPI_LUT_SEQ(CMD_SDR,   FLEXSPI_1PAD, 0x0B /* the command to send */,
+            //                 RADDR_SDR, FLEXSPI_1PAD, 24  /* bits to transmit */),
+            // FLEXSPI_LUT_SEQ(DUMMY_SDR, FLEXSPI_1PAD, 8 /* 8 dummy clocks */,
+            //                 READ_SDR,  FLEXSPI_1PAD, 0x04),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 1: ROM: Read status
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR,  FLEXSPI_1PAD, 0x05  /* the command to send */,
+                                     READ_SDR, FLEXSPI_1PAD, 0x02),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 2: Empty
+            EMPTY_SEQUENCE,
+
+            // 3: ROM: Write Enable
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x06  /* the command to send */,
+                                     STOP,    FLEXSPI_1PAD, 0x00),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 4: Config: Write Status
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR,   FLEXSPI_1PAD, 0x01  /* the command to send */,
+                                     WRITE_SDR, FLEXSPI_1PAD, 0x02),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 5: ROM: Erase Sector
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR,   FLEXSPI_1PAD, 0x20  /* the command to send */,
+                                     RADDR_SDR, FLEXSPI_1PAD, 24 /* bits to transmit */),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 6: Empty
+            EMPTY_SEQUENCE,
+
+            // 7: Empty
+            EMPTY_SEQUENCE,
+
+            // 8: Block Erase
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR,   FLEXSPI_1PAD, 0xD8  /* the command to send */,
+                                     RADDR_SDR, FLEXSPI_1PAD, 24 /* bits to transmit */),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 9: ROM: Page program
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR,   FLEXSPI_1PAD, 0x02  /* the command to send */,
+                                     RADDR_SDR, FLEXSPI_1PAD, 24 /* bits to transmit */),
+
+                     FLEXSPI_LUT_SEQ(WRITE_SDR, FLEXSPI_1PAD, 0x04  /* data out */,
+                                     STOP,      FLEXSPI_1PAD, 0),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 10: Empty
+            EMPTY_SEQUENCE,
+
+            // 11: ROM: Chip erase
+            SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0x60  /* the command to send */,
+                                     STOP,    FLEXSPI_1PAD, 0),
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS,
+                     TWO_EMPTY_STEPS),
+
+            // 12: Empty
+            EMPTY_SEQUENCE,
+
+            // 13: ROM: Read SFDP
+            EMPTY_SEQUENCE,
+
+            // 14: ROM: Restore no cmd
+            EMPTY_SEQUENCE,
+
+            // 15: ROM: Dummy
+            EMPTY_SEQUENCE
+        },
+    },
+};


### PR DESCRIPTION
Boards:

- Seed Arch Mix RT1052
- Olimex RT1011
- Makerdiary RT1011 Nano Kit

All sets differ only slightly from the respective imxrt10xx-evk files. Major changes are flash size and LED pin. All have been tested with theses boards.
