### PR TITLE
mimxrt10xx/boards: Increase the flash CLK frequency.

### DIFF
--- a/ports/mimxrt10xx/boards/arch_mix_1052/flash_config.c
+++ b/ports/mimxrt10xx/boards/arch_mix_1052/flash_config.c
@@ -65,7 +65,7 @@ const flexspi_nor_config_t qspiflash_config = {
         .deviceModeArg = 0x40,
         .deviceType    = kFlexSpiDeviceType_SerialNOR,
         .sflashPadType = kSerialFlash_4Pads,
-        .serialClkFreq = kFlexSpiSerialClk_60MHz,
+        .serialClkFreq = kFlexSpiSerialClk_133MHz,
         .sflashA1Size  = FLASH_SIZE,
         .lookupTable =
         {

--- a/ports/mimxrt10xx/boards/imxrt1010_evk/flash_config.c
+++ b/ports/mimxrt10xx/boards/imxrt1010_evk/flash_config.c
@@ -64,7 +64,7 @@ const flexspi_nor_config_t qspiflash_config = {
         .deviceModeArg = 0x02,
         .deviceType    = kFlexSpiDeviceType_SerialNOR,
         .sflashPadType = kSerialFlash_4Pads,
-        .serialClkFreq = kFlexSpiSerialClk_60MHz,
+        .serialClkFreq = kFlexSpiSerialClk_100MHz,
         .sflashA1Size  = FLASH_SIZE,
         .lookupTable =
         {

--- a/ports/mimxrt10xx/boards/imxrt1015_evk/flash_config.c
+++ b/ports/mimxrt10xx/boards/imxrt1015_evk/flash_config.c
@@ -64,7 +64,7 @@ const flexspi_nor_config_t qspiflash_config = {
         .deviceModeArg = 0x02,
         .deviceType    = kFlexSpiDeviceType_SerialNOR,
         .sflashPadType = kSerialFlash_4Pads,
-        .serialClkFreq = kFlexSpiSerialClk_60MHz,
+        .serialClkFreq = kFlexSpiSerialClk_100MHz,
         .sflashA1Size  = FLASH_SIZE,
         .lookupTable =
         {

--- a/ports/mimxrt10xx/boards/imxrt1020_evk/flash_config.c
+++ b/ports/mimxrt10xx/boards/imxrt1020_evk/flash_config.c
@@ -64,7 +64,7 @@ const flexspi_nor_config_t qspiflash_config = {
         .deviceModeArg = 0x40,
         .deviceType    = kFlexSpiDeviceType_SerialNOR,
         .sflashPadType = kSerialFlash_4Pads,
-        .serialClkFreq = kFlexSpiSerialClk_30MHz,
+        .serialClkFreq = kFlexSpiSerialClk_133MHz,
         .sflashA1Size  = FLASH_SIZE,
         .lookupTable =
         {

--- a/ports/mimxrt10xx/boards/imxrt1040_evk/flash_config.c
+++ b/ports/mimxrt10xx/boards/imxrt1040_evk/flash_config.c
@@ -64,7 +64,7 @@ const flexspi_nor_config_t qspiflash_config = {
         .deviceModeArg = 0x40,
         .deviceType    = kFlexSpiDeviceType_SerialNOR,
         .sflashPadType = kSerialFlash_4Pads,
-        .serialClkFreq = kFlexSpiSerialClk_60MHz,
+        .serialClkFreq = kFlexSpiSerialClk_100MHz,
         .sflashA1Size  = FLASH_SIZE,
         .lookupTable =
         {

--- a/ports/mimxrt10xx/boards/imxrt1050_evkb/flash_config.c
+++ b/ports/mimxrt10xx/boards/imxrt1050_evkb/flash_config.c
@@ -65,7 +65,7 @@ const flexspi_nor_config_t qspiflash_config = {
         .deviceModeArg = 0x40,
         .deviceType    = kFlexSpiDeviceType_SerialNOR,
         .sflashPadType = kSerialFlash_4Pads,
-        .serialClkFreq = kFlexSpiSerialClk_60MHz,
+        .serialClkFreq = kFlexSpiSerialClk_133MHz,
         .sflashA1Size  = FLASH_SIZE,
         .lookupTable =
         {

--- a/ports/mimxrt10xx/boards/imxrt1060_evk/flash_config.c
+++ b/ports/mimxrt10xx/boards/imxrt1060_evk/flash_config.c
@@ -64,7 +64,7 @@ const flexspi_nor_config_t qspiflash_config = {
         .deviceModeArg = 0x40,
         .deviceType    = kFlexSpiDeviceType_SerialNOR,
         .sflashPadType = kSerialFlash_4Pads,
-        .serialClkFreq = kFlexSpiSerialClk_60MHz,
+        .serialClkFreq = kFlexSpiSerialClk_133MHz,
         .sflashA1Size  = FLASH_SIZE,
         .lookupTable =
         {

--- a/ports/mimxrt10xx/boards/imxrt1064_evk/flash_config.c
+++ b/ports/mimxrt10xx/boards/imxrt1064_evk/flash_config.c
@@ -70,7 +70,7 @@ const flexspi_nor_config_t qspiflash_config = {
         },
         .deviceType = kFlexSpiDeviceType_SerialNOR,
         .sflashPadType = kSerialFlash_4Pads,
-        .serialClkFreq = kFlexSpiSerialClk_60MHz,
+        .serialClkFreq = kFlexSpiSerialClk_100MHz,
         .sflashA1Size  = BOARD_FLASH_SIZE,
         .lookupTable =
         {

--- a/ports/mimxrt10xx/boards/makerdiary_rt1011/flash_config.c
+++ b/ports/mimxrt10xx/boards/makerdiary_rt1011/flash_config.c
@@ -36,7 +36,7 @@ const BOOT_DATA_T g_boot_data = {
   0xFFFFFFFF                  /* empty - extra data word */
 };
 
-// Config for AT25SF128A with QSPI routed.
+// Config for W25Q128VPQ with QSPI routed.
 __attribute__((section(".boot_hdr.conf")))
 const flexspi_nor_config_t qspiflash_config = {
     .pageSize           = 256u,
@@ -64,7 +64,7 @@ const flexspi_nor_config_t qspiflash_config = {
         .deviceModeArg = 0x200,
         .deviceType    = kFlexSpiDeviceType_SerialNOR,
         .sflashPadType = kSerialFlash_4Pads,
-        .serialClkFreq = kFlexSpiSerialClk_60MHz,
+        .serialClkFreq = kFlexSpiSerialClk_100MHz,
         .sflashA1Size  = FLASH_SIZE,
         .lookupTable =
         {

--- a/ports/mimxrt10xx/boards/metro_m7_1011/flash_config.c
+++ b/ports/mimxrt10xx/boards/metro_m7_1011/flash_config.c
@@ -70,7 +70,7 @@ const flexspi_nor_config_t qspiflash_config = {
         },
         .deviceType    = kFlexSpiDeviceType_SerialNOR,
         .sflashPadType = kSerialFlash_4Pads,
-        .serialClkFreq = kFlexSpiSerialClk_60MHz,
+        .serialClkFreq = kFlexSpiSerialClk_100MHz,
         .sflashA1Size  = FLASH_SIZE,
         .lookupTable =
         {

--- a/ports/mimxrt10xx/boards/metro_m7_1011_sd/flash_config.c
+++ b/ports/mimxrt10xx/boards/metro_m7_1011_sd/flash_config.c
@@ -70,7 +70,7 @@ const flexspi_nor_config_t qspiflash_config = {
         },
         .deviceType    = kFlexSpiDeviceType_SerialNOR,
         .sflashPadType = kSerialFlash_4Pads,
-        .serialClkFreq = kFlexSpiSerialClk_60MHz,
+        .serialClkFreq = kFlexSpiSerialClk_100MHz,
         .sflashA1Size  = FLASH_SIZE,
         .lookupTable =
         {

--- a/ports/mimxrt10xx/boards/olimex_rt1010/flash_config.c
+++ b/ports/mimxrt10xx/boards/olimex_rt1010/flash_config.c
@@ -36,7 +36,7 @@ const BOOT_DATA_T g_boot_data = {
   0xFFFFFFFF                  /* empty - extra data word */
 };
 
-// Config for AT25SF128A with QSPI routed.
+// Config for W25Q16DVSSIG with QSPI routed.
 __attribute__((section(".boot_hdr.conf")))
 const flexspi_nor_config_t qspiflash_config = {
     .pageSize           = 256u,
@@ -64,7 +64,7 @@ const flexspi_nor_config_t qspiflash_config = {
         .deviceModeArg = 0x200,
         .deviceType    = kFlexSpiDeviceType_SerialNOR,
         .sflashPadType = kSerialFlash_4Pads,
-        .serialClkFreq = kFlexSpiSerialClk_60MHz,
+        .serialClkFreq = kFlexSpiSerialClk_100MHz,
         .sflashA1Size  = FLASH_SIZE,
         .lookupTable =
         {


### PR DESCRIPTION
CLK is increased to the highest value defined in the data sheets of the respective flash device. The previous values of 60MHz and 30MHz reduce the speed of the APP. Tested with:

- arch_mix_1052
- imxrt1010_evk
- imxrt1015_evk
- imxrt1020_evk
- makerdiary_rt1011
- metro_m7_1011
- olimex_rt1010

