### PR TITLE
mimxrt10xx/boards/olimex_rt1010/flash_config.c: Fix flash settings for the init sequence.

### DIFF
--- a/ports/mimxrt10xx/boards/olimex_rt1010/flash_config.c
+++ b/ports/mimxrt10xx/boards/olimex_rt1010/flash_config.c
@@ -36,7 +36,7 @@ const BOOT_DATA_T g_boot_data = {
   0xFFFFFFFF                  /* empty - extra data word */
 };
 
-// Config for W25Q16DVSSIG with QSPI routed.
+// Config for EN25Q16B-104HIP with QSPI routed.
 __attribute__((section(".boot_hdr.conf")))
 const flexspi_nor_config_t qspiflash_config = {
     .pageSize           = 256u,
@@ -61,7 +61,7 @@ const flexspi_nor_config_t qspiflash_config = {
           .seqId = 4u,
           .seqNum = 1u,
         },
-        .deviceModeArg = 0x200,
+        .deviceModeArg = 0x40,
         .deviceType    = kFlexSpiDeviceType_SerialNOR,
         .sflashPadType = kSerialFlash_4Pads,
         .serialClkFreq = kFlexSpiSerialClk_100MHz,
@@ -110,7 +110,7 @@ const flexspi_nor_config_t qspiflash_config = {
 
             // 4: Config: Write Status
             SEQUENCE(FLEXSPI_LUT_SEQ(CMD_SDR,   FLEXSPI_1PAD, 0x01  /* the command to send */,
-                                     WRITE_SDR, FLEXSPI_1PAD, 0x02),
+                                     WRITE_SDR, FLEXSPI_1PAD, 0x01),
                      TWO_EMPTY_STEPS,
                      TWO_EMPTY_STEPS,
                      TWO_EMPTY_STEPS),


### PR DESCRIPTION
## Description of Change

The settings for the initialization sequence of my last PR were not the right ones. Instead of the W25Q16 flash listed initially in the first Olimex documentation, the production boards now use an EN25Q16B-104HIP chip, which needs different arguments to enable quad mode. With the existing arguments, the flash may get write locked.

Tested with an Olimex RT1010Py board.

P.S.: In case the flash got write locked can then be unlocked using the flash-sfdp mode for uploading the UF2 bootloader.
