### PR TITLE
add UF2 family ID for ESP32-P4

### DIFF
--- a/ports/espressif/boards/boards.h
+++ b/ports/espressif/boards/boards.h
@@ -37,6 +37,8 @@
   #define BOARD_UF2_FAMILY_ID     0xbfdd4eee
 #elif CONFIG_IDF_TARGET_ESP32S3
   #define BOARD_UF2_FAMILY_ID     0xc47e5767
+#elif CONFIG_IDF_TARGET_ESP32P4
+  #define BOARD_UF2_FAMILY_ID     0x3d308e94
 #else
   #error unsupported MCUs
 #endif

--- a/ports/espressif/components/tinyusb_src/tusb_config.h
+++ b/ports/espressif/components/tinyusb_src/tusb_config.h
@@ -40,6 +40,8 @@
   #define CFG_TUSB_MCU               OPT_MCU_ESP32S2
 #elif CONFIG_IDF_TARGET_ESP32S3
   #define CFG_TUSB_MCU               OPT_MCU_ESP32S3
+#elif CONFIG_IDF_TARGET_ESP32P4
+  #define CFG_TUSB_MCU               OPT_MCU_ESP32P4
 #endif
 
 #define CFG_TUSB_OS                OPT_OS_FREERTOS

--- a/ports/espressif/family.cmake
+++ b/ports/espressif/family.cmake
@@ -2,6 +2,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/boards/${BOARD}/board.cmake)
 
 set(UF2_FAMILY_ID_esp32s2 0xbfdd4eee)
 set(UF2_FAMILY_ID_esp32s3 0xc47e5767)
+set(UF2_FAMILY_ID_esp32p4 0x3d308e94)
 set(UF2_FAMILY_ID ${UF2_FAMILY_ID_${IDF_TARGET}})
 
 # override default family_gen_uf2


### PR DESCRIPTION
## Description of Change

Intension of this PR is to add UF2 family ID for ESP32-P4
https://github.com/microsoft/uf2/blob/master/utils/uf2families.json#L228

This action paves the way to further addition of ESP32-P4 target boards.
