### PR TITLE
Restore FlexSPI1 clock before app jump on RT1170

### DIFF
--- a/ports/mimxrt10xx/boards/imxrt1170_evk/board/clock_config.c
+++ b/ports/mimxrt10xx/boards/imxrt1170_evk/board/clock_config.c
@@ -160,10 +160,12 @@ void BOARD_BootClockRUN(void) {
     rootCfg.div = 1;
     CLOCK_SetRootClock(kCLOCK_Root_Cssys, &rootCfg);
 
-    /* Configure FLEXSPI1 using OSC_RC_48M_DIV2 */
-    rootCfg.mux = kCLOCK_FLEXSPI1_ClockRoot_MuxOscRc48MDiv2;
-    rootCfg.div = 1;
+    /* Configure FLEXSPI1 using OSC_RC_400M (100MHz) */
+    rootCfg.mux = kCLOCK_FLEXSPI1_ClockRoot_MuxOscRc400M;
+    rootCfg.div = 4;
     CLOCK_SetRootClock(kCLOCK_Root_Flexspi1, &rootCfg);
+    FLEXSPI1->MCR0 |= FLEXSPI_MCR0_SWRESET_MASK;
+    while (FLEXSPI1->MCR0 & FLEXSPI_MCR0_SWRESET_MASK) {}
 
     /* Configure GPT1 using OSC_24M for timing */
     rootCfg.mux = kCLOCK_GPT1_ClockRoot_MuxOsc24MOut;

--- a/ports/mimxrt10xx/boards/imxrt1170_evk/mimxrt1170_evkb.mex
+++ b/ports/mimxrt10xx/boards/imxrt1170_evk/mimxrt1170_evkb.mex
@@ -231,7 +231,7 @@
                   <clock_output id="CSTRACE_CLK_ROOT.outFreq" value="132 MHz" locked="false" accuracy=""/>
                   <clock_output id="FLEXIO1_CLK_ROOT.outFreq" value="24 MHz" locked="false" accuracy=""/>
                   <clock_output id="FLEXIO2_CLK_ROOT.outFreq" value="24 MHz" locked="false" accuracy=""/>
-                  <clock_output id="FLEXSPI1_CLK_ROOT.outFreq" value="24 MHz" locked="false" accuracy=""/>
+                  <clock_output id="FLEXSPI1_CLK_ROOT.outFreq" value="100 MHz" locked="false" accuracy=""/>
                   <clock_output id="FLEXSPI2_CLK_ROOT.outFreq" value="24 MHz" locked="false" accuracy=""/>
                   <clock_output id="GPT1_CLK_ROOT.outFreq" value="24 MHz" locked="false" accuracy=""/>
                   <clock_output id="GPT1_ipg_clk_highfreq.outFreq" value="24 MHz" locked="false" accuracy=""/>
@@ -303,6 +303,8 @@
                   <setting id="CCM.CLOCK_ROOT25.MUX.sel" value="ANADIG_PLL.SYS_PLL2_CLK" locked="false"/>
                   <setting id="CCM.CLOCK_ROOT26.DIV.scale" value="22" locked="false"/>
                   <setting id="CCM.CLOCK_ROOT26.MUX.sel" value="ANADIG_PLL.SYS_PLL2_CLK" locked="false"/>
+                  <setting id="CCM.CLOCK_ROOT20.DIV.scale" value="4" locked="false"/>
+                  <setting id="CCM.CLOCK_ROOT20.MUX.sel" value="ANADIG_OSC.OSC_RC_400M" locked="false"/>
                   <setting id="CCM.CLOCK_ROOT3.DIV.scale" value="3" locked="false"/>
                   <setting id="CCM.CLOCK_ROOT3.MUX.sel" value="ANADIG_PLL.SYS_PLL3_CLK" locked="false"/>
                   <setting id="CCM.CLOCK_ROOT4.DIV.scale" value="3" locked="false"/>


### PR DESCRIPTION
## Checklist

*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

- [x] Please provide specific title of the PR describing the change

*This checklist items that are not applicable to your PR can be deleted.*

-----------

## Description of Change

On testing a performance critical application I found I was getting slow LVGL performance compared to just flashing the hex files. Turns out the FlexSPI clock stays at 24MHz. This change addresses that, and also addresses your comment on https://github.com/adafruit/tinyuf2/pull/470 while I'm here to do the same change as early as possible too.

Tested on a custom 1176 board. 