### PR TITLE
 Upload Espressif bootloader .zip and combined*.bin to board-specific  dirs on S3

### DIFF
--- a/.github/workflows/build_util.yml
+++ b/.github/workflows/build_util.yml
@@ -75,6 +75,8 @@ jobs:
         run: |
           if [ ${{ inputs.toolchain }} == 'esp-idf' ]; then
             zip -jr tinyuf2-${{ matrix.board }}-${{ github.event.release.tag_name }}.zip ${{ env.BIN_PATH }}
+            cp ${{ env.BIN_PATH }}/combined.bin combined.bin
+            [ -f ${{ env.BIN_PATH }}/combined-ota.bin ] && cp ${{ env.BIN_PATH }}/combined-ota.bin combined-ota.bin
             cp ${{ env.BIN_PATH }}/apps/update-tinyuf2.uf2 update-tinyuf2-${{ matrix.board }}-${{ github.event.release.tag_name }}.uf2
           else
             if [[ ${{ inputs.build-system }} == cmake ]]; then
@@ -99,5 +101,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         if: github.event_name == 'release' && inputs.port == 'espressif'
         run: |
-          [ -z \"$AWS_ACCESS_KEY_ID\" ] || aws s3 cp tinyuf2-${{ matrix.board }}-${{ github.event.release.tag_name }}.zip s3://adafruit-circuit-python/bootloaders/esp32/tinyuf2-${{ matrix.board }}-${{ github.event.release.tag_name }}.zip --no-progress --region us-east-1
-          [ -z \"$AWS_ACCESS_KEY_ID\" ] || aws s3 cp update-tinyuf2-${{ matrix.board }}-${{ github.event.release.tag_name }}.uf2 s3://adafruit-circuit-python/bootloaders/esp32/update-tinyuf2-${{ matrix.board }}-${{ github.event.release.tag_name }}.uf2 --no-progress --region us-east-1
+          [ -z \"$AWS_ACCESS_KEY_ID\" ] || aws s3 cp tinyuf2-${{ matrix.board }}-${{ github.event.release.tag_name }}.zip s3://adafruit-circuit-python/bootloaders/esp32/${{ matrix.board }}/tinyuf2-${{ matrix.board }}-${{ github.event.release.tag_name }}.zip --no-progress --region us-east-1
+          [ -z \"$AWS_ACCESS_KEY_ID\" ] || aws s3 cp update-tinyuf2-${{ matrix.board }}-${{ github.event.release.tag_name }}.uf2 s3://adafruit-circuit-python/bootloaders/esp32/${{ matrix.board }}/update-tinyuf2-${{ matrix.board }}-${{ github.event.release.tag_name }}.uf2 --no-progress --region us-east-1
+          [ -z \"$AWS_ACCESS_KEY_ID\" ] || aws s3 cp combined.bin s3://adafruit-circuit-python/bootloaders/esp32/${{ matrix.board }}/tinyuf2-${{ matrix.board }}-${{ github.event.release.tag_name }}-combined.bin --no-progress --region us-east-1
+          [ -z \"$AWS_ACCESS_KEY_ID\" ] || [ ! -f combined-ota.bin ] || aws s3 cp combined-ota.bin s3://adafruit-circuit-python/bootloaders/esp32/${{ matrix.board }}/tinyuf2-${{ matrix.board }}-${{ github.event.release.tag_name }}-combined-ota.bin --no-progress --region us-east-1

--- a/.github/workflows/build_util.yml
+++ b/.github/workflows/build_util.yml
@@ -88,7 +88,7 @@ jobs:
           fi
 
       - name: Upload Release Asset
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: github.event_name == 'release'
         with:
           files: |
@@ -101,7 +101,9 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         if: github.event_name == 'release' && inputs.port == 'espressif'
         run: |
-          [ -z \"$AWS_ACCESS_KEY_ID\" ] || aws s3 cp tinyuf2-${{ matrix.board }}-${{ github.event.release.tag_name }}.zip s3://adafruit-circuit-python/bootloaders/esp32/${{ matrix.board }}/tinyuf2-${{ matrix.board }}-${{ github.event.release.tag_name }}.zip --no-progress --region us-east-1
-          [ -z \"$AWS_ACCESS_KEY_ID\" ] || aws s3 cp update-tinyuf2-${{ matrix.board }}-${{ github.event.release.tag_name }}.uf2 s3://adafruit-circuit-python/bootloaders/esp32/${{ matrix.board }}/update-tinyuf2-${{ matrix.board }}-${{ github.event.release.tag_name }}.uf2 --no-progress --region us-east-1
-          [ -z \"$AWS_ACCESS_KEY_ID\" ] || aws s3 cp combined.bin s3://adafruit-circuit-python/bootloaders/esp32/${{ matrix.board }}/tinyuf2-${{ matrix.board }}-${{ github.event.release.tag_name }}-combined.bin --no-progress --region us-east-1
-          [ -z \"$AWS_ACCESS_KEY_ID\" ] || [ ! -f combined-ota.bin ] || aws s3 cp combined-ota.bin s3://adafruit-circuit-python/bootloaders/esp32/${{ matrix.board }}/tinyuf2-${{ matrix.board }}-${{ github.event.release.tag_name }}-combined-ota.bin --no-progress --region us-east-1
+          if [ -n \"$AWS_ACCESS_KEY_ID\" ]; then
+            aws s3 cp tinyuf2-${{ matrix.board }}-${{ github.event.release.tag_name }}.zip s3://adafruit-circuit-python/bootloaders/esp32/${{ matrix.board }}/tinyuf2-${{ matrix.board }}-${{ github.event.release.tag_name }}.zip --no-progress --region us-east-1
+            aws s3 cp update-tinyuf2-${{ matrix.board }}-${{ github.event.release.tag_name }}.uf2 s3://adafruit-circuit-python/bootloaders/esp32/${{ matrix.board }}/update-tinyuf2-${{ matrix.board }}-${{ github.event.release.tag_name }}.uf2 --no-progress --region us-east-1
+            aws s3 cp combined.bin s3://adafruit-circuit-python/bootloaders/esp32/${{ matrix.board }}/tinyuf2-${{ matrix.board }}-${{ github.event.release.tag_name }}-combined.bin --no-progress --region us-east-1
+            [ -f combined-ota.bin ] && aws s3 cp combined-ota.bin s3://adafruit-circuit-python/bootloaders/esp32/${{ matrix.board }}/tinyuf2-${{ matrix.board }}-${{ github.event.release.tag_name }}-combined-ota.bin --no-progress --region us-east-1
+          fi


### PR DESCRIPTION
- Fixes #452

During a release
- Change the upload location on S3 for the `tinyuf2*.zip` and `update-tinyuf2*.uf2` to a board-specific directory. The upload path used to be, for example:
  `s3://adafruit-circuit-python/bootloaders/esp32/tinyuf2-adafruit_feather_esp32s3-0.32.0.zip`
  and now it is
  `s3://adafruit-circuit-python/bootloaders/esp32/adafruit_feather_esp32s3/tinyuf2-adafruit_feather_esp32s3-0.32.0.zip`
  This groups by board name, and reduces the large number of files at one level in S3.
- Also upload, to the same board directory, the `combined.bin` and, if it exists, the `combined-ota.bin`. The files are renamed to include the board name and version, for example
  `tinyuf2-adafruit_feather_esp32s3-0.32.0-combined.bin`

See https://adafruit-circuit-python.s3.amazonaws.com/index.html?prefix=bootloaders/esp32/ for both old and new hiearchies.

@hathach I have tried to be careful about this, but I'm not sure how to test the uploads without doing a release. Could you double-check the paths? Thanks.


I have already copied files to board-specific dirs using a script for the previous releases. When this is merged I will submit a PR update https://github.com/adafruit/web-firmware-installer-js to look in the new locations, and after that's merged I'll delete old uploads that are in the top-level directory.