### PR TITLE
espressif: add ESP32-S3-DevKitC-1-N32R16 board

### DIFF
--- a/ports/espressif/boards/espressif_esp32s3_devkitc_1_n32r16/board.cmake
+++ b/ports/espressif/boards/espressif_esp32s3_devkitc_1_n32r16/board.cmake
@@ -1,0 +1,2 @@
+# Apply board specific content here
+set(IDF_TARGET "esp32s3")

--- a/ports/espressif/boards/espressif_esp32s3_devkitc_1_n32r16/board.h
+++ b/ports/espressif/boards/espressif_esp32s3_devkitc_1_n32r16/board.h
@@ -1,0 +1,74 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef ESPRESSIF_S3_DEVKITC_N32R16_H_
+#define ESPRESSIF_S3_DEVKITC_N32R16_H_
+
+//--------------------------------------------------------------------+
+// Button
+//--------------------------------------------------------------------+
+
+// Enter UF2 mode if GPIO is pressed while 2nd stage bootloader indicator
+// is on e.g RGB = Purple. If it is GPIO0, user should not hold this while
+// reset since that will instead run the 1st stage ROM bootloader
+#define PIN_BUTTON_UF2        0
+
+// GPIO that implement 1-bit memory with RC components which hold the
+// pin value long enough for double reset detection.
+// #define PIN_DOUBLE_RESET_RC
+
+//--------------------------------------------------------------------+
+// LED
+//--------------------------------------------------------------------+
+
+// GPIO connected to Neopixel data
+#define NEOPIXEL_PIN          38
+
+// Brightness percentage from 1 to 255
+#define NEOPIXEL_BRIGHTNESS   0x10
+
+// Number of neopixels
+#define NEOPIXEL_NUMBER       1
+
+
+// LED for indicator
+// If not defined neopixel will be use for flash writing instead
+// #define LED_PIN               42
+// #define LED_STATE_ON          1
+
+//--------------------------------------------------------------------+
+// USB UF2
+//--------------------------------------------------------------------+
+
+#define USB_VID           0x239A
+#define USB_PID           0x00A5    // TODO temporarily shared with S2 saola wrover
+#define USB_MANUFACTURER  "Espressif"
+#define USB_PRODUCT       "ESP32S3 DevKitC 1 N32R16"
+
+#define UF2_PRODUCT_NAME  USB_MANUFACTURER " " USB_PRODUCT
+#define UF2_BOARD_ID      "ESP32S3-DevKitC-1-N32R16-v1.1"
+#define UF2_VOLUME_LABEL  "N32R16BOOT"
+#define UF2_INDEX_URL     "https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32s3/esp32-s3-devkitc-1/user_guide_v1.1.html"
+
+#endif

--- a/ports/espressif/boards/espressif_esp32s3_devkitc_1_n32r16/sdkconfig
+++ b/ports/espressif/boards/espressif_esp32s3_devkitc_1_n32r16/sdkconfig
@@ -1,0 +1,7 @@
+# Board Specific Config
+
+# Partition Table
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions-32MB.csv"
+
+# Serial flasher config
+CONFIG_ESPTOOLPY_FLASHSIZE_32MB=y

--- a/ports/espressif/partitions-32MB.csv
+++ b/ports/espressif/partitions-32MB.csv
@@ -1,0 +1,10 @@
+# ESP-IDF Partition Table
+# Name,   Type, SubType, Offset,  Size, Flags
+# bootloader.bin,,          0x1000, 32K
+# partition table,,         0x8000, 4K
+nvs,      data, nvs,      0x9000,  20K,
+otadata,  data, ota,      0xe000,  8K,
+ota_0,    app,  ota_0,   0x10000,  2048K,
+ota_1,    app,  ota_1,  0x210000,  2048K,
+uf2,      app,  factory,0x410000,  256K,
+ffat,     data, fat,    0x450000,  28352K,


### PR DESCRIPTION
Addresses the flash size half of #481.

The only `espressif_esp32s3_devkitc_1` build is configured for 8MB flash, so on the 32MB N32R16V most of the flash is unreachable. @grgrant measured CircuitPython's filesystem at 5,935,104 bytes under the stock bootloader versus 31,080,448 flashed directly with esptool. Details in adafruit/circuitpython#11192.

Adds `partitions-32MB.csv` and an `espressif_esp32s3_devkitc_1_n32r16` board that uses it. The existing devkitc_1 board is untouched, since changing its partition table would break existing installs.

Draft because I don't have N32R16V hardware. @grgrant has the board and offered to test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)