### PR TITLE
Fix NeoPixel RG inversion in ESP32 bootloader

### DIFF
--- a/ports/espressif/bootloader_components/main/bootloader_start.c
+++ b/ports/espressif/bootloader_components/main/bootloader_start.c
@@ -39,7 +39,11 @@
   #define UF2_DETECTION_DELAY_MS     500
 #endif
 
+#ifndef NEOPIXEL_INVERT_RG
 uint8_t const RGB_DOUBLE_TAP[] = { 0x80, 0x00, 0xff }; // Purple
+#else
+uint8_t const RGB_DOUBLE_TAP[] = { 0x00, 0x80, 0xff }; // Purple
+#endif
 uint8_t const RGB_OFF[]        = { 0x00, 0x00, 0x00 };
 
 //--------------------------------------------------------------------+


### PR DESCRIPTION
Fix the ESP32 second-stage bootloader to honor `NEOPIXEL_INVERT_RG`, correcting the startup indicator from cyan to purple on boards with inverted red/green channel NeoPixel LEDs.