### PR TITLE
Waveshare pico S3: change the color order of the RBG LED

### DIFF
--- a/ports/espressif/boards/waveshare_esp32_s3_pico/board.h
+++ b/ports/espressif/boards/waveshare_esp32_s3_pico/board.h
@@ -51,6 +51,8 @@
 // Number of neopixels
 #define NEOPIXEL_NUMBER       1
 
+// Invert Neopixel red and green
+#define NEOPIXEL_INVERT_RG    1
 
 // LED for indicator and writing flash
 // If not defined neopixel will be use for flash writing instead


### PR DESCRIPTION
I didn't find a clear documentation of the color order of the neopixel on the board, but the Micropython demo from Waveshare does swap red and green instead of the default (1, 0, 2, 3), so I think it's good.
```py
# Set the color order for the NeoPixel object
rgb_led.ORDER = (0, 1, 2, 3)
```
Tested and the color is now correct (LED green when connected to USB, red when on a power bank).