### PR TITLE
Add Waveshare ESP32-S3-Tiny board support

### DIFF
--- a/ports/espressif/boards/waveshare_esp32_s3_tiny/board.cmake
+++ b/ports/espressif/boards/waveshare_esp32_s3_tiny/board.cmake
@@ -1,0 +1,2 @@
+# Apply board specific content here
+set(IDF_TARGET "esp32s3")

--- a/ports/espressif/boards/waveshare_esp32_s3_tiny/board.h
+++ b/ports/espressif/boards/waveshare_esp32_s3_tiny/board.h
@@ -1,0 +1,74 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef WAVESHARE_ESP32_S3_TINY_H_
+#define WAVESHARE_ESP32_S3_TINY_H_
+
+//--------------------------------------------------------------------+
+// Button
+//--------------------------------------------------------------------+
+
+// Enter UF2 mode if GPIO is pressed while 2nd stage bootloader indicator
+// is on e.g RGB = Purple. If it is GPIO0, user should not hold this while
+// reset since that will instead run the 1st stage ROM bootloader
+#define PIN_BUTTON_UF2        0
+
+// GPIO that implement 1-bit memory with RC components which hold the
+// pin value long enough for double reset detection.
+// #define PIN_DOUBLE_RESET_RC
+
+//--------------------------------------------------------------------+
+// LED
+//--------------------------------------------------------------------+
+
+// GPIO connected to Neopixel data
+#define NEOPIXEL_PIN          38
+
+// Brightness percentage from 1 to 255
+#define NEOPIXEL_BRIGHTNESS   0x10
+
+// Number of neopixels
+#define NEOPIXEL_NUMBER       1
+
+// Invert Neopixel red and green
+#define NEOPIXEL_INVERT_RG    1
+
+// LED for indicator and writing flash
+// If not defined neopixel will be use for flash writing instead
+
+//--------------------------------------------------------------------+
+// USB UF2
+//--------------------------------------------------------------------+
+
+#define USB_VID                  0x303a
+#define USB_PID                  0x81F8
+#define USB_MANUFACTURER         "Waveshare Electronics"
+#define USB_PRODUCT              "ESP32-S3-Tiny"
+
+#define UF2_PRODUCT_NAME         USB_MANUFACTURER " " USB_PRODUCT
+#define UF2_BOARD_ID             "ESP32-S3-Tiny"
+#define UF2_VOLUME_LABEL         "WS3TINYBOOT"
+#define UF2_INDEX_URL            "https://www.waveshare.com/wiki/ESP32-S3-Tiny"
+
+#endif

--- a/ports/espressif/boards/waveshare_esp32_s3_tiny/sdkconfig
+++ b/ports/espressif/boards/waveshare_esp32_s3_tiny/sdkconfig
@@ -1,0 +1,7 @@
+# Board Specific Config
+
+# Partition Table
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-4MB-noota.csv"
+
+# Serial flasher config
+CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y

--- a/supported_boards.md
+++ b/supported_boards.md
@@ -105,6 +105,7 @@
 | waveshare_esp32_s3_pico | Waveshare Electronics ESP32-S3-Pico | 0x303A:0x81A2 | http://www.waveshare.com/wiki/ESP32-S2-Pico |
 | waveshare_esp32_s3_touch_lcd_169 | Waveshare Electronics ESP32-S3-Touch-LCD-1.69 | 0x303A:0x8220 | https://www.waveshare.com/product/esp32-s3-touch-lcd-1.69.htm |
 | waveshare_esp32_s3_touch_lcd_2 | Waveshare Electronics ESP32-S3-Touch-LCD-2 | 0x303A:0x82CF | https://www.waveshare.com/esp32-s3-touch-lcd-2.htm?sku=29667 |
+| waveshare_esp32_s3_tiny | Waveshare Electronics ESP32-S3-Tiny | 0x303A:0x81F8 | https://www.waveshare.com/wiki/ESP32-S3-Tiny |
 | waveshare_esp32_s3_zero | Waveshare Electronics ESP32-S3-Zero | 0x303A:0x81B3 | https://www.waveshare.com/wiki/ESP32-S3-Zero |
 | waveshare_esp32s2_pico | Waveshare Electronics ESP32-S2-Pico | 0x303A:0x8109 | http://www.waveshare.com/wiki/ESP32-S2-Pico |
 | waveshare_esp32s3_lcd_169 | Waveshare Electronics ESP32-S3-LCD-1.69 | 0x303A:0x8223 | https://www.waveshare.com/product/esp32-s3-lcd-1.69.htm |


### PR DESCRIPTION
## Summary

Add tinyuf2 bootloader support for the **Waveshare ESP32-S3-Tiny** board.

The [circuitpython.org board page](https://circuitpython.org/board/waveshare_esp32_s3_tiny/) references a tinyuf2 bootloader file (`tinyuf2-waveshare_esp32_s3_tiny-0.35.0.zip`) that doesn't exist because this board hasn't been added to the tinyuf2 build system yet.

## Board Specs

- **Chip:** ESP32-S3FH4R2 (dual-core Xtensa LX7, up to 240MHz)
- **Flash:** 4MB
- **PSRAM:** 2MB
- **Neopixel:** GPIO38 (GRB color order)
- **Boot button:** GPIO0
- **USB VID:PID:** 0x303A:0x81F8

## Changes

- `ports/espressif/boards/waveshare_esp32_s3_tiny/board.h` — Board header with pin definitions and USB descriptors
- `ports/espressif/boards/waveshare_esp32_s3_tiny/board.cmake` — CMake target config (esp32s3)
- `ports/espressif/boards/waveshare_esp32_s3_tiny/sdkconfig` — 4MB flash, no-OTA partition table
- `supported_boards.md` — Added board entry

## References

- Based on the existing `waveshare_esp32_s3_zero` board definition (same chip and flash size)
- Pin assignments verified against the [CircuitPython board definition](https://github.com/adafruit/circuitpython/tree/main/ports/espressif/boards/waveshare_esp32_s3_tiny) and [Waveshare wiki](https://www.waveshare.com/wiki/ESP32-S3-Tiny)
- USB PID (0x81F8) matches the [CircuitPython mpconfigboard.mk](https://github.com/adafruit/circuitpython/blob/main/ports/espressif/boards/waveshare_esp32_s3_tiny/mpconfigboard.mk)

Resolves adafruit/circuitpython-org#1692