### PR TITLE
Support Devices with One Direction Endpoints

### DIFF
--- a/src/usb_descriptors.c
+++ b/src/usb_descriptors.c
@@ -89,9 +89,16 @@ uint8_t const* tud_descriptor_device_cb(void) {
 #define CONFIG_TOTAL_LEN  (TUD_CONFIG_DESC_LEN + TUD_MSC_DESC_LEN + \
                            CFG_TUD_CDC*TUD_CDC_DESC_LEN + CFG_TUD_VENDOR*TUD_VENDOR_DESC_LEN)
 
-// MSC is mandatory, use endpoint 1
-#define EPNUM_MSC_OUT     0x01
-#define EPNUM_MSC_IN      0x81
+// MSC is mandatory
+#if defined(TUD_ENDPOINT_ONE_DIRECTION_ONLY)
+  // MCUs that don't support a same endpoint number with different direction
+  #define EPNUM_MSC_OUT     0x01
+  #define EPNUM_MSC_IN      0x82
+#else
+  // Use endpoint 1 for most devices
+  #define EPNUM_MSC_OUT     0x01
+  #define EPNUM_MSC_IN      0x81
+#endif
 
 // Board/Port can force CDC endpoint numbering
 #if defined(BOARD_EPNUM_CDC_OUT) && defined(BOARD_EPNUM_CDC_IN) && defined(BOARD_EPNUM_CDC_NOTIF)
@@ -99,9 +106,16 @@ uint8_t const* tud_descriptor_device_cb(void) {
   #define EPNUM_CDC_OUT     BOARD_EPNUM_CDC_OUT
   #define EPNUM_CDC_IN      BOARD_EPNUM_CDC_IN
 #else
-  #define EPNUM_CDC_NOTIF   0x82
-  #define EPNUM_CDC_OUT     0x03
-  #define EPNUM_CDC_IN      0x83
+  #if defined(TUD_ENDPOINT_ONE_DIRECTION_ONLY)
+    // MCUs that don't support a same endpoint number with different direction
+    #define EPNUM_CDC_NOTIF   0x83
+    #define EPNUM_CDC_OUT     0x04
+    #define EPNUM_CDC_IN      0x85
+  #else
+    #define EPNUM_CDC_NOTIF   0x82
+    #define EPNUM_CDC_OUT     0x03
+    #define EPNUM_CDC_IN      0x83
+  #endif
 #endif
 
 uint8_t TINYUF2_CONST desc_configuration[] = {


### PR DESCRIPTION
## Checklist

*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

- [x] Please provide specific title of the PR describing the change

*This checklist items that are not applicable to your PR can be deleted.*

-----------

## Description of Change

Updated the USB Descriptors to accommodate MCUs where the endpoint number can only be used in a single direction.  These devices are identified in TinyUSB by the TUD_ENDPOINT_ONE_DIRECTION_ONLY definition.  This update is in preparation for utilizing the TinyUF2 project with Analog Devices MAX32 MCUs, and contributing a port to those parts.

