### PR TITLE
add Waveshare ESP32-S3-Tiny-N8R8 board

### DIFF
--- a/ports/espressif/boards/waveshare_esp32_s3_tiny_n8r8/board.cmake
+++ b/ports/espressif/boards/waveshare_esp32_s3_tiny_n8r8/board.cmake
@@ -1,0 +1,2 @@
+# Apply board specific content here
+set(IDF_TARGET "esp32s3")

--- a/ports/espressif/boards/waveshare_esp32_s3_tiny_n8r8/board.h
+++ b/ports/espressif/boards/waveshare_esp32_s3_tiny_n8r8/board.h
@@ -1,0 +1,74 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef WAVESHARE_ESP32_S3_TINY_N8R8_H_
+#define WAVESHARE_ESP32_S3_TINY_N8R8_H_
+
+//--------------------------------------------------------------------+
+// Button
+//--------------------------------------------------------------------+
+
+// Enter UF2 mode if GPIO is pressed while 2nd stage bootloader indicator
+// is on e.g RGB = Purple. If it is GPIO0, user should not hold this while
+// reset since that will instead run the 1st stage ROM bootloader
+#define PIN_BUTTON_UF2        0
+
+// GPIO that implement 1-bit memory with RC components which hold the
+// pin value long enough for double reset detection.
+// #define PIN_DOUBLE_RESET_RC
+
+//--------------------------------------------------------------------+
+// LED
+//--------------------------------------------------------------------+
+
+// GPIO connected to Neopixel data
+#define NEOPIXEL_PIN          38
+
+// Brightness percentage from 1 to 255
+#define NEOPIXEL_BRIGHTNESS   0x10
+
+// Number of neopixels
+#define NEOPIXEL_NUMBER       1
+
+// Invert Neopixel red and green
+#define NEOPIXEL_INVERT_RG    1
+
+// LED for indicator and writing flash
+// If not defined neopixel will be use for flash writing instead
+
+//--------------------------------------------------------------------+
+// USB UF2
+//--------------------------------------------------------------------+
+
+#define USB_VID                  0x303a
+#define USB_PID                  0x837a
+#define USB_MANUFACTURER         "Waveshare Electronics"
+#define USB_PRODUCT              "ESP32-S3-Tiny-N8R8"
+
+#define UF2_PRODUCT_NAME         USB_MANUFACTURER " " USB_PRODUCT
+#define UF2_BOARD_ID             "ESP32-S3-Tiny-N8R8"
+#define UF2_VOLUME_LABEL         "WS3TINYBOOT"
+#define UF2_INDEX_URL            "https://docs.waveshare.com/ESP32-S3-Tiny?variant=ESP32-S3-Tiny-N8R8"
+
+#endif

--- a/ports/espressif/boards/waveshare_esp32_s3_tiny_n8r8/sdkconfig
+++ b/ports/espressif/boards/waveshare_esp32_s3_tiny_n8r8/sdkconfig
@@ -1,0 +1,7 @@
+# Board Specific Config
+
+# Partition Table
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-8MB.csv"
+
+# Serial flasher config
+CONFIG_ESPTOOLPY_FLASHSIZE_8MB=y


### PR DESCRIPTION
## Checklist

*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

- [x] Please provide specific title of the PR describing the change
- [x] If you are adding an new boards, please make sure
  - [x] Provide link to your allocated VID/PID if applicable
  - [x] `UF2_BOARD_ID` in your board.h follow correct format from [uf2 specs](https://github.com/microsoft/uf2#files-exposed-by-bootloaders)

*This checklist items that are not applicable to your PR can be deleted.*

-----------

Added a definition for Waveshare ESP32-S3-Tiny-N8R8 board.
It is similar to older ESP32-S3-Tiny, but uses ESP32-PICO-N8R8 chip.
https://docs.waveshare.com/ESP32-S3-Tiny?variant=ESP32-S3-Tiny-N8R8

USB PID 0x837A
https://github.com/espressif/usb-pids/commit/862f878db26ad34abdab50f1d7da5a77e9ddb701