### PR TITLE
ports/stm32f4: Keep bootloader within first 32K

### DIFF
--- a/ports/stm32f4/linker/stm32f4_boot_compact.ld
+++ b/ports/stm32f4/linker/stm32f4_boot_compact.ld
@@ -1,0 +1,176 @@
+/*
+*****************************************************************************
+**
+
+**  File        : LinkerScript.ld
+**
+**  Abstract    : Linker script for STM32F405RGTx Device with
+**                1024KByte FLASH, 128KByte RAM
+**
+**                Set heap size, stack size and stack location according
+**                to application requirements.
+**
+**                Set memory bank area and size if external memory is used.
+**
+**  Target      : STMicroelectronics STM32
+**
+**
+**  Distribution: The file is distributed as is, without any warranty
+**                of any kind.
+**
+**  (c)Copyright Ac6.
+**  You may use this file as-is or modify it according to the needs of your
+**  project. Distribution of this file (unmodified or modified) is not
+**  permitted. Ac6 permit registered System Workbench for MCU users the
+**  rights to distribute the assembled, compiled & linked contents of this
+**  file as part of an application binary file, provided that it is built
+**  using the System Workbench for MCU toolchain.
+**
+*****************************************************************************
+*/
+
+/* Specify the memory areas */
+MEMORY
+{
+  RAM (xrw)     : ORIGIN = 0x20000000, LENGTH = 64K - 4 /* reserve 4 bytes for double tap */
+  FLASH (rx)    : ORIGIN = 0x08000000, LENGTH = 15K
+  CONFIG (rx)   : ORIGIN = 0x08004000 - 1024, LENGTH = 1024
+}
+
+/* Entry Point */
+ENTRY(Reset_Handler)
+
+/* Highest address of the user mode stack */
+_estack = ORIGIN(RAM) + LENGTH(RAM);    /* end of RAM */
+_board_dfu_dbl_tap = _estack;
+
+/* Generate a link error if heap and stack don't fit into RAM */
+_Min_Heap_Size = 0x200;      /* required amount of heap  */
+_Min_Stack_Size = 0x400; /* required amount of stack */
+
+/* Define output sections */
+SECTIONS
+{
+  /* The startup code goes first into FLASH */
+  .isr_vector :
+  {
+    . = ALIGN(4);
+    KEEP(*(.isr_vector)) /* Startup code */
+    . = ALIGN(4);
+  } >FLASH
+
+  /* The program code and other data goes into FLASH */
+  .text :
+  {
+    . = ALIGN(4);
+    *(.text)           /* .text sections (code) */
+    *(.text*)          /* .text* sections (code) */
+    *(.glue_7)         /* glue arm to thumb code */
+    *(.glue_7t)        /* glue thumb to arm code */
+    *(.eh_frame)
+
+    KEEP (*(.init))
+    KEEP (*(.fini))
+
+    . = ALIGN(4);
+    _etext = .;        /* define a global symbols at end of code */
+  } >FLASH
+
+  /* Constant data goes into FLASH */
+  .rodata :
+  {
+    . = ALIGN(4);
+    *(.rodata)         /* .rodata sections (constants, strings, etc.) */
+    *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
+    . = ALIGN(4);
+  } >FLASH
+
+  .ARM.extab   : { *(.ARM.extab* .gnu.linkonce.armextab.*) } >FLASH
+  .ARM : {
+    __exidx_start = .;
+    *(.ARM.exidx*)
+    __exidx_end = .;
+  } >FLASH
+
+  .preinit_array     :
+  {
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP (*(.preinit_array*))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+  } >FLASH
+  .init_array :
+  {
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP (*(SORT(.init_array.*)))
+    KEEP (*(.init_array*))
+    PROVIDE_HIDDEN (__init_array_end = .);
+  } >FLASH
+  .fini_array :
+  {
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP (*(SORT(.fini_array.*)))
+    KEEP (*(.fini_array*))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+  } >FLASH
+
+  /* CF2 config */
+  . = ORIGIN(CONFIG);
+  .config :
+  {
+    KEEP (*(.config))
+  } >CONFIG
+
+  /* used by the startup to initialize data */
+  _sidata = LOADADDR(.data);
+
+  /* Initialized data sections goes into RAM, load LMA copy after code */
+  .data :
+  {
+    . = ALIGN(4);
+    _sdata = .;        /* create a global symbol at data start */
+    *(.data)           /* .data sections */
+    *(.data*)          /* .data* sections */
+
+    . = ALIGN(4);
+    _edata = .;        /* define a global symbol at data end */
+  } >RAM AT> FLASH
+
+  /* Uninitialized data section */
+  . = ALIGN(4);
+  .bss :
+  {
+    /* This is used by the startup in order to initialize the .bss section */
+    _sbss = .;         /* define a global symbol at bss start */
+    __bss_start__ = _sbss;
+    *(.bss)
+    *(.bss*)
+    *(COMMON)
+
+    . = ALIGN(4);
+    _ebss = .;         /* define a global symbol at bss end */
+    __bss_end__ = _ebss;
+  } >RAM
+
+  /* User_heap_stack section, used to check that there is enough RAM left */
+  ._user_heap_stack :
+  {
+    . = ALIGN(8);
+    PROVIDE ( end = . );
+    PROVIDE ( _end = . );
+    . = . + _Min_Heap_Size;
+    . = . + _Min_Stack_Size;
+    . = ALIGN(8);
+  } >RAM
+
+
+
+  /* Remove information from the standard libraries */
+  /DISCARD/ :
+  {
+    libc.a ( * )
+    libm.a ( * )
+    libgcc.a ( * )
+  }
+
+  .ARM.attributes 0 : { *(.ARM.attributes) }
+}

--- a/ports/stm32f4/port.mk
+++ b/ports/stm32f4/port.mk
@@ -22,6 +22,8 @@ CFLAGS += -Wno-error=cast-align -Wno-error=unused-parameter
 # default linker file
 ifdef BUILD_APPLICATION
   LD_FILES ?= $(PORT_DIR)/linker/stm32f4_app.ld
+else ifdef COMPACT_BOOTLOADER
+  LD_FILES ?= $(PORT_DIR)/linker/stm32f4_boot_compact.ld
 else
   LD_FILES ?= $(PORT_DIR)/linker/stm32f4_boot.ld
 endif


### PR DESCRIPTION
In order to free up sectors 2 and 3 for the application, limit the bootloader to the first 16K sector, config to the next 16K. We keep the application still starting at 0x10000 so that 0x8000 and 0xC000 sectors can be used by the application for settings/config storage.

## Checklist

*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

- [x] Please provide specific title of the PR describing the change
- [ ] Please provide related links (*eg. Issue which will be closed by this Pull Request*)

*This checklist items that are not applicable to your PR can be deleted.*

-----------

## Description of Change

While trying to set up an stm32f401cb based board to run ZMK (using Zephyr under the hood), I ran into an issue trying to use Zephy's NVS driver for persistence of settings. Zephyr's NVS expects two sectors of 16K, which basically means I need to use sectors 2 and 3 for this:

![image](https://github.com/user-attachments/assets/ed412753-dbaa-4124-b678-c7d8344221a6)

I was able to make this work with the correct partitioning on the Zephyr/ZMK side, and properly fit the bootloader into the first two sectors with the changes in this PR. The device runs, and properly store settings as expected.
