### PR TITLE
Add support for LILYGO T-Dongle S3

### DIFF
--- a/ports/espressif/README.md
+++ b/ports/espressif/README.md
@@ -22,6 +22,7 @@ Following boards are supported:
 - [LILYGO® TTGO T8 ESP32-S2-WROOM](http://www.lilygo.cn/prod_view.aspx?TypeId=50063&Id=1320&FId=t3:50063:3)
 - [LILYGO® TTGO T-Beam Supreme](https://www.lilygo.cc/products/softrf-t-beamsupreme)
 - [LILYGO® TTGO T-TWR Plus](https://www.lilygo.cc/products/t-twr-plus)
+- [LILYGO® T-Dongle S3](https://www.lilygo.cc/products/t-dongle-s3)
 - [LOLIN Wemos® S2 Pico](https://www.wemos.cc/en/latest/s2/s2_pico.html)
 - [Maker badge](https://github.com/dronecz/maker_badge)
 - [MicroDev microS2](https://github.com/microDev1/microS2/wiki)

--- a/ports/espressif/boards/lilygo_tdongle_s3/board.cmake
+++ b/ports/espressif/boards/lilygo_tdongle_s3/board.cmake
@@ -1,0 +1,2 @@
+# Apply board specific content here
+set(IDF_TARGET "esp32s3")

--- a/ports/espressif/boards/lilygo_tdongle_s3/board.h
+++ b/ports/espressif/boards/lilygo_tdongle_s3/board.h
@@ -54,6 +54,34 @@
 //
 
 // LCD is ST7735 and may need a custom init cmd to use the ILI9341 driver.
+// #define CONFIG_LCD_TYPE_ILI9341
+
+// #define DISPLAY_PIN_MISO       -1 // required if use CONFIG_LCD_TYPE_AUTO
+// #define DISPLAY_PIN_MOSI        3
+// #define DISPLAY_PIN_SCK         5
+
+// #define DISPLAY_PIN_CS          4
+// #define DISPLAY_PIN_DC          2
+// #define DISPLAY_PIN_RST         1
+
+// #define DISPLAY_PIN_BL         38
+// #define DISPLAY_BL_ON           1 // GPIO state to enable back light
+
+// #define DISPLAY_PIN_POWER      -1
+// #define DISPLAY_POWER_ON        1 // GPIO state to enable TFT
+
+// #define DISPLAY_WIDTH         160
+// #define DISPLAY_HEIGHT         80
+
+// #define DISPLAY_COL_OFFSET     26
+// #define DISPLAY_ROW_OFFSET      1
+
+// Memory Data Access Control & // Vertical Scroll Start Address
+// #define DISPLAY_MADCTL        (TFT_MADCTL_BGR | TFT_MADCTL_MY | TFT_MADCTL_MV)
+// #define DISPLAY_VSCSAD        80
+// Display rotated 90 degrees
+
+// #define DISPLAY_TITLE         "T-Dongle-S3"
 
 //--------------------------------------------------------------------+
 // USB UF2

--- a/ports/espressif/boards/lilygo_tdongle_s3/board.h
+++ b/ports/espressif/boards/lilygo_tdongle_s3/board.h
@@ -1,0 +1,70 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Robert Grizzell, Independently providing these changes
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef LILYGO_TDONGLE_S3_H_
+#define LILYGO_TDONGLE_S3_H_
+
+//--------------------------------------------------------------------+
+// Button
+//--------------------------------------------------------------------+
+
+// Enter UF2 mode if GPIO is pressed while 2nd stage bootloader indicator
+// is on e.g RGB = Purple. If it is GPIO0, user should not hold this while
+// reset since that will instead run the 1st stage ROM bootloader
+#define PIN_BUTTON_UF2       0
+
+//--------------------------------------------------------------------+
+// LED
+//--------------------------------------------------------------------+
+
+// Number of Dotstar
+#define DOTSTAR_NUMBER        1
+
+// GPIO connected to Dotstar
+#define DOTSTAR_PIN_DATA      40
+#define DOTSTAR_PIN_SCK       39
+
+//--------------------------------------------------------------------+
+// TFT
+//--------------------------------------------------------------------+
+//
+
+// LCD is ST7735 and may need a custom init cmd to use the ILI9341 driver.
+
+//--------------------------------------------------------------------+
+// USB UF2
+//--------------------------------------------------------------------+
+
+#define USB_VID                  0x303A
+#define USB_PID                  0x82C3
+
+#define USB_MANUFACTURER         "LILYGO"
+#define USB_PRODUCT              "T-Dongle S3"
+
+#define UF2_PRODUCT_NAME         USB_MANUFACTURER " " USB_PRODUCT
+#define UF2_BOARD_ID             "ESP32S3-T-Dongle-S3"
+#define UF2_VOLUME_LABEL         "TDNGLBOOT"
+#define UF2_INDEX_URL            "https://github.com/Xinyuan-LilyGO/T-Dongle-S3"
+
+#endif

--- a/ports/espressif/boards/lilygo_tdongle_s3/board.h
+++ b/ports/espressif/boards/lilygo_tdongle_s3/board.h
@@ -67,7 +67,7 @@
 
 #define UF2_PRODUCT_NAME         USB_MANUFACTURER " " USB_PRODUCT
 #define UF2_BOARD_ID             "ESP32S3-T_Dongle_S3-rev2" // Rev. 2 added a QWIIC connector
-#define UF2_VOLUME_LABEL         "TDNGLBOOT"
+#define UF2_VOLUME_LABEL         "LILYGOBOOT"
 #define UF2_INDEX_URL            "https://github.com/Xinyuan-LilyGO/T-Dongle-S3"
 
 #endif

--- a/ports/espressif/boards/lilygo_tdongle_s3/board.h
+++ b/ports/espressif/boards/lilygo_tdongle_s3/board.h
@@ -63,7 +63,7 @@
 #define USB_PRODUCT              "T-Dongle S3"
 
 #define UF2_PRODUCT_NAME         USB_MANUFACTURER " " USB_PRODUCT
-#define UF2_BOARD_ID             "ESP32S3-T-Dongle-S3"
+#define UF2_BOARD_ID             "ESP32S3-T_Dongle_S3-rev2" // Rev. 2 added a QWIIC connector
 #define UF2_VOLUME_LABEL         "TDNGLBOOT"
 #define UF2_INDEX_URL            "https://github.com/Xinyuan-LilyGO/T-Dongle-S3"
 

--- a/ports/espressif/boards/lilygo_tdongle_s3/board.h
+++ b/ports/espressif/boards/lilygo_tdongle_s3/board.h
@@ -45,6 +45,9 @@
 #define DOTSTAR_PIN_DATA      40
 #define DOTSTAR_PIN_SCK       39
 
+// Brightness percentage from 1 to 255
+#define DOTSTAR_BRIGHTNESS     127
+
 //--------------------------------------------------------------------+
 // TFT
 //--------------------------------------------------------------------+

--- a/ports/espressif/boards/lilygo_tdongle_s3/sdkconfig
+++ b/ports/espressif/boards/lilygo_tdongle_s3/sdkconfig
@@ -1,0 +1,9 @@
+# Board Specific Config
+
+# Partition Table
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-16MB.csv"
+
+# Serial flasher config
+CONFIG_ESPTOOLPY_FLASHSIZE_16MB=y
+CONFIG_FLASHMODE_DIO=n
+CONFIG_FLASHMODE_QIO=y


### PR DESCRIPTION
## Checklist

*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

- [x] Please provide specific title of the PR describing the change
- [x] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
- [x] If you are adding an new boards, please make sure
  - [x] Provide link to your allocated VID/PID if applicable
  - [x] `UF2_BOARD_ID` in your board.h follow correct format from [uf2 specs](https://github.com/microsoft/uf2#files-exposed-by-bootloaders)

*This checklist items that are not applicable to your PR can be deleted.*

-----------

## Description of Change

Adding support for the [LILYGO T-Dongle-S3](https://github.com/Xinyuan-LilyGO/T-Dongle-S3/).

Allocated PID:
- [0x82C3 | LILYGO T-Dongle-S3 - UF2 Bootloader](https://github.com/espressif/usb-pids/pull/220)
