### PR TITLE
Change s3 4m partition to noota

### DIFF
--- a/.github/workflows/build_util.yml
+++ b/.github/workflows/build_util.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Build using ESP-IDF docker
         if: inputs.toolchain == 'esp-idf'
-        run: docker run --rm -v $PWD:/project -w /project espressif/idf:${{ inputs.toolchain_version }} /bin/bash -c "git config --global --add safe.directory /project && make -C ports/espressif/ BOARD=${{ matrix.board }} all self-update copy-artifact"
+        run: docker run --rm -v $PWD:/project -w /project espressif/idf:${{ inputs.toolchain_version }} /bin/bash -c "git config --global --add safe.directory /project && make -C ports/espressif/ BOARD=${{ matrix.board }} all copy-artifact"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/ports/espressif/CMakeLists.txt
+++ b/ports/espressif/CMakeLists.txt
@@ -38,6 +38,18 @@ add_custom_command(TARGET app POST_BUILD
   COMMAND ${Python_EXECUTABLE} ${UF2CONV_PY} --carray -o ${CMAKE_CURRENT_LIST_DIR}/apps/self_update/main/bootloader_bin.c ${CMAKE_BINARY_DIR}/tinyuf2.bin
   )
 
+# External project for self-update
+externalproject_add(self_update
+  SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/apps/self_update
+  BINARY_DIR ${CMAKE_BINARY_DIR}/self_update
+  # Modiying the list separator for the arguments, as such, we won't need to manually
+  # replace the new separator by the default ';' in the subproject
+  CMAKE_ARGS -DBOARD=${BOARD}
+  INSTALL_COMMAND ""
+  BUILD_ALWAYS 1
+  DEPENDS app
+  )
+
 # -------------------------------------------------------------
 # Post build: update arduino-esp32 bootloader for debug purpose
 # -------------------------------------------------------------

--- a/ports/espressif/Makefile
+++ b/ports/espressif/Makefile
@@ -50,15 +50,8 @@ combined-flash: $(BUILD)/combined.bin
 	esptool.py --chip $(IDF_TARGET) write_flash 0x0 $<
 
 #-------------- Self Update --------------
-SELF_APP = apps/self_update
-SELF_BUILD = ${SELF_APP}/${BUILD}
-
-# cmake post build of tinyuf2's app will generate bootloader_bin.c
-# cmake post build of self-update's app will generate update-tinyuf2.uf2
-$(SELF_BUILD)/update-tinyuf2.uf2: app
-	idf.py -C ${SELF_APP} -B${SELF_BUILD} -DBOARD=${BOARD} app
-
-self-update: $(SELF_BUILD)/update-tinyuf2.uf2
+# Self_update is a sub/external project, will be built by cmake's all target
+SELF_BUILD = ${BUILD}/self_update
 
 #-------------- Artifacts --------------
 $(BIN):
@@ -67,7 +60,7 @@ $(BIN):
 # get the partition csv from sdkconfig
 PARTITION_CSV := $(strip $(foreach csv,$(wildcard partitions-*.csv),$(findstring $(csv),$(file < boards/$(BOARD)/sdkconfig))))
 
-copy-artifact: $(BIN) all self-update $(BUILD)/combined.bin
+copy-artifact: $(BIN) all $(BUILD)/combined.bin
 	@cp $(BUILD)/bootloader/bootloader.bin $<
 	@cp $(BUILD)/partition_table/partition-table.bin $<
 	@cp $(BUILD)/ota_data_initial.bin $<

--- a/ports/espressif/apps/self_update/CMakeLists.txt
+++ b/ports/espressif/apps/self_update/CMakeLists.txt
@@ -7,6 +7,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/../../boards/${BOARD}/board.cmake)
 
 # Must be set before including IDF project.cmake
 set(EXTRA_COMPONENT_DIRS "../../boards" "../../components")
+set(SDKCONFIG ${CMAKE_BINARY_DIR}/sdkconfig)
 
 set(SELFUPDATE_BUILD 1)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)

--- a/ports/espressif/boards/adafruit_feather_esp32s3/sdkconfig
+++ b/ports/espressif/boards/adafruit_feather_esp32s3/sdkconfig
@@ -1,7 +1,7 @@
 # Board Specific Config
 
 # Partition Table
-CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-4MB.csv"
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-4MB-noota.csv"
 
 # Serial flasher config
 CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y

--- a/ports/espressif/boards/adafruit_feather_esp32s3_reverse_tft/sdkconfig
+++ b/ports/espressif/boards/adafruit_feather_esp32s3_reverse_tft/sdkconfig
@@ -1,7 +1,7 @@
 # Board Specific Config
 
 # Partition Table
-CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-4MB.csv"
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-4MB-noota.csv"
 
 # Serial flasher config
 CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y

--- a/ports/espressif/boards/adafruit_feather_esp32s3_tft/sdkconfig
+++ b/ports/espressif/boards/adafruit_feather_esp32s3_tft/sdkconfig
@@ -1,7 +1,7 @@
 # Board Specific Config
 
 # Partition Table
-CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-4MB.csv"
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-4MB-noota.csv"
 
 # Serial flasher config
 CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y

--- a/ports/espressif/boards/adafruit_qtpy_esp32s3_n4r2/sdkconfig
+++ b/ports/espressif/boards/adafruit_qtpy_esp32s3_n4r2/sdkconfig
@@ -1,7 +1,7 @@
 # Board Specific Config
 
 # Partition Table
-CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-4MB.csv"
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-4MB-noota.csv"
 
 # Serial flasher config
 CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y

--- a/ports/espressif/boards/deneyap_kart_1a_v2/sdkconfig
+++ b/ports/espressif/boards/deneyap_kart_1a_v2/sdkconfig
@@ -1,7 +1,7 @@
 # Board Specific Config
 
 # Partition Table
-CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-4MB.csv"
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-4MB-noota.csv"
 
 # Serial flasher config
 CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y

--- a/ports/espressif/boards/espressif_esp32s3_devkitc_1/board.h
+++ b/ports/espressif/boards/espressif_esp32s3_devkitc_1/board.h
@@ -43,7 +43,7 @@
 //--------------------------------------------------------------------+
 
 // GPIO connected to Neopixel data
-#define NEOPIXEL_PIN          48
+#define NEOPIXEL_PIN          38
 
 // Brightness percentage from 1 to 255
 #define NEOPIXEL_BRIGHTNESS   0x10

--- a/ports/espressif/boards/lilygo_tqt_pro_psram/sdkconfig
+++ b/ports/espressif/boards/lilygo_tqt_pro_psram/sdkconfig
@@ -1,7 +1,7 @@
 # Board Specific Config
 
 # Partition Table
-CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-4MB.csv"
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-4MB-noota.csv"
 
 # Serial flasher config
 CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y

--- a/ports/espressif/boards/lolin_s3_mini/sdkconfig
+++ b/ports/espressif/boards/lolin_s3_mini/sdkconfig
@@ -1,7 +1,7 @@
 # Board Specific Config
 
 # Partition Table
-CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-4MB.csv"
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-4MB-noota.csv"
 
 # Serial flasher config
 CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y

--- a/ports/espressif/boards/magiclick_s3_n4r2/sdkconfig
+++ b/ports/espressif/boards/magiclick_s3_n4r2/sdkconfig
@@ -1,7 +1,7 @@
 # Board Specific Config
 
 # Partition Table
-CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-4MB.csv"
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-4MB-noota.csv"
 
 # Serial flasher config
 CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y

--- a/ports/espressif/boards/waveshare_esp32_s3_matrix/sdkconfig
+++ b/ports/espressif/boards/waveshare_esp32_s3_matrix/sdkconfig
@@ -1,7 +1,7 @@
 # Board Specific Config
 
 # Partition Table
-CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-4MB.csv"
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-4MB-noota.csv"
 
 # Serial flasher config
 CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y

--- a/ports/espressif/boards/waveshare_esp32_s3_zero/sdkconfig
+++ b/ports/espressif/boards/waveshare_esp32_s3_zero/sdkconfig
@@ -1,7 +1,7 @@
 # Board Specific Config
 
 # Partition Table
-CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-4MB.csv"
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-4MB-noota.csv"
 
 # Serial flasher config
 CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y


### PR DESCRIPTION
## Description of Change

### Board configuration updates:

* Updated the partition table filenames from `partitions-4MB.csv` to `partitions-4MB-noota.csv` for multiple boards, including `adafruit_feather_esp32s3`, `adafruit_feather_esp32s3_reverse_tft`, `adafruit_feather_esp32s3_tft`, `adafruit_qtpy_esp32s3_n4r2`, `deneyap_kart_1a_v2`, `lilygo_tqt_pro_psram`, `lolin_s3_mini`, `magiclick_s3_n4r2`, `waveshare_esp32_s3_matrix`, and `waveshare_esp32_s3_zero`. [[1]](diffhunk://#diff-62166c16d9852bb91dff61b8609e68d4a496fe0a5944c9473520df8c94f6aad2L4-R4) [[2]](diffhunk://#diff-4ec656212ee487c916db4217649f2de7a5f1f808dd79f8577cc61797a819d7e9L4-R4)

### Pin configuration update:

* [`ports/espressif/boards/espressif_esp32s3_devkitc_1/board.h`](diffhunk://#diff-715ec43d3b71766f21d052069ce94e43b45da93cccf487e1437ba089a32a9bb2L46-R46): Changed the Neopixel data pin from 48 to 38.

### Improvements to build process:

* [`.github/workflows/build_util.yml`](diffhunk://#diff-49007146ac3621ac1e9e053efba49295ac42e5d1820935ba6cf044fc034fafbdL61-R61): Removed the `self-update` target from the build command to streamline the build process.
* [`ports/espressif/CMakeLists.txt`](diffhunk://#diff-7d3872f7a6da0ff5bbf9e863b2384558d80ccb452173b9778f0542635d560428R41-R52): Added an external project for self-update to handle the self-update build process separately.
* [`ports/espressif/Makefile`](diffhunk://#diff-c9bb8741d3fb6b2364b58fa90638114b80d0dc512982dc3fccb21cc2087f20b8L53-R54): Updated the makefile to remove the `self-update` target and adjusted the `copy-artifact` target accordingly. [[1]](diffhunk://#diff-c9bb8741d3fb6b2364b58fa90638114b80d0dc512982dc3fccb21cc2087f20b8L53-R54) [[2]](diffhunk://#diff-c9bb8741d3fb6b2364b58fa90638114b80d0dc512982dc3fccb21cc2087f20b8L70-R63)